### PR TITLE
Fix random DB password generation to not generate invalid passwords

### DIFF
--- a/backend/terraform/modules/analyzer/secrets.tf
+++ b/backend/terraform/modules/analyzer/secrets.tf
@@ -18,8 +18,9 @@ resource "aws_secretsmanager_secret" "db-master-password" {
 }
 
 resource "random_password" "db-master-password" {
-  length  = 16
-  special = true
+  length           = 32
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?" # Default TF value minus @
 }
 
 resource "aws_secretsmanager_secret_version" "db-master-password" {
@@ -33,8 +34,9 @@ resource "aws_secretsmanager_secret" "db-user" {
 }
 
 resource "random_password" "db-user" {
-  length  = 16
-  special = true
+  length           = 32
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?" # Default TF value minus @
 }
 
 resource "aws_secretsmanager_secret_version" "db-user" {


### PR DESCRIPTION
## Description
Fix random DB password generation to not generate invalid passwords. Also increase the password length to 32 characters.

## Motivation and Context
The default set of special characters used by the `random_password` includes characters that cannot be used as PostgreSQL passwords (specifically `@`). When this occurs the Terraform errors out with:
```
module.analyzer.null_resource.aurora_db_master_password (local-exec): An error occurred (InvalidParameterValue) when calling the ModifyDBCluster operation: The parameter MasterUserPassword is not a valid password. Only printable ASCII characters besides '/', '@', '"', ' ' may be used.
```
https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password#override_special

## How Has This Been Tested?
- Verified TF applies successfully

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Pic
![Embed something funny here](https://media.giphy.com/media/DfSXiR60W9MVq/giphy.gif)