### PR TITLE
Bugfixes: email migration and user deletion

### DIFF
--- a/backend/lambdas/api/authorizer/authorizer/handlers.py
+++ b/backend/lambdas/api/authorizer/authorizer/handlers.py
@@ -194,6 +194,10 @@ def _get_update_or_create_user(email: str) -> User:
 
         # Check if any aliases exist for domain, and attempt to find a match
         for alias in EMAIL_DOMAIN_ALIASES:
+            # if user was found in a previous iteration, break the loop
+            if user and not user.deleted:
+                break
+
             if alias["new_domain"] == email_domain:
                 for old_domain in alias["old_domains"]:
                     if alias.get("email_transformation"):
@@ -215,6 +219,8 @@ def _get_update_or_create_user(email: str) -> User:
                         LOG.debug(f"Attempting to user email from {old_email} to {email}")
                         user.email = email
                         user.save()
+                        # since user was successfully found and updated, break out of inner loop
+                        break
 
     # if user is found directly or via alias (and was not soft-deleted), ensure that user's self group is named correctly, then return user
     if user and not user.deleted:

--- a/backend/lambdas/api/authorizer/authorizer/handlers.py
+++ b/backend/lambdas/api/authorizer/authorizer/handlers.py
@@ -215,10 +215,11 @@ def _get_update_or_create_user(email: str) -> User:
 
                     # If a user is found with an old email (and was not soft-deleted), update the email and return user
                     if user and not user.deleted:
-                        LOG.debug(f"User account discovered with old email {old_email}")
-                        LOG.debug(f"Attempting to user email from {old_email} to {email}")
+                        LOG.debug(f"User account discovered with alias {old_email}")
+                        LOG.debug(f"Attempting to update user email from {old_email} to {email}")
                         user.email = email
                         user.save()
+                        LOG.debug(f"User account email updated to {user.email}")
                         # since user was successfully found and updated, break out of inner loop
                         break
 
@@ -230,8 +231,9 @@ def _get_update_or_create_user(email: str) -> User:
             LOG.debug(f"Attempting to update self group name to {user.email}")
             user.self_group.name = user.email
             user.self_group.save()
+            LOG.debug(f"Self group name updated to {user.self_group.name}")
 
-        LOG.debug(f"Returning user with email {user.email}")
+        LOG.debug(f"Returning user with email {user.email} and self group {user.self_group.name}")
         return user
 
     # Create the user since no match has been found at this point

--- a/backend/lambdas/api/authorizer/authorizer/handlers.py
+++ b/backend/lambdas/api/authorizer/authorizer/handlers.py
@@ -227,6 +227,7 @@ def _get_update_or_create_user(email: str, source_ip: str) -> User:
                             user=user.email, scope=user.scope, features=user.features, admin=user.admin
                         )
                         LOG.debug(f"User account email updated to {user.email}")
+
                         # since user was successfully found and updated, break out of inner loop
                         break
 
@@ -285,6 +286,7 @@ def _create_user(email: str, source_ip: str) -> User:
         admin=user.self_group.admin,
         allowlist=user.self_group.allowlist,
     )
+
     return user
 
 

--- a/backend/lambdas/api/authorizer/tests/test_get_user.py
+++ b/backend/lambdas/api/authorizer/tests/test_get_user.py
@@ -20,6 +20,11 @@ EMAIL_DOMAIN_ALIASES = [
         "old_domains": ["company.com"],
         "email_transformation": {"new_email_regex": "_", "old_email_expr": "."},
     },
+    {
+        "new_domain": "company5.com",
+        "old_domains": ["company6.com", "company6andsuffix.com"],
+        "email_transformation": {"new_email_regex": "[.]", "old_email_expr": "_"},
+    },
     {"new_domain": "newcompany.com", "old_domains": ["company.com"]},
 ]
 
@@ -59,6 +64,20 @@ USERS = [
         "deleted": False,
         "last_login": "2023-01-01 00:00:00.000000+00:00",
         "self_group": {"name": "first_last@company3.com"},
+    },
+    {
+        "id": 6,
+        "email": "first_last@company6.com",
+        "deleted": False,
+        "last_login": "2023-01-01 00:00:00.000000+00:00",
+        "self_group": {"name": "first_last@company6.com"},
+    },
+    {
+        "id": 7,
+        "email": "first2_last2@company6andsuffix.com",
+        "deleted": False,
+        "last_login": "2023-01-01 00:00:00.000000+00:00",
+        "self_group": {"name": "first2_last2@company6andsuffix.com"},
     },
 ]
 
