### PR TITLE
Configure Cloudfront Distribution to use TLSv1.2_2021

### DIFF
--- a/backend/terraform/environments/example/main.tf
+++ b/backend/terraform/environments/example/main.tf
@@ -120,7 +120,7 @@ module "analyzer" {
   database_availability_zones = ["${local.region}a", "${local.region}d"]
   db_instance_type            = "db.r6g.2xlarge"
   database_cidrs              = ["10.0.2.0/24", "10.0.3.0/24"]
-  ui_origin_url               = "https://CF_DISTRO_ID.cloudfront.net"
+  ui_origin_url               = "https://artemis-ui.example.com"
   cognito_domain              = "COGNITO_DOMAIN"
   cognito_app_id              = "COGNITO_APP_ID"
   cognito_pool_id             = "COGNITO_POOL_ID"

--- a/backend/terraform/modules/analyzer/api_main.tf
+++ b/backend/terraform/modules/analyzer/api_main.tf
@@ -399,6 +399,12 @@ resource "aws_api_gateway_deployment" "api" {
 # Certificate and DNS
 ###############################################################################
 
+provider "aws" {
+  alias   = "us-east-1"
+  region  = "us-east-1"
+  profile = var.profile
+}
+
 resource "aws_acm_certificate" "api" {
   domain_name               = var.domain_name
   subject_alternative_names = var.alternative_names

--- a/ui/terraform/environments/example/main.tf
+++ b/ui/terraform/environments/example/main.tf
@@ -32,10 +32,12 @@ provider "aws" {
 module "analyzer-ui" {
   source = "../../modules/analyzer-ui"
 
-  app         = local.app
-  environment = local.environment
-  tags        = local.tags
-  profile     = local.profile
+  app               = local.app
+  environment       = local.environment
+  tags              = local.tags
+  profile           = local.profile
+  cloudfront_domain = "artemis-ui.example.com"
+  zone_name         = "artemis.example.com"
 }
 
 output "cloudfront_url" {

--- a/ui/terraform/modules/analyzer-ui/variables.tf
+++ b/ui/terraform/modules/analyzer-ui/variables.tf
@@ -12,6 +12,14 @@ variable "tags" {
   type = map(any)
 }
 
+variable "cloudfront_domain" {
+  description = "Domain name that will be used for Cloudfront distribution"
+}
+
+variable "zone_name" {
+  description = "Name of the zone in which the Cloudfront domain will be created"
+}
+
 variable "profile" {}
 
 ###############################################################################


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Amazon recommends using TLSv1.2_2021 with Cloudfront distributions for greater security. However, this is only possible if we do not use the default Cloudfront certificate (the way it is now) which supports TLSv1+ and is not customizable. A custom certificate must exist in us-east-1 to be used with Cloudfront.

This PR does the following:
- Creates a new certificate in us-east-1
- Creates a custom DNS record that points to the Cloudfront distribution, since it is not possible to generate a certificate for the default *.cloudfront.net domain

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://avd.aquasec.com/misconfig/aws/cloudfront/avd-aws-0013

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested in a development instance of Artemis

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

**This change requires a few variables to be defined in terraform. The example terraform files have been updated to reflect this.**

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.