### PR TITLE
Surface configuration of ARTEMIS_REVPROXY_DOMAIN_SUBSTRING env var

### DIFF
--- a/backend/terraform/modules/analyzer/engine.tf
+++ b/backend/terraform/modules/analyzer/engine.tf
@@ -45,6 +45,8 @@ module "public_engine_cluster" {
 
   metadata_scheme_modules = var.metadata_scheme_modules
   mandatory_include_paths = var.mandatory_include_paths
+
+  revproxy_domain_substring = var.revproxy_domain_substring
 }
 
 module "nat_engine_cluster" {
@@ -95,4 +97,6 @@ module "nat_engine_cluster" {
 
   metadata_scheme_modules = var.metadata_scheme_modules
   mandatory_include_paths = var.mandatory_include_paths
+
+  revproxy_domain_substring = var.revproxy_domain_substring
 }

--- a/backend/terraform/modules/analyzer/lambdas.tf
+++ b/backend/terraform/modules/analyzer/lambdas.tf
@@ -197,6 +197,7 @@ resource "aws_lambda_function" "repo-handler" {
       ARTEMIS_DOMAIN_NAME               = var.domain_name
       ARTEMIS_METADATA_FORMATTER_MODULE = var.metadata_formatter_module
       ARTEMIS_CUSTOM_FILTERING_MODULE   = var.custom_filtering_module
+      ARTEMIS_REVPROXY_DOMAIN_SUBSTRING = var.revproxy_domain_substring
     }
   }
 

--- a/backend/terraform/modules/analyzer/modules/engine_cluster/main.tf
+++ b/backend/terraform/modules/analyzer/modules/engine_cluster/main.tf
@@ -25,24 +25,25 @@ data "template_file" "engine-script" {
   template = file("${path.module}/templates/user_data/engine.sh")
 
   vars = {
-    s3_bucket                = var.s3_analyzer_files_bucket
-    ver                      = var.ver
-    type                     = var.public ? "public" : "nat"
-    aqua_enabled             = var.aqua_enabled ? 1 : 0
-    veracode_enabled         = var.veracode_enabled ? 1 : 0
-    snyk_enabled             = var.snyk_enabled ? 1 : 0
-    github_app_id            = var.github_app_id
-    private_docker_repos_key = var.private_docker_repos_key
-    plugin_java_heap_size    = var.plugin_java_heap_size
-    status_lambda            = var.system_status_lambda.arn
-    aws_region               = var.aws_region
-    docker_compose_ver       = var.docker_compose_ver
-    engine_block_device      = var.engine_block_device
-    application              = var.app
-    region                   = var.aws_region
-    domain_name              = var.domain_name
-    mandatory_include_paths  = jsonencode(var.mandatory_include_paths)
-    metadata_scheme_modules  = var.metadata_scheme_modules
+    s3_bucket                 = var.s3_analyzer_files_bucket
+    ver                       = var.ver
+    type                      = var.public ? "public" : "nat"
+    aqua_enabled              = var.aqua_enabled ? 1 : 0
+    veracode_enabled          = var.veracode_enabled ? 1 : 0
+    snyk_enabled              = var.snyk_enabled ? 1 : 0
+    github_app_id             = var.github_app_id
+    private_docker_repos_key  = var.private_docker_repos_key
+    plugin_java_heap_size     = var.plugin_java_heap_size
+    status_lambda             = var.system_status_lambda.arn
+    aws_region                = var.aws_region
+    docker_compose_ver        = var.docker_compose_ver
+    engine_block_device       = var.engine_block_device
+    application               = var.app
+    region                    = var.aws_region
+    domain_name               = var.domain_name
+    mandatory_include_paths   = jsonencode(var.mandatory_include_paths)
+    metadata_scheme_modules   = var.metadata_scheme_modules
+    revproxy_domain_substring = var.revproxy_domain_substring
   }
 }
 

--- a/backend/terraform/modules/analyzer/modules/engine_cluster/templates/user_data/engine.sh
+++ b/backend/terraform/modules/analyzer/modules/engine_cluster/templates/user_data/engine.sh
@@ -18,6 +18,7 @@ export "type"
 export "ver"
 export "veracode_enabled"
 export "snyk_enabled"
+export "revproxy_domain_substring"
 
 # Format and mount data volume
 mkfs -t ext4 "${engine_block_device}"
@@ -78,6 +79,7 @@ REGION=${region}
 ARTEMIS_DOMAIN_NAME=${domain_name}
 ARTEMIS_MANDATORY_INCLUDE_PATHS=${mandatory_include_paths}
 ARTEMIS_METADATA_SCHEME_MODULES=${metadata_scheme_modules}
+ARTEMIS_REVPROXY_DOMAIN_SUBSTRING=${revproxy_domain_substring}
 EOF
 
 # Fix ownership of files for ec2-user

--- a/backend/terraform/modules/analyzer/modules/engine_cluster/variables.tf
+++ b/backend/terraform/modules/analyzer/modules/engine_cluster/variables.tf
@@ -36,6 +36,11 @@ variable "domain_name" {
   description = "FQDN of the Artemis deployment"
 }
 
+variable "revproxy_domain_substring" {
+  description = "Base domain for the reverse proxy to access VCS, if used"
+  default     = ""
+}
+
 ###############################################################################
 # Cluster configuration
 ###############################################################################

--- a/backend/terraform/modules/analyzer/variables.tf
+++ b/backend/terraform/modules/analyzer/variables.tf
@@ -147,6 +147,11 @@ variable "s3_analyzer_files_arn" {}
 
 variable "s3_analyzer_files_bucket" {}
 
+variable "revproxy_domain_substring" {
+  description = "Base domain for the reverse proxy to access VCS, if used"
+  default     = ""
+}
+
 ###############################################
 # SQS Variables
 ################################################


### PR DESCRIPTION
## Description
This variable allows the system to determine whether to include the revproxy auth header in requests.

## Motivation and Context
This change surfaces the variable configuration so that deployments can set it.

## How Has This Been Tested?
Verified against a test deployment that utilizes a reverse proxy to access a particular VCS.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Pic
![Embed something funny here](https://media.giphy.com/media/pJmnk86fXFNmrUb8LB/giphy.gif)