### PR TITLE
Specify cryptography as required extra to pyjwt.

### DIFF
--- a/backend/libs/artemislib/setup.py
+++ b/backend/libs/artemislib/setup.py
@@ -25,7 +25,7 @@ setup(
         "boto3",
         # pyjwt requires the cryptography library but it needs to be installed
         # separately because it contains platform-dependent pre-compiled code
-        "pyjwt",
+        "pyjwt[crypto]",
         "requests",
         "urllib3<2",  # https://github.com/boto/botocore/issues/2926
     ],


### PR DESCRIPTION
When setting up in a clean environment, running api_runner may fail due to the "cryptography" module not being found.

## Description

This fix follows the pyjwt recommendation of specifying the dependency as a required extra:
https://pyjwt.readthedocs.io/en/latest/installation.html#cryptographic-dependencies-optional

## Motivation and Context

Fixes initial set up in a clean environment and explicitly notes the dependency.

## How Has This Been Tested?

Tested before and after with a clean Python 3.9.18 virtualenv.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
