### PR TITLE
Fix bug in how GitHub auth header was being set

### DIFF
--- a/backend/libs/artemislib/artemislib/github/api.py
+++ b/backend/libs/artemislib/artemislib/github/api.py
@@ -27,8 +27,8 @@ class GitHubAPI:
             cls._instance._repo = repo
 
             # Set the auth header
-            key = _get_authorization(org, github_secret_loc)
-            cls._instance._headers = {"Authorization": f"bearer {key}", "Accept": "application/vnd.github+json"}
+            auth = _get_authorization(org, github_secret_loc)
+            cls._instance._headers = {"Authorization": auth, "Accept": "application/vnd.github+json"}
 
             # Set the revproxy auth header, if needed
             if REV_PROXY_DOMAIN_SUBSTRING and REV_PROXY_DOMAIN_SUBSTRING in service_hostname:


### PR DESCRIPTION
## Description
Fix bug in how GitHub auth header was being set

## Motivation and Context
This fixes a bug created during some refactoring of the ghas_secrets plugin during PR https://github.com/WarnerMedia/artemis/pull/23

## How Has This Been Tested?
- Verified in local testing

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Pic
![Embed something funny here](https://media.giphy.com/media/1NS0NcsFenn1yuYoaP/giphy.gif)