### PR TITLE
Fix bug in report generation with config results

### DIFF
--- a/backend/lambdas/generators/json_report/json_report/results/configuration.py
+++ b/backend/lambdas/generators/json_report/json_report/results/configuration.py
@@ -49,6 +49,7 @@ def get_configuration(scan: Scan, params: dict) -> PLUGIN_RESULTS:
                 passing = finding.get("pass", False)
 
                 item = {
+                    "id": id,  # Needed for checking against the allow list
                     "name": name,
                     "description": description,
                     "severity": severity,
@@ -59,13 +60,14 @@ def get_configuration(scan: Scan, params: dict) -> PLUGIN_RESULTS:
                     and severity in filtered_severities
                     and not allowlisted_configuration(item, allow_list)
                 ):
+                    del item["id"]  # Not needed anymore and is redundant to include
                     configuration[id] = item
                     summary[severity] += 1
 
     if plugin is _empty:
-        # Loop of configuration plugins never ran so there were no configuration plugin results. In this case the summary
-        # should be None to indicate that there were no configuration results instead of that there were configuration results
-        # that found no configuration items.
+        # Loop of configuration plugins never ran so there were no configuration plugin results. In this case the
+        # summary should be None to indicate that there were no configuration results instead of that there were
+        # configuration results that found no configuration items.
         summary = None
 
     return PLUGIN_RESULTS(configuration, errors, True, summary)


### PR DESCRIPTION
## Description
This fixes an issue where reports would fail to generate if the scan had configuration results and configuration allowlist items. Because the "id" key was removed in https://github.com/WarnerMedia/artemis/pull/31 it was not present to check against the allowlist items, causing an exception. This fix puts the "id" key back for the allowlist check.

This change also includes two line-length formatting fixes within a comment block.

## Motivation and Context
Fixes bug introduced by https://github.com/WarnerMedia/artemis/pull/31

## How Has This Been Tested?
- Verified fixed in running Artemis instance
- Unit tests pass

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Pic
![Embed something funny here](https://media.giphy.com/media/A4rF61phtNkUQEG7tL/giphy.gif)