### PR TITLE
Allow configuration of the DB engine version.

### DIFF
--- a/backend/terraform/modules/analyzer/db.tf
+++ b/backend/terraform/modules/analyzer/db.tf
@@ -9,7 +9,7 @@ module "aurora" {
   name = "${var.app}-${var.environment}"
 
   engine                          = "aurora-postgresql"
-  engine_version                  = "11.17"
+  engine_version                  = var.db_engine_version
   auto_minor_version_upgrade      = true
   apply_immediately               = true
   db_parameter_group_name         = aws_db_parameter_group.db_parameter_group.name

--- a/backend/terraform/modules/analyzer/variables.tf
+++ b/backend/terraform/modules/analyzer/variables.tf
@@ -62,6 +62,12 @@ variable "db_instance_type" {
   description = "RDS instance type"
 }
 
+variable "db_engine_version" {
+  description = "RDS database engine version"
+  type        = string
+  default     = "11"
+}
+
 variable "ui_origin_url" {
   description = "Origin URL for the UI"
 }


### PR DESCRIPTION
## Description

The `analyzer` Terraform module now supports a variable `db_engine_version` that allows the database engine version to be specified.

## Motivation and Context

This is to support upgrading the RDS database engine, e.g. upgrading the development environment first before upgrading production.

Additionally, the new default only specifies the major version number in order to permit automated minor version upgrades.

## How Has This Been Tested?

Spot-applied the resource (with the new default value) and confirmed that only the state is updated.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
