### PR TITLE
Bugfix: Update localstack init for localstack v2

### DIFF
--- a/backend/docker-compose.local.yml
+++ b/backend/docker-compose.local.yml
@@ -13,7 +13,7 @@ services:
     image: "localstack/localstack:latest"
     container_name: "localstack"
     volumes:
-      - ${PWD}/localstack:/docker-entrypoint-initaws.d
+      - ${PWD}/localstack:/etc/localstack/init/ready.d
     ports:
       - "8080:8080"
       - "4566:4566"

--- a/backend/localstack/initialize.sh
+++ b/backend/localstack/initialize.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 awslocal sqs create-queue --queue-name artemis-task-queue
 awslocal sqs create-queue --queue-name artemis-priority-task-queue
 awslocal sqs create-queue --queue-name artemis-callback-queue


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Updates `docker-compose.local.yml` to use localstack's [currently-supported initialization hooks](https://docs.localstack.cloud/references/init-hooks/), enabling automatic creation of localstack infrastructure for local development.

## Motivation and Context

The `docker-entrypoint-initaws.d` initialization location was [removed](https://github.com/localstack/localstack/issues/8127#issuecomment-1505615761) in localstack v2, so the localstack infrastructure specified by `initialize.sh` was not being created automatically upon initialization of the localstack container.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Local testing (this file is only used when running Artemis locally).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Pic
![](https://media.giphy.com/media/cuVG15Drd8DMdXHvKX/giphy.gif)