### PR TITLE
Update the Maven version and hash

### DIFF
--- a/backend/Dockerfiles/Dockerfile.veracode
+++ b/backend/Dockerfiles/Dockerfile.veracode
@@ -52,8 +52,8 @@ RUN mkdir -p /ant && \
 
 FROM python:3.9-bullseye as maven-builder
 
-ARG MAVENVER=3.8.7
-ARG MAVENSHA=21c2be0a180a326353e8f6d12289f74bc7cd53080305f05358936f3a1b6dd4d91203f4cc799e81761cf5c53c5bbe9dcc13bdb27ec8f57ecf21b2f9ceec3c8d27
+ARG MAVENVER=3.8.8
+ARG MAVENSHA=332088670d14fa9ff346e6858ca0acca304666596fec86eea89253bd496d3c90deae2be5091be199f48e09d46cec817c6419d5161fb4ee37871503f472765d00
 
 RUN mkdir -p /maven && \
     echo "$MAVENSHA /maven/maven.tar.gz" > /maven_checksum.txt && \


### PR DESCRIPTION
## Description
Apache does not keep previous versions around for download so the Veracode image build was failing because it could not download the specified version.

## Motivation and Context
Fixes build failure.

## How Has This Been Tested?
Verified image build locally

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Pic
![Embed something funny here](https://media.giphy.com/media/HaKdwo6p8WPBK/giphy.gif)