### PR TITLE
Escape double quotes in branch_name

### DIFF
--- a/backend/lambdas/api/repo/repo/github_util/github_utils.py
+++ b/backend/lambdas/api/repo/repo/github_util/github_utils.py
@@ -47,6 +47,11 @@ def _build_queries(req_list, service, authz):
     count = 0
     for req in req_list:
         branch_name = req.get("branch")
+
+        # Escape Double quotes in branch name. Leaving double quotes in will affect the graphql query
+        if branch_name:
+            branch_name = branch_name.replace('"', '\\"')
+
         org_name = req.get("org", DEFAULT_ORG)
 
         # Validate that this API key is authorized to scan this repo

--- a/backend/lambdas/api/repo/repo/github_util/github_utils.py
+++ b/backend/lambdas/api/repo/repo/github_util/github_utils.py
@@ -59,7 +59,6 @@ def _build_queries(req_list, service, authz):
         if branch_name:
             # Escape Double quotes in branch name. Leaving double quotes in will affect the graphql query
             branch_name = branch_name.replace('"', '\\"')
-
             query_list.append(
                 """
                 repo%d: repository(owner: "%s", name: "%s") {

--- a/backend/lambdas/api/repo/repo/github_util/github_utils.py
+++ b/backend/lambdas/api/repo/repo/github_util/github_utils.py
@@ -48,10 +48,6 @@ def _build_queries(req_list, service, authz):
     for req in req_list:
         branch_name = req.get("branch")
 
-        # Escape Double quotes in branch name. Leaving double quotes in will affect the graphql query
-        if branch_name:
-            branch_name = branch_name.replace('"', '\\"')
-
         org_name = req.get("org", DEFAULT_ORG)
 
         # Validate that this API key is authorized to scan this repo
@@ -61,6 +57,9 @@ def _build_queries(req_list, service, authz):
             continue
 
         if branch_name:
+            # Escape Double quotes in branch name. Leaving double quotes in will affect the graphql query
+            branch_name = branch_name.replace('"', '\\"')
+
             query_list.append(
                 """
                 repo%d: repository(owner: "%s", name: "%s") {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A `branch_name` with a double quote causes the repo-handler's github utility to build an invalid graphql query

https://github.com/WarnerMedia/artemis/blob/fbf2847a27185ce4798580507404ffc162b97ee8/backend/lambdas/api/repo/repo/github_util/github_utils.py#L58-L70

This PR escapes double quotes in branch_names to avoid creating an invalid graphql query

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in a dev environment
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
