### PR TITLE
Require IMDSv2 when retrieving instance metadata

### DIFF
--- a/backend/aws_env.py
+++ b/backend/aws_env.py
@@ -17,7 +17,15 @@ def parse_args():
 
 args = parse_args()
 
-resp = requests.get("http://169.254.169.254/latest/dynamic/instance-identity/document")
+resp = requests.put("http://169.254.169.254/latest/api/token", headers={"X-aws-ec2-metadata-token-ttl-seconds": 21600})
+if resp.status_code != 200:
+    sys.exit(1)
+
+token = resp.text
+
+resp = requests.get(
+    "http://169.254.169.254/latest/dynamic/instance-identity/document", headers={"X-aws-ec2-metadata-token": token}
+)
 if resp.status_code != 200:
     sys.exit(1)
 

--- a/backend/terraform/modules/analyzer/modules/engine_cluster/main.tf
+++ b/backend/terraform/modules/analyzer/modules/engine_cluster/main.tf
@@ -84,6 +84,10 @@ resource "aws_launch_template" "engine-template" {
     }
   }
 
+  metadata_options {
+    http_tokens = "required"
+  }
+
   tag_specifications {
     resource_type = "instance"
 

--- a/backend/terraform/modules/analyzer/modules/engine_cluster/main.tf
+++ b/backend/terraform/modules/analyzer/modules/engine_cluster/main.tf
@@ -85,7 +85,8 @@ resource "aws_launch_template" "engine-template" {
   }
 
   metadata_options {
-    http_tokens = "required"
+    http_endpoint = "enabled"
+    http_tokens   = "required"
   }
 
   tag_specifications {

--- a/backend/terraform/modules/analyzer/modules/engine_cluster/main.tf
+++ b/backend/terraform/modules/analyzer/modules/engine_cluster/main.tf
@@ -85,8 +85,9 @@ resource "aws_launch_template" "engine-template" {
   }
 
   metadata_options {
-    http_endpoint = "enabled"
-    http_tokens   = "required"
+    http_endpoint               = "enabled"
+    http_tokens                 = "required"
+    http_put_response_hop_limit = 3
   }
 
   tag_specifications {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Require IMDSv2 when retrieving instance metadata.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
For increased security, it is recommended that IMDSv2 be utilized when attempting to retrieve instance metadata.
https://aws.amazon.com/blogs/security/defense-in-depth-open-firewalls-reverse-proxies-ssrf-vulnerabilities-ec2-instance-metadata-service/

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in a development environment. Terminated old containers after applying terraform, and ran a test scan successfully.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.