### PR TITLE
remove check for advanced security for public repos

### DIFF
--- a/backend/engine/plugins/ghas_secrets/main.py
+++ b/backend/engine/plugins/ghas_secrets/main.py
@@ -48,9 +48,7 @@ def main():
 
 def _ghas_secrets_enabled(gh: GitHubAPI) -> bool:
     resp = gh.get_repo()
-    return (
-        resp.get("security_and_analysis", {}).get("secret_scanning", {}).get("status") == "enabled"
-    )
+    return resp.get("security_and_analysis", {}).get("secret_scanning", {}).get("status") == "enabled"
 
 
 def _ghas_secrets(gh: GitHubAPI, path: str) -> Tuple[list[dict], dict]:

--- a/backend/engine/plugins/ghas_secrets/main.py
+++ b/backend/engine/plugins/ghas_secrets/main.py
@@ -49,8 +49,7 @@ def main():
 def _ghas_secrets_enabled(gh: GitHubAPI) -> bool:
     resp = gh.get_repo()
     return (
-        resp.get("security_and_analysis", {}).get("advanced_security", {}).get("status") == "enabled"
-        and resp.get("security_and_analysis", {}).get("secret_scanning", {}).get("status") == "enabled"
+        resp.get("security_and_analysis", {}).get("secret_scanning", {}).get("status") == "enabled"
     )
 
 


### PR DESCRIPTION
## Description
GitHub doesn't support a check for advanced security on public repos, since they are enabled by default.

## How Has This Been Tested?
This was tested on nonprod

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Pic
![Embed something funny here](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExMThydDl0djF0bDN4bGxkYmV5cDl6OXdlMmVzem16Y2praGFwM3B6cyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/82rEYzUgZbgQM/giphy.gif)