### PR TITLE
Remove redundant `id` field from Configuration plugin type results

### DIFF
--- a/backend/lambdas/api/spec.yaml
+++ b/backend/lambdas/api/spec.yaml
@@ -2434,9 +2434,6 @@ components:
                 type: object
                 description: The ID of the vulnerability
                 properties:
-                  id:
-                    description: The identifier for the check
-                    type: string
                   name:
                     description: Human-readable name for the check
                     type: string

--- a/backend/lambdas/generators/json_report/json_report/results/configuration.py
+++ b/backend/lambdas/generators/json_report/json_report/results/configuration.py
@@ -49,7 +49,6 @@ def get_configuration(scan: Scan, params: dict) -> PLUGIN_RESULTS:
                 passing = finding.get("pass", False)
 
                 item = {
-                    "id": id,
                     "name": name,
                     "description": description,
                     "severity": severity,

--- a/backend/lambdas/generators/json_report/tests/test_generate_report.py
+++ b/backend/lambdas/generators/json_report/tests/test_generate_report.py
@@ -435,7 +435,6 @@ class TestGenerateReport(unittest.TestCase):
         expected_configuration = PLUGIN_RESULTS(
             {
                 "branch_commit_signing": {
-                    "id": "branch_commit_signing",
                     "name": "Branch - Require Commit Signing",
                     "description": "Branch protection rule is enabled to enforce code signing",
                     "severity": "high",


### PR DESCRIPTION
Remove redundant `id` field from Configuration plugin type results

## Description
The `id` field in Configuration plugin type results is redundant with the key that indexes the result. This PR removes the redundant field.

## Motivation and Context
- The `id` field is redundant, so removing it cleans up the output

## How Has This Been Tested?
Tests have been modified for the new spec

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [x] My code follows conforms to the coding standards.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.