### PR TITLE
Trivy- Replacing application component path

### DIFF
--- a/backend/engine/plugins/trivy_sbom/main.py
+++ b/backend/engine/plugins/trivy_sbom/main.py
@@ -7,6 +7,7 @@ from engine.plugins.lib.trivy_common.generate_locks import check_package_files
 from engine.plugins.lib.sbom_common.go_installer import go_mod_download
 from engine.plugins.lib.sbom_common.yarn_installer import yarn_install
 from engine.plugins.trivy_sbom.parser import clean_output_application_sbom
+from engine.plugins.trivy_sbom.parser import edit_application_sbom_path
 from engine.plugins.lib.utils import convert_string_to_json
 from engine.plugins.lib.utils import setup_logging
 from engine.plugins.lib.utils import parse_args
@@ -50,7 +51,6 @@ def execute_trivy_image_sbom(image: str):
 def process_docker_images(images: list):
     """
     Pulls a list of image information, scans the successful ones, and returns the outputs.
-    example list item:
     """
     outputs = []
     parsed = []
@@ -88,6 +88,7 @@ def main():
     logger.info("Executing Trivy SBOM")
     args = parse_args()
     include_dev = args.engine_vars.get("include_dev", False)
+    repo = args.engine_vars.get("repo")
     results = []
     parsed = []
     alerts = []
@@ -109,7 +110,7 @@ def main():
     errors.extend(go_mod_errors)
 
     # Scan local lock files
-    application_sbom_output = convert_string_to_json(execute_trivy_application_sbom(args.path, include_dev), logger)
+    application_sbom_output = edit_application_sbom_path(repo, convert_string_to_json(execute_trivy_application_sbom(args.path, include_dev), logger))
     application_sbom_output_parsed = clean_output_application_sbom(application_sbom_output)
     logger.debug(application_sbom_output)
     if not application_sbom_output:

--- a/backend/engine/plugins/trivy_sbom/main.py
+++ b/backend/engine/plugins/trivy_sbom/main.py
@@ -110,7 +110,9 @@ def main():
     errors.extend(go_mod_errors)
 
     # Scan local lock files
-    application_sbom_output = edit_application_sbom_path(repo, convert_string_to_json(execute_trivy_application_sbom(args.path, include_dev), logger))
+    application_sbom_output = edit_application_sbom_path(
+        repo, convert_string_to_json(execute_trivy_application_sbom(args.path, include_dev), logger)
+    )
     application_sbom_output_parsed = clean_output_application_sbom(application_sbom_output)
     logger.debug(application_sbom_output)
     if not application_sbom_output:

--- a/backend/engine/plugins/trivy_sbom/parser.py
+++ b/backend/engine/plugins/trivy_sbom/parser.py
@@ -6,6 +6,7 @@ from engine.plugins.lib.trivy_common.parsing_util import convert_type
 
 logger = setup_logging("trivy_sbom")
 
+
 # Gets the scan and formats it to work with the processor
 def clean_output_application_sbom(output: list) -> list:
     results = []
@@ -33,6 +34,7 @@ def clean_output_application_sbom(output: list) -> list:
                 break
         results.append({"bom-ref": bom_ref, "name": name, "version": version, "licenses": licenses, "type": type})
     return results
+
 
 # Updates the path to be relative to the repo instead of relative to artemis
 def edit_application_sbom_path(repo: str, application_sbom_output: dict):

--- a/backend/engine/plugins/trivy_sbom/parser.py
+++ b/backend/engine/plugins/trivy_sbom/parser.py
@@ -33,3 +33,9 @@ def clean_output_application_sbom(output: list) -> list:
                 break
         results.append({"bom-ref": bom_ref, "name": name, "version": version, "licenses": licenses, "type": type})
     return results
+
+# Updates the path to be relative to the repo instead of relative to artemis
+def edit_application_sbom_path(repo: str, application_sbom_output: dict):
+    if application_sbom_output and application_sbom_output.get("metadata").get("component").get("name"):
+        application_sbom_output["metadata"]["component"]["name"] = repo
+    return application_sbom_output


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
For our image sbom scans we have the metadata component name as org/repo, but for our application level SBOM scans we displayed the artemis container path. I fixed this bug by replacing it with org/repo as we have it on image scanning.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The resulting cycloneDX should not have artemis specific details incase it wants to be digested by other tools
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran and built locally and tested in a dev environment
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Pic
![Embed something funny here](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdHozZnVjcnU5d3p4OXZlbzYxZm95emh0a3l2ZTRsbHA3MjBiNjVteiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/xUPGcM9CazM9H5KrEA/giphy.gif)