### PR TITLE
Fix pg_restore error on dependency_path_after_trg.

### DIFF
--- a/backend/libs/artemisdb/artemisdb/artemisdb/migrations/0050_dep_path_trigger.py
+++ b/backend/libs/artemisdb/artemisdb/artemisdb/migrations/0050_dep_path_trigger.py
@@ -1,5 +1,6 @@
 from django.db import migrations
 
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -32,6 +33,6 @@ CREATE TRIGGER dependency_path_after_trg
     FOR EACH ROW
     WHEN (NEW.path IS DISTINCT FROM OLD.path)
     EXECUTE PROCEDURE _update_descendants_dependency_path();
-"""
+""",
         )
     ]

--- a/backend/libs/artemisdb/artemisdb/artemisdb/migrations/0050_dep_path_trigger.py
+++ b/backend/libs/artemisdb/artemisdb/artemisdb/migrations/0050_dep_path_trigger.py
@@ -1,0 +1,37 @@
+from django.db import migrations
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("artemisdb", "0049_auto_20240206_2045"),
+    ]
+
+    operations = [
+        # Using "IS DISTINCT FROM" on ltree types in a trigger condition
+        # causes failures when restoring a database dump via pg_restore, as
+        # can happen when upgrading between major PostgreSQL server versions.
+        # This is due to the "=" operator not being found during the restore:
+        #   ERROR:  operator does not exist: public.ltree = public.ltree
+        #
+        # The workaround is to use OPERATOR, as suggested here:
+        #   https://www.postgresql.org/message-id/CAKFQuwZsArqyJbcL5%2BH56hAV9nhHNxV2vFVeWq9H2NmVxq2XJQ%40mail.gmail.com
+        migrations.RunSQL(
+            sql="""
+DROP TRIGGER IF EXISTS dependency_path_after_trg ON artemisdb_dependency;
+CREATE TRIGGER dependency_path_after_trg
+    AFTER UPDATE ON artemisdb_dependency
+    FOR EACH ROW
+    WHEN (NOT(NEW.path OPERATOR("public".=) OLD.path) AND
+        (COALESCE(NEW.path, OLD.path) IS NOT NULL))
+    EXECUTE PROCEDURE _update_descendants_dependency_path();
+""",
+            reverse_sql="""
+DROP TRIGGER IF EXISTS dependency_path_after_trg ON artemisdb_dependency;
+CREATE TRIGGER dependency_path_after_trg
+    AFTER UPDATE ON artemisdb_dependency
+    FOR EACH ROW
+    WHEN (NEW.path IS DISTINCT FROM OLD.path)
+    EXECUTE PROCEDURE _update_descendants_dependency_path();
+"""
+        )
+    ]


### PR DESCRIPTION
## Description

Modifies the `dependency_path_after_trg` trigger to avoid `IS DISTINCT FROM`, which is problematic when using pg_restore.

## Motivation and Context

When using pg_dump and pg_restore to migrate the database (e.g. between major PostgreSQL versions), pg_restore will error out with:

```
pg_restore: error: could not execute query: ERROR:  operator does not exist: public.ltree = public.ltree
LINE 1: ...isdb_dependency" FOR EACH ROW WHEN (("new"."path" IS DISTINC...
                                                             ^
HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
Command was: CREATE TRIGGER "dependency_path_after_trg" AFTER UPDATE ON "public"."artemisdb_dependency" FOR EACH ROW WHEN (("new"."path" IS DISTINCT FROM "old"."path")) EXECUTE PROCEDURE "public"."_update_descendants_dependency_path"();
```

This fix implements the suggestion offered [here](https://www.postgresql.org/message-id/CAKFQuwZsArqyJbcL5%2BH56hAV9nhHNxV2vFVeWq9H2NmVxq2XJQ%40mail.gmail.com) using `OPERATOR` directly.

## How Has This Been Tested?

On my local machine, performed a schema-only migration between PostgreSQL 11.21 and 16.2, which now succeeds.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
