### PR TITLE
Use PostgreSQL 16.1 for local development.

### DIFF
--- a/backend/docker-compose.local.yml
+++ b/backend/docker-compose.local.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   database:
-    image: "postgres:11.7"
+    image: "postgres:16.1"
     container_name: "artemisdb"
     ports:
       - "${ANALYZER_DB_PORT}:5432"


### PR DESCRIPTION
## Description

This switches the database used for local development from PostgreSQL 11 to PostgreSQL 16, which is our upcoming new target version.

## Motivation and Context

AWS RDS support for PostgreSQL 11.x ended on 2024-02-29.

## How Has This Been Tested?

Basic startup and API tests only so far.  This change is being made now to discover any potential issues over the next couple weeks.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
