### PR TITLE
Add additional Terraform module outputs

### DIFF
--- a/backend/terraform/modules/analyzer/outputs.tf
+++ b/backend/terraform/modules/analyzer/outputs.tf
@@ -13,3 +13,11 @@ output "pub_engine_subnet" {
 output "nat_engine_subnet" {
   value = module.nat_engine_cluster.subnet
 }
+
+output "lambda_subnet" {
+  value = aws_subnet.lambdas
+}
+
+output "lambda_security_group" {
+  value = aws_security_group.lambda-sg
+}


### PR DESCRIPTION
## Description
Add additional Terraform module outputs

## Motivation and Context
The Lambda subnet and security group resources are added to the module outputs so that other modules may consume them and run Lambdas where they can reach the database.

## How Has This Been Tested?
Verified TF applies cleanly

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
- [X] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Pic
![Embed something funny here](https://media.giphy.com/media/xUA7aNKumDkMaGDgn6/giphy.gif)