### PR TITLE
Fix NAT engine cluster connectivity

### DIFF
--- a/backend/terraform/modules/analyzer/db.tf
+++ b/backend/terraform/modules/analyzer/db.tf
@@ -60,6 +60,7 @@ resource "aws_security_group" "db" {
     protocol  = "tcp"
     security_groups = [
       module.public_engine_cluster.engine-sec-group.id,
+      module.nat_engine_cluster.engine-sec-group.id,
       aws_security_group.lambda-sg.id
     ]
     cidr_blocks = aws_subnet.database.*.cidr_block

--- a/backend/terraform/modules/analyzer/engine.tf
+++ b/backend/terraform/modules/analyzer/engine.tf
@@ -52,12 +52,13 @@ module "nat_engine_cluster" {
 
   app               = var.app
   name              = "nat"
+  public            = false
   aws_region        = var.aws_region
   availability_zone = var.availability_zone
   tags              = var.tags
 
   vpc_id             = var.vpc_id
-  vpc_route_table_id = var.vpc_route_table_id
+  vpc_route_table_id = aws_route_table.lambda_routes.id
   engine_cidr        = "10.0.1.0/24"
 
   engine_size           = var.nat_engine_size


### PR DESCRIPTION
## Description
- Add NAT engine SG to DB ingress
- Update NAT engine cluster so public=false
- Update NAT engine cluster to use Lambda routing table, which has the NAT GW route

## Motivation and Context
Fixes the NAT cluster so that it does egress through the NAT gateway and can connect to the DB.

## How Has This Been Tested?
Verified against test instance that a repository that resides in a VCS requiring connectivity from a specific IP can be successfully scanned.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Pic
![Embed something funny here](https://media.giphy.com/media/ID4NXWnwuLnLq/giphy.gif)