### PR TITLE
Update the Maven version and hash

### DIFF
--- a/backend/Dockerfiles/Dockerfile.veracode
+++ b/backend/Dockerfiles/Dockerfile.veracode
@@ -52,8 +52,8 @@ RUN mkdir -p /ant && \
 
 FROM python:3.9-bullseye as maven-builder
 
-ARG MAVENVER=3.8.6
-ARG MAVENSHA=f790857f3b1f90ae8d16281f902c689e4f136ebe584aba45e4b1fa66c80cba826d3e0e52fdd04ed44b4c66f6d3fe3584a057c26dfcac544a60b301e6d0f91c26
+ARG MAVENVER=3.8.7
+ARG MAVENSHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
 
 RUN mkdir -p /maven && \
     echo "$MAVENSHA /maven/maven.tar.gz" > /maven_checksum.txt && \


### PR DESCRIPTION
## Description
Update the Maven version and hash

## Motivation and Context
Apache does not keep previous versions around for download so the Veracode image build was failing because it could not download the specified version.

## How Has This Been Tested?
Verified image builds

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Pic
![Embed something funny here](https://media.giphy.com/media/2fQ1Gq3KOpvNs4NTmu/giphy.gif)