@@ -239,6 +258,36 @@ class TestGetUser(unittest.TestCase):
         user = _get_update_or_create_user(email=email)
         self.assertTrue(
             user.__dict__.get("id") == expected_userid
+            and user.__dict__.get("email") == email
+            and user.__dict__.get("self_group").name == email
+        )
+
+    def test_get_user_with_new_email_and_multiple_old_domains_first_domain(self):
+        """
+        User logs in with email "first.last@company5.com" and has an existing acount with email "first_last@company6.com"
+        Existing account is found, and email and self group name are updated to the new email "first.last@company5.com"
+        This is distinct from other tests because there are multiple old domains mapped to new domain company5.com
+        """
+        MockUser.users = copy.deepcopy(USERS)
+        email = "first.last@company5.com"
+        user = _get_update_or_create_user(email=email)
+        self.assertTrue(
+            user.__dict__.get("id") == 6
+            and user.__dict__.get("email") == email
+            and user.__dict__.get("self_group").name == email
+        )
+
+    def test_get_user_with_new_email_and_multiple_old_domains_second_domain(self):
+        """
+        User logs in with email "first2.last2@company5.com" and has an existing acount with email "first2_last2@company6andsuffix.com"
+        Existing account is found, and email and self group name are updated to the new email "first.last@company5.com"
+        This is distinct from other tests because there are multiple old domains mapped to new domain company5.com
+        """
+        MockUser.users = copy.deepcopy(USERS)
+        email = "first2.last2@company5.com"
+        user = _get_update_or_create_user(email=email)
+        self.assertTrue(
+            user.__dict__.get("id") == 7
             and user.__dict__.get("email") == email
             and user.__dict__.get("self_group").name == email
         )

--- a/backend/lambdas/api/authorizer/tests/test_get_user.py
+++ b/backend/lambdas/api/authorizer/tests/test_get_user.py
@@ -81,10 +81,17 @@ USERS = [
     },
 ]
 
+EVENT_IP = "0.0.0.0"
+
 
 class MockGroup(object):
     def __init__(self, **kwargs):
         self.name = kwargs.get("name") or ""
+        self.group_id = ""
+        self.scope = []
+        self.features = {}
+        self.admin = False
+        self.allowlist = False
 
     def save(self):
         pass
@@ -107,6 +114,9 @@ class MockUser(object):
         self_group = kwargs.get("self_group") or None
         if self_group:
             self.self_group = MockGroup(name=self_group.get("name"))
+        self.scope = []
+        self.features = {}
+        self.admin = False
 
     def save(self):
         for user in MockUser.users:
@@ -137,6 +147,10 @@ class MockUser(object):
 _get_update_or_create_user = authorizer.handlers._get_update_or_create_user.__wrapped__
 
 
+@patch("authorizer.handlers.AuditLogger.group_created", lambda *x, **y: None)
+@patch("authorizer.handlers.AuditLogger.group_modified", lambda *x, **y: None)
+@patch("authorizer.handlers.AuditLogger.user_created", lambda *x, **y: None)
+@patch("authorizer.handlers.AuditLogger.user_modified", lambda *x, **y: None)
 @patch("authorizer.handlers.EMAIL_DOMAIN_ALIASES", EMAIL_DOMAIN_ALIASES)
 @patch("authorizer.handlers.User", MockUser)
 @patch("authorizer.handlers.Group", MockGroup)
@@ -147,7 +161,7 @@ class TestGetUser(unittest.TestCase):
         """
         MockUser.users = copy.deepcopy(USERS)
         email = "first.last@company.com"
-        user = _get_update_or_create_user(email=email)
+        user = _get_update_or_create_user(email=email, source_ip=EVENT_IP)
         self.assertTrue(
             user.__dict__.get("id") == 1
             and user.__dict__.get("email") == email
@@ -160,7 +174,7 @@ class TestGetUser(unittest.TestCase):
         """
         MockUser.users = copy.deepcopy(USERS)
         email = "first.last.1@company.com"
-        user = _get_update_or_create_user(email=email)
+        user = _get_update_or_create_user(email=email, source_ip=EVENT_IP)
         self.assertTrue(user == None)
 
     def test_get_nonexistent_user(self):
@@ -170,7 +184,7 @@ class TestGetUser(unittest.TestCase):
         MockUser.users = copy.deepcopy(USERS)
         email = "first.last@doesnotexist.com"
         expected_userid = MockUser.users[-1].get("id") + 1
-        user = _get_update_or_create_user(email=email)
+        user = _get_update_or_create_user(email=email, source_ip=EVENT_IP)
         self.assertTrue(
             user.__dict__.get("id") == expected_userid
             and user.__dict__.get("email") == email
@@ -184,7 +198,7 @@ class TestGetUser(unittest.TestCase):
         """
         MockUser.users = copy.deepcopy(USERS)
         email = "first.last@newcompany.com"
-        user = _get_update_or_create_user(email=email)
+        user = _get_update_or_create_user(email=email, source_ip=EVENT_IP)
         self.assertTrue(
             user.__dict__.get("id") == 1
             and user.__dict__.get("email") == email
@@ -198,7 +212,7 @@ class TestGetUser(unittest.TestCase):
         """
         MockUser.users = copy.deepcopy(USERS)
         email = "first.last@company1.com"
-        user = _get_update_or_create_user(email=email)
+        user = _get_update_or_create_user(email=email, source_ip=EVENT_IP)
         self.assertTrue(
             user.__dict__.get("id") == 2
             and user.__dict__.get("email") == email
@@ -212,7 +226,7 @@ class TestGetUser(unittest.TestCase):
         """
         MockUser.users = copy.deepcopy(USERS)
         email = "first.last@company2.com"
-        user = _get_update_or_create_user(email=email)
+        user = _get_update_or_create_user(email=email, source_ip=EVENT_IP)
         self.assertTrue(
             user.__dict__.get("id") == 4
             and user.__dict__.get("email") == email
@@ -226,7 +240,7 @@ class TestGetUser(unittest.TestCase):
         """
         MockUser.users = copy.deepcopy(USERS)
         email = "first_last@company3.com"
-        user = _get_update_or_create_user(email=email)
+        user = _get_update_or_create_user(email=email, source_ip=EVENT_IP)
         self.assertTrue(
             user.__dict__.get("id") == 1
             and user.__dict__.get("email") == email
@@ -240,7 +254,7 @@ class TestGetUser(unittest.TestCase):
         """
         MockUser.users = copy.deepcopy(USERS)
         email = "first.last@company4.com"
-        user = _get_update_or_create_user(email=email)
+        user = _get_update_or_create_user(email=email, source_ip=EVENT_IP)
         self.assertTrue(
             user.__dict__.get("id") == 5
             and user.__dict__.get("email") == email
@@ -255,7 +269,7 @@ class TestGetUser(unittest.TestCase):
         MockUser.users = copy.deepcopy(USERS)
         email = "first.last.1@newcompany.com"
         expected_userid = MockUser.users[-1].get("id") + 1
-        user = _get_update_or_create_user(email=email)
+        user = _get_update_or_create_user(email=email, source_ip=EVENT_IP)
         self.assertTrue(
             user.__dict__.get("id") == expected_userid
             and user.__dict__.get("email") == email
@@ -270,7 +284,7 @@ class TestGetUser(unittest.TestCase):
         """
         MockUser.users = copy.deepcopy(USERS)
         email = "first.last@company5.com"
-        user = _get_update_or_create_user(email=email)
+        user = _get_update_or_create_user(email=email, source_ip=EVENT_IP)
         self.assertTrue(
             user.__dict__.get("id") == 6
             and user.__dict__.get("email") == email
@@ -285,7 +299,7 @@ class TestGetUser(unittest.TestCase):
         """
         MockUser.users = copy.deepcopy(USERS)
         email = "first2.last2@company5.com"
-        user = _get_update_or_create_user(email=email)
+        user = _get_update_or_create_user(email=email, source_ip=EVENT_IP)
         self.assertTrue(
             user.__dict__.get("id") == 7
             and user.__dict__.get("email") == email

--- a/backend/lambdas/api/authorizer/tests/test_get_user.py
+++ b/backend/lambdas/api/authorizer/tests/test_get_user.py
@@ -87,11 +87,11 @@ EVENT_IP = "0.0.0.0"
 class MockGroup(object):
     def __init__(self, **kwargs):
         self.name = kwargs.get("name") or ""
-        self.group_id = ""
-        self.scope = []
-        self.features = {}
-        self.admin = False
-        self.allowlist = False
+        self.group_id = kwargs.get("group_id") or ""
+        self.scope = kwargs.get("scope") or []
+        self.features = kwargs.get("features") or {}
+        self.admin = kwargs.get("admin") or False
+        self.allowlist = kwargs.get("allowlist") or False
 
     def save(self):
         pass
@@ -114,9 +114,9 @@ class MockUser(object):
         self_group = kwargs.get("self_group") or None
         if self_group:
             self.self_group = MockGroup(name=self_group.get("name"))
-        self.scope = []
-        self.features = {}
-        self.admin = False
+        self.scope = kwargs.get("scope") or []
+        self.features = kwargs.get("features") or {}
+        self.admin = kwargs.get("admin") or False
 
     def save(self):
         for user in MockUser.users:

--- a/backend/lambdas/api/users/users/delete.py
+++ b/backend/lambdas/api/users/users/delete.py
@@ -54,6 +54,9 @@ def delete(event, email=None, admin: bool = False):
         # Hard delete all of the user's self group API keys
         user.self_group.apikey_set.all().delete()
 
+        # Hard delete user's services
+        user.userservice_set.all().delete()
+
     # This is outside the transaction so that if the transaction rolled back we don't log the audit event
     if user.deleted:
         audit_log = AuditLogger(principal=email, source_ip=event["requestContext"]["identity"]["sourceIp"])

--- a/backend/libs/artemislib/artemislib/audit/logger.py
+++ b/backend/libs/artemislib/artemislib/audit/logger.py
@@ -43,21 +43,45 @@ class AuditLogger:
     # User audit events
 
     def user_login(self) -> None:
-        self._queue_event(UserAuditEvent(self.principal, self.source_ip, Action.LOGIN))
+        self._queue_event(UserAuditEvent(principal=self.principal, source_ip=self.source_ip, action=Action.LOGIN))
 
     def user_created(self, user: str, scope: list[str], features: dict, admin: bool) -> None:
-        self._queue_event(UserAuditEvent(self.principal, self.source_ip, Action.CREATED, user, scope, features, admin))
+        self._queue_event(
+            UserAuditEvent(
+                principal=self.principal,
+                source_ip=self.source_ip,
+                action=Action.CREATED,
+                user=user,
+                scope=scope,
+                features=features,
+                admin=admin,
+            )
+        )
 
     def user_modified(self, user: str, scope: list[str] = None, features: dict = None, admin: bool = None) -> None:
-        self._queue_event(UserAuditEvent(self.principal, self.source_ip, Action.MODIFIED, user, scope, features, admin))
+        self._queue_event(
+            UserAuditEvent(
+                principal=self.principal,
+                source_ip=self.source_ip,
+                action=Action.MODIFIED,
+                user=user,
+                scope=scope,
+                features=features,
+                admin=admin,
+            )
+        )
 
     def user_deleted(self, user: str) -> None:
-        self._queue_event(UserAuditEvent(self.principal, self.source_ip, Action.DELETED, user))
+        self._queue_event(
+            UserAuditEvent(principal=self.principal, source_ip=self.source_ip, action=Action.DELETED, user=user)
+        )
 
     # API key audit events
 
     def key_login(self, key_id: str) -> None:
-        self._queue_event(APIKeyAuditEvent(self.principal, self.source_ip, Action.LOGIN, key_id))
+        self._queue_event(
+            APIKeyAuditEvent(principal=self.principal, source_ip=self.source_ip, action=Action.LOGIN, key_id=key_id)
+        )
 
     def key_created(
         self,
@@ -71,21 +95,23 @@ class AuditLogger:
     ) -> None:
         self._queue_event(
             APIKeyAuditEvent(
-                self.principal,
-                self.source_ip,
-                Action.CREATED,
-                key_id,
-                scope,
-                features,
-                admin,
-                expires,
-                group_id,
-                group_name,
+                principal=self.principal,
+                source_ip=self.source_ip,
+                action=Action.CREATED,
+                key_id=key_id,
+                scope=scope,
+                features=features,
+                admin=admin,
+                expires=expires,
+                group_id=group_id,
+                group_name=group_name,
             )
         )
 
     def key_deleted(self, key_id: str) -> None:
-        self._queue_event(APIKeyAuditEvent(self.principal, self.source_ip, Action.DELETED, key_id))
+        self._queue_event(
+            APIKeyAuditEvent(principal=self.principal, source_ip=self.source_ip, action=Action.DELETED, key_id=key_id)
+        )
 
     # AllowList audit events
 
@@ -94,17 +120,17 @@ class AuditLogger:
     ) -> None:
         self._queue_event(
             AllowListAuditEvent(
-                self.principal,
-                self.source_ip,
-                Action.CREATED,
-                al_id,
-                service,
-                repo,
-                type,
-                expires,
-                value,
-                reason,
-                severity,
+                principal=self.principal,
+                source_ip=self.source_ip,
+                action=Action.CREATED,
+                al_id=al_id,
+                service=service,
+                repo=repo,
+                type=type,
+                expires=expires,
+                value=value,
+                reason=reason,
+                severity=severity,
             )
         )
 
@@ -113,17 +139,17 @@ class AuditLogger:
     ) -> None:
         self._queue_event(
             AllowListAuditEvent(
-                self.principal,
-                self.source_ip,
-                Action.MODIFIED,
-                al_id,
-                service,
-                repo,
-                type,
-                expires,
-                value,
-                reason,
-                severity,
+                principal=self.principal,
+                source_ip=self.source_ip,
+                action=Action.MODIFIED,
+                al_id=al_id,
+                service=service,
+                repo=repo,
+                type=type,
+                expires=expires,
+                value=value,
+                reason=reason,
+                severity=severity,
             )
         )
 
@@ -132,17 +158,17 @@ class AuditLogger:
     ) -> None:
         self._queue_event(
             AllowListAuditEvent(
-                self.principal,
-                self.source_ip,
-                Action.DELETED,
-                al_id,
-                service,
-                repo,
-                type,
-                expires,
-                value,
-                reason,
-                severity,
+                principal=self.principal,
+                source_ip=self.source_ip,
+                action=Action.DELETED,
+                al_id=al_id,
+                service=service,
+                repo=repo,
+                type=type,
+                expires=expires,
+                value=value,
+                reason=reason,
+                severity=severity,
             )
         )
 
@@ -150,17 +176,41 @@ class AuditLogger:
 
     def sal_created(self, al_id: str, type: str, value: dict, reason: str) -> None:
         self._queue_event(
-            AllowListAuditEvent(self.principal, self.source_ip, Action.CREATED, al_id, type, value, reason)
+            AllowListAuditEvent(
+                principal=self.principal,
+                source_ip=self.source_ip,
+                action=Action.CREATED,
+                al_id=al_id,
+                type=type,
+                value=value,
+                reason=reason,
+            )
         )
 
     def sal_modified(self, al_id: str, type: str, value: dict, reason: str) -> None:
         self._queue_event(
-            AllowListAuditEvent(self.principal, self.source_ip, Action.MODIFIED, al_id, type, value, reason)
+            AllowListAuditEvent(
+                principal=self.principal,
+                source_ip=self.source_ip,
+                action=Action.MODIFIED,
+                al_id=al_id,
+                type=type,
+                value=value,
+                reason=reason,
+            )
         )
 
     def sal_deleted(self, al_id: str, type: str, value: dict, reason: str) -> None:
         self._queue_event(
-            AllowListAuditEvent(self.principal, self.source_ip, Action.DELETED, al_id, type, value, reason)
+            AllowListAuditEvent(
+                principal=self.principal,
+                source_ip=self.source_ip,
+                action=Action.DELETED,
+                al_id=al_id,
+                type=type,
+                value=value,
+                reason=reason,
+            )
         )
 
     # Group audit events
@@ -170,7 +220,15 @@ class AuditLogger:
     ) -> None:
         self._queue_event(
             GroupAuditEvent(
-                self.principal, self.source_ip, Action.CREATED, group_id, name, scope, features, admin, allowlist
+                principal=self.principal,
+                source_ip=self.source_ip,
+                action=Action.CREATED,
+                group_id=group_id,
+                name=name,
+                scope=scope,
+                features=features,
+                admin=admin,
+                allowlist=allowlist,
             )
         )
 
@@ -179,26 +237,61 @@ class AuditLogger:
     ) -> None:
         self._queue_event(
             GroupAuditEvent(
-                self.principal, self.source_ip, Action.MODIFIED, group_id, name, scope, features, admin, allowlist
+                principal=self.principal,
+                source_ip=self.source_ip,
+                action=Action.MODIFIED,
+                group_id=group_id,
+                name=name,
+                scope=scope,
+                features=features,
+                admin=admin,
+                allowlist=allowlist,
             )
         )
 
     def group_deleted(self, group_id: str, name: str) -> None:
-        self._queue_event(GroupAuditEvent(self.principal, self.source_ip, Action.DELETED, group_id, name))
+        self._queue_event(
+            GroupAuditEvent(
+                principal=self.principal, source_ip=self.source_ip, action=Action.DELETED, group_id=group_id, name=name
+            )
+        )
 
     # Group membership audit events
 
     def group_member_added(self, user_id: str, group_id: str, name: str, admin: bool) -> None:
         self._queue_event(
-            GroupMemberAuditEvent(self.principal, self.source_ip, Action.CREATED, user_id, group_id, name, admin)
+            GroupMemberAuditEvent(
+                principal=self.principal,
+                source_ip=self.source_ip,
+                action=Action.CREATED,
+                user_id=user_id,
+                group_id=group_id,
+                name=name,
+                admin=admin,
+            )
         )
 
     def group_member_modified(self, user_id: str, group_id: str, name: str, admin: bool) -> None:
         self._queue_event(
-            GroupMemberAuditEvent(self.principal, self.source_ip, Action.MODIFIED, user_id, group_id, name, admin)
+            GroupMemberAuditEvent(
+                principal=self.principal,
+                source_ip=self.source_ip,
+                action=Action.MODIFIED,
+                user_id=user_id,
+                group_id=group_id,
+                name=name,
+                admin=admin,
+            )
         )
 
     def group_member_removed(self, user_id: str, group_id: str, name: str) -> None:
         self._queue_event(
-            GroupMemberAuditEvent(self.principal, self.source_ip, Action.DELETED, user_id, group_id, name)
+            GroupMemberAuditEvent(
+                principal=self.principal,
+                source_ip=self.source_ip,
+                action=Action.DELETED,
+                user_id=user_id,
+                group_id=group_id,
+                name=name,
+            )
         )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

This PR addresses a bug introduced by #78 which affected Artemis' ability to automatically update user email addresses based on predefined patterns.

## Motivation and Context

Prior to #78, the logic which searches for user accounts matching potential aliases for a user's email address immediately returned the user account once it was found, breaking out of a couple of loops. The changes introduced in #78 deferred the return of the user account in this context in order to update the name of the user's self group as well. However, these changes did not add logic to break out of the nested loops while staying within the function, causing unexpected behavior.

The troubleshooting process for this bug also enabled the discovery of a couple of other bugs: 
- When a user account is deleted, the associated `UserService` objects are not deleted. This seems to cause the `/users/self` API to return a 502 error after a new Artemis user account linked a GitHub account when that GitHub account was already associated with a deleted account.
- Audit log steps were missing from creation and modification events for users and groups when performed by the authorizer lambda
- Some audit events were being incorrectly formed due to some misaligned parameters

This PR does the following:
- addresses the main bug by breaking out of the search loops when a valid user account is located
- adds debug-level logging to the authorizer lambda to make this code easier to debug in a deployed environment
- adds unit test cases that would have caught the bug introduced by #78 
- implements hard deletion of a user's services when their account is soft-deleted
- adds audit logging steps to user and group operations performed by the authorizer lambda
- updates the creation of audit events to use keyword arguments, rather than positional, to eliminate the issue of misaligned positional parameters

## How Has This Been Tested?

- unit tests
- tested for functionality in a live non-production environment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Pic
![](https://media.giphy.com/media/aiI8nWM1j6iR2/giphy.gif)