### PR TITLE
Bugfix: Update signin-handler lambda timeout to 10 seconds

### DIFF
--- a/backend/terraform/modules/analyzer/lambdas.tf
+++ b/backend/terraform/modules/analyzer/lambdas.tf
@@ -398,7 +398,7 @@ resource "aws_lambda_function" "signin-handler" {
   runtime       = var.lambda_runtime
   architectures = [var.lambda_architecture]
   memory_size   = 128
-  timeout       = 5
+  timeout       = 10
 
   role = aws_iam_role.lambda-assume-role.arn
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updates the `signin-handler` lambda's timeout from 5 seconds to 10 seconds. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This lambda is dependent on an HTTP request to an external identity service; this sometimes takes long enough to eat into the allotted 5 seconds and cause a timeout. This timeout, in turn, causes the authenticating user to experience a 502 error on what would otherwise be a successful request given more time.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Change has been tested in a live nonprod environment.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Pic
![](https://media.giphy.com/media/xUySTroyGxjaQe0kdG/giphy.gif)