### PR TITLE
SBOM storage formatting fix

### DIFF
--- a/backend/engine/plugins/veracode_sbom/main.py
+++ b/backend/engine/plugins/veracode_sbom/main.py
@@ -160,7 +160,7 @@ def lookup_licenses(coord1: str, coord2: str, version: str, libs: list) -> list:
                     continue
 
                 for license in v["licenses"]:
-                    licenses.append({"license_id": license["name"], "name": license["license"]})
+                    licenses.append({"id": license["name"], "name": license["license"]})
 
     return licenses
 
@@ -202,7 +202,7 @@ def process_unmatched_libraries(libs: list, matched: set) -> list:
                         "version": version["version"],
                         "licenses": [
                             # Don't need to lookup the libraries because they're right here
-                            {"license_id": license["name"], "name": license["license"]}
+                            {"id": license["name"], "name": license["license"]}
                             for license in version["licenses"]
                         ],
                         # Use coordinate type  instead of a filename so it's marginally helpful in tracking it down

--- a/backend/engine/processor/sbom.py
+++ b/backend/engine/processor/sbom.py
@@ -37,7 +37,7 @@ def process_dependency(dep: dict, scan: Scan):
 
     licenses = []
     for license in dep["licenses"]:
-        license_id = license["license_id"].lower()
+        license_id = license["id"].lower()
         if license_id not in license_obj_cache:
             # If we don't have a local copy of the license object get it from the DB
             license_obj_cache[license_id], _ = License.objects.get_or_create(

--- a/backend/engine/tests/data/veracode/sample-sbom-results.json
+++ b/backend/engine/tests/data/veracode/sample-sbom-results.json
@@ -1,0 +1,86 @@
+{
+  "metadata" : {
+    "requestDate" : "2021-01-01T00:00:00.000+00:00"
+  },
+  "records" : [ {
+    "metadata" : {
+      "recordType" : "SCAN",
+      "report" : null
+    },
+    "graphs" : [ {
+      "coords" : {
+        "coordinateType" : "PYPI",
+        "coordinate1" : "<undefined>",
+        "coordinate2" : null,
+        "version" : "<undefined>",
+        "scope" : null,
+        "platform" : null,
+        "commitHash" : null
+      },
+      "directs" : [ {
+        "coords" : {
+          "coordinateType" : "PYPI",
+          "coordinate1" : "PyLibrary",
+          "coordinate2" : null,
+          "version" : "1.0.0",
+          "scope" : null,
+          "platform" : null,
+          "commitHash" : null
+        },
+        "directs" : [ ],
+        "filename" : "requirements.txt",
+        "lineNumber" : 1,
+        "moduleName" : null,
+        "sha1" : null,
+        "sha2" : null,
+        "bytecodeHash" : null
+      } ],
+      "filename" : "requirements.txt",
+      "lineNumber" : null,
+      "moduleName" : null,
+      "sha1" : null,
+      "sha2" : null,
+      "bytecodeHash" : null
+    } ],
+    "libraries" : [ {
+      "name" : "PyLibrary",
+      "description" : "Python library",
+      "author" : "Example",
+      "authorUrl" : "https://github.com/example/pylibrary",
+      "language" : "PYTHON",
+      "coordinateType" : "PYPI",
+      "coordinate1" : "pylibrary",
+      "coordinate2" : "",
+      "bugTrackerUrl" : null,
+      "codeRepoType" : null,
+      "codeRepoUrl" : "https://github.com/example/pylibrary",
+      "latestRelease" : "2.0.0",
+      "latestReleaseDate" : "2021-01-01T00:00:00.000+00:00",
+      "recommendedVersion" : null,
+      "versions" : [ {
+        "version" : "1.0.0",
+        "releaseDate" : "2021-01-01T00:00:00.000+00:00",
+        "sha1" : "2aae6c35c94fcfb415dbe95f408b9ce91ee846ed",
+        "sha2" : "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9",
+        "bytecodeHash" : null,
+        "platform" : "source",
+        "licenses" : [ {
+          "name" : "MIT",
+          "license" : "MIT license (MIT)",
+          "fromParentPom" : false,
+          "risk" : "LOW",
+          "spdxId" : "MIT"
+        } ],
+        "_links" : {
+          "html" : "https://example.com"
+        }
+      } ],
+      "_links" : {
+        "html" : "https://example.com"
+      }
+    } ],
+    "vulnerabilities" : [ ],
+    "unmatchedLibraries" : [ ],
+    "vulnMethods" : [ ]
+  } ]
+}

--- a/backend/engine/tests/test_veracode_sbom_parser.py
+++ b/backend/engine/tests/test_veracode_sbom_parser.py
@@ -12,6 +12,10 @@ from engine.processor.sbom import process_sbom as flatten_sbom_and_write_to_s3
 from utils.plugin import Result
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+TEST_VERACODE_OUTPUT_PATH = os.path.join(TEST_DIR, "data", "veracode", "sample-sbom-results.json")
+EXPECTED_JSON = '[{"name": "PyLibrary", "version": "1.0.0", "licenses": [], "source": "requirements.txt", "deps": [], "type": null}, {"name": "pylibrary", "version": "1.0.0", "licenses": [{"id": "MIT", "name": "MIT license (MIT)"}], "source": "PYPI", "deps": [], "type": "pypi"}]'
+
+
 VERACODE_SBOM_RESULT = Result(
     name="Veracode SBOM",
     type="sbom",
@@ -22,20 +26,22 @@ VERACODE_SBOM_RESULT = Result(
     alerts=[],
     debug=[],
 )
-TEST_VERACODE_OUTPUT_PATH = os.path.join(TEST_DIR, "data", "veracode", "sample-sbom-results.json")
-EXPECTED_JSON = '[{"name": "PyLibrary", "version": "1.0.0", "licenses": [], "source": "requirements.txt", "deps": [], "type": null}, {"name": "pylibrary", "version": "1.0.0", "licenses": [{"id": "MIT", "name": "MIT license (MIT)"}], "source": "PYPI", "deps": [], "type": "pypi"}]'
 
 
 @patch("engine.processor.sbom.write_sbom_json", autospec=True)
 @patch("engine.processor.sbom.process_dependency")
 class TestVeracodeSbomParser(unittest.TestCase):
-    def test_raw_sbom_parse(self, _, mock_write_sbom_json):
+    def test_sbom_parse(self, _, mock_write_sbom_json):
         with open(TEST_VERACODE_OUTPUT_PATH) as f:
             output = json.load(f, parse_float=Decimal)
+
+        # process raw Veracode output in the same way SBOM plugin does
         graph = process_veracode_output(graphs=output["records"][0]["graphs"], libs=output["records"][0]["libraries"])
+
         mock_result = unittest.mock.MagicMock(side_effect=VERACODE_SBOM_RESULT)
         type(mock_result).details = PropertyMock(return_value=graph)
         mock_scan = unittest.mock.MagicMock(side_effect=Scan())
+
         flatten_sbom_and_write_to_s3(mock_result, mock_scan)
 
         # asserts that the json sent to s3 is equal to the expected json

--- a/backend/engine/tests/test_veracode_sbom_parser.py
+++ b/backend/engine/tests/test_veracode_sbom_parser.py
@@ -1,0 +1,42 @@
+import json
+import os
+import unittest
+from decimal import Decimal
+from unittest.mock import patch
+
+from mock import PropertyMock
+
+from artemisdb.artemisdb.models import Scan
+from engine.plugins.veracode_sbom.main import process_sbom as process_veracode_output
+from engine.processor.sbom import process_sbom as flatten_sbom_and_write_to_s3
+from utils.plugin import Result
+
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+VERACODE_SBOM_RESULT = Result(
+    name="Veracode SBOM",
+    type="sbom",
+    success=True,
+    truncated=False,
+    details=[],
+    errors=[],
+    alerts=[],
+    debug=[],
+)
+TEST_VERACODE_OUTPUT_PATH = os.path.join(TEST_DIR, "data", "veracode", "sample-sbom-results.json")
+EXPECTED_JSON = '[{"name": "PyLibrary", "version": "1.0.0", "licenses": [], "source": "requirements.txt", "deps": [], "type": null}, {"name": "pylibrary", "version": "1.0.0", "licenses": [{"id": "MIT", "name": "MIT license (MIT)"}], "source": "PYPI", "deps": [], "type": "pypi"}]'
+
+
+@patch("engine.processor.sbom.write_sbom_json", autospec=True)
+@patch("engine.processor.sbom.process_dependency")
+class TestVeracodeSbomParser(unittest.TestCase):
+    def test_raw_sbom_parse(self, _, mock_write_sbom_json):
+        with open(TEST_VERACODE_OUTPUT_PATH) as f:
+            output = json.load(f, parse_float=Decimal)
+        graph = process_veracode_output(graphs=output["records"][0]["graphs"], libs=output["records"][0]["libraries"])
+        mock_result = unittest.mock.MagicMock(side_effect=VERACODE_SBOM_RESULT)
+        type(mock_result).details = PropertyMock(return_value=graph)
+        mock_scan = unittest.mock.MagicMock(side_effect=Scan())
+        flatten_sbom_and_write_to_s3(mock_result, mock_scan)
+
+        # asserts that the json sent to s3 is equal to the expected json
+        mock_write_sbom_json.assert_called_with(mock_scan.scan_id, json.loads(EXPECTED_JSON))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This change ensures that license IDs in SBOM reports are reported with the key `id`, rather than `license_id`. The `id` key was in the original spec (and is the format that Artemis' UI expects); however, this was unintentionally changed to `license_id` by #48.

## Motivation and Context

#48 changed the way Artemis stores SBOM-generated dependency trees on the backend (from database to S3 bucket storage). It also unintentionally introduced a change to the format of SBOM results.

When SBOM reports were generated on-the-fly from the database, the textual representation of license objects was generated by [this to_dict() function](https://github.com/WarnerMedia/artemis/blob/670f823251cb2d77436db3ef52e77f0a3b56637f/backend/libs/artemisdb/artemisdb/artemisdb/models.py#L958-L959), which represented the `license_id` field with the `id` key.

However, when reports were written as JSON files directly to an S3 bucket, this `to_dict()` representation was not used, and this field was instead stored with the `license_id` key. A field name change constitutes a breaking change, and created validation issues when downloading SBOM reports via the UI.

This change also introduces a unit test which validates that the code which parses Veracode SBOM output returns JSON in the expected schema for submission to the S3 bucket.

## How Has This Been Tested?

 - This change has been tested in a live non-production environment
 - This change has been tested with a new unit test

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Pic
![](https://media.giphy.com/media/eNds87WCypxHqhaadW/giphy.gif)