### PR TITLE
Migrate away from obsolete template provider.

### DIFF
--- a/backend/terraform/modules/analyzer/modules/engine_cluster/main.tf
+++ b/backend/terraform/modules/analyzer/modules/engine_cluster/main.tf
@@ -21,42 +21,37 @@ resource "aws_route_table_association" "routing" {
 ###############################################################################
 # EC2 Instance
 ###############################################################################
-data "template_file" "engine-script" {
-  template = file("${path.module}/templates/user_data/engine.sh")
-
-  vars = {
-    s3_bucket                    = var.s3_analyzer_files_bucket
-    ver                          = var.ver
-    type                         = var.public ? "public" : "nat"
-    aqua_enabled                 = var.aqua_enabled ? 1 : 0
-    veracode_enabled             = var.veracode_enabled ? 1 : 0
-    snyk_enabled                 = var.snyk_enabled ? 1 : 0
-    ghas_enabled                 = var.ghas_enabled ? 1 : 0
-    github_app_id                = var.github_app_id
-    private_docker_repos_key     = var.private_docker_repos_key
-    plugin_java_heap_size        = var.plugin_java_heap_size
-    status_lambda                = var.system_status_lambda.arn
-    aws_region                   = var.aws_region
-    docker_compose_ver           = var.docker_compose_ver
-    engine_block_device          = var.engine_block_device
-    application                  = var.app
-    region                       = var.aws_region
-    domain_name                  = var.domain_name
-    mandatory_include_paths      = jsonencode(var.mandatory_include_paths)
-    metadata_scheme_modules      = var.metadata_scheme_modules
-    revproxy_domain_substring    = var.revproxy_domain_substring
-    revproxy_secret              = var.revproxy_secret
-    revproxy_secret_region       = var.revproxy_secret_region
-    secrets_events_enabled       = var.secrets_events_enabled
-    inventory_events_enabled     = var.inventory_events_enabled
-    configuration_events_enabled = var.configuration_events_enabled
-    vulnerability_events_enabled = var.vulnerability_events_enabled
-    log_level                    = var.log_level
-  }
-}
-
 locals {
-  engine_user_data = data.template_file.engine-script.rendered
+  engine_user_data = templatefile(
+    "${path.module}/templates/user_data/engine.sh", {
+      s3_bucket                    = var.s3_analyzer_files_bucket
+      ver                          = var.ver
+      type                         = var.public ? "public" : "nat"
+      aqua_enabled                 = var.aqua_enabled ? 1 : 0
+      veracode_enabled             = var.veracode_enabled ? 1 : 0
+      snyk_enabled                 = var.snyk_enabled ? 1 : 0
+      ghas_enabled                 = var.ghas_enabled ? 1 : 0
+      github_app_id                = var.github_app_id
+      private_docker_repos_key     = var.private_docker_repos_key
+      plugin_java_heap_size        = var.plugin_java_heap_size
+      status_lambda                = var.system_status_lambda.arn
+      aws_region                   = var.aws_region
+      docker_compose_ver           = var.docker_compose_ver
+      engine_block_device          = var.engine_block_device
+      application                  = var.app
+      region                       = var.aws_region
+      domain_name                  = var.domain_name
+      mandatory_include_paths      = jsonencode(var.mandatory_include_paths)
+      metadata_scheme_modules      = var.metadata_scheme_modules
+      revproxy_domain_substring    = var.revproxy_domain_substring
+      revproxy_secret              = var.revproxy_secret
+      revproxy_secret_region       = var.revproxy_secret_region
+      secrets_events_enabled       = var.secrets_events_enabled
+      inventory_events_enabled     = var.inventory_events_enabled
+      configuration_events_enabled = var.configuration_events_enabled
+      vulnerability_events_enabled = var.vulnerability_events_enabled
+      log_level                    = var.log_level
+  })
 }
 
 resource "aws_launch_template" "engine-template" {


### PR DESCRIPTION
Removes the dependency on the obsolete hashicorp/template provider, which is not available for Apple Silicon Macs.

## Description

The "template_file" data source uses the hashicorp/template provider, which is officially deprecated and archived, with the functionality moved into the templatefile function in Terraform 0.12.

This is a problem because the final release of the template provider, 2.2.0, does not include a darwin_arm64 build, so folks on that platform will get the following error:

    template v2.2.0 does not have a package available for your current platform, darwin_arm64

The official migration path is to use the [templatefile](https://developer.hashicorp.com/terraform/language/functions/templatefile) function instead.

This change only removes the dependency on the hashicorp/template provider, there are no functional changes.

See also:
https://registry.terraform.io/providers/hashicorp/template/latest/docs#deprecation

## Motivation and Context

Enables Terraform deployments on Apple Silicon (M1, etc.) Macs.

## How Has This Been Tested?

* Verified with `terraform plan` that there are no changes, then `terraform apply` to update the statefile.
* Verified that that statefile no longer references the `hashicorp/template` provider and `terraform init` no longer installs the provider.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly. (N/A)
- [ ] I have added tests to cover my changes. (N/A)
- [x] All new and existing tests passed.
