### PR TITLE
Update the parameter group based on major version

### DIFF
--- a/backend/terraform/modules/analyzer/db.tf
+++ b/backend/terraform/modules/analyzer/db.tf
@@ -52,11 +52,15 @@ locals {
 resource "aws_db_parameter_group" "db_parameter_group" {
   name   = "${var.app}-db-parameter-group"
   family = local.parameter_group_family
+
+  tags = var.tags
 }
 
 resource "aws_rds_cluster_parameter_group" "cluster_parameter_group" {
   name   = "${var.app}-cluster-parameter-group"
   family = local.parameter_group_family
+
+  tags = var.tags
 }
 
 resource "aws_security_group" "db" {

--- a/backend/terraform/modules/analyzer/db.tf
+++ b/backend/terraform/modules/analyzer/db.tf
@@ -40,14 +40,23 @@ module "aurora" {
   )
 }
 
+locals {
+  # If the parameter_group_family hasn't been set, use the default based
+  # on the database engine major version.
+  engine_major_version = split(".", var.db_engine_version)[0]
+  parameter_group_family = var.db_parameter_group_family == null ? (
+    "aurora-postgresql${local.engine_major_version}"
+  ) : var.db_parameter_group_family
+}
+
 resource "aws_db_parameter_group" "db_parameter_group" {
   name   = "${var.app}-db-parameter-group"
-  family = "aurora-postgresql11"
+  family = local.parameter_group_family
 }
 
 resource "aws_rds_cluster_parameter_group" "cluster_parameter_group" {
   name   = "${var.app}-cluster-parameter-group"
-  family = "aurora-postgresql11"
+  family = local.parameter_group_family
 }
 
 resource "aws_security_group" "db" {

--- a/backend/terraform/modules/analyzer/variables.tf
+++ b/backend/terraform/modules/analyzer/variables.tf
@@ -68,6 +68,12 @@ variable "db_engine_version" {
   default     = "11"
 }
 
+variable "db_parameter_group_family" {
+  description = "RDS database parameter group family"
+  type        = string
+  default     = null
+}
+
 variable "ui_origin_url" {
   description = "Origin URL for the UI"
 }


### PR DESCRIPTION
## Description

This makes the database parameter group family configurable, and sets a reasonable default if not specified.

Additionally, tags are now propagated to the database parameter group resources.

## Motivation and Context

This fixes the case where the `db_engine_version` is set to something other than "11".

This is the last part necessary to support specifying a database engine version other than 11.

## How Has This Been Tested?

Tested by deploying with `db_engine_version` set to 16.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
