### PR TITLE
Enable specifying the allowed metadata schemes

### DIFF
--- a/backend/engine/metadata/metadata.py
+++ b/backend/engine/metadata/metadata.py
@@ -2,17 +2,20 @@ from typing import Tuple
 
 from metadata.util import is_name_in_patterns, load_schemes
 
-schemes = load_schemes()
+default_schemes = load_schemes()
 
 
-def get_all_metadata(app_metadata_settings, service, repo, working_dir) -> Tuple[dict, dict]:
+def get_all_metadata(app_metadata_settings, service, repo, working_dir, schemes: dict = None) -> Tuple[dict, dict]:
     """Get the metadata for all supported schemes
+
+    The available schemes are expected to have been loaded via load_schemes().
+    If omitted, then the default schemes loaded from the system configuration will be used.
 
     returns (metadata, timestamps)
     """
     result = {}
     timestamps = {}
-    for scheme in schemes:
+    for scheme in (schemes if schemes != None else default_schemes):
         if scheme in app_metadata_settings:
             metadata = app_metadata_settings[scheme]
             if is_name_in_patterns(repo, metadata["include"]) and not is_name_in_patterns(repo, metadata["exclude"]):

--- a/backend/engine/metadata/metadata.py
+++ b/backend/engine/metadata/metadata.py
@@ -15,7 +15,7 @@ def get_all_metadata(app_metadata_settings, service, repo, working_dir, schemes:
     """
     result = {}
     timestamps = {}
-    for scheme in (schemes if schemes != None else default_schemes):
+    for scheme in schemes if schemes != None else default_schemes:
         if scheme in app_metadata_settings:
             metadata = app_metadata_settings[scheme]
             if is_name_in_patterns(repo, metadata["include"]) and not is_name_in_patterns(repo, metadata["exclude"]):

--- a/backend/engine/metadata/util.py
+++ b/backend/engine/metadata/util.py
@@ -14,7 +14,7 @@ def is_name_in_patterns(name, patterns: list) -> bool:
     return False
 
 
-def load_schemes(scheme_modules: list[str]=None) -> dict:
+def load_schemes(scheme_modules: list[str] = None) -> dict:
     """
     Load the metadata processing plugin modules and populate the schemes dictionary.
 
@@ -75,7 +75,7 @@ def load_schemes(scheme_modules: list[str]=None) -> dict:
     # It is required that each module has a SCHEME_NAME string and a method called get_metadata to
     # facilitate building of the schemes mapping dictionary.
     schemes = {}
-    for module in (scheme_modules if scheme_modules != None else METADATA_SCHEME_MODULES):
+    for module in scheme_modules if scheme_modules != None else METADATA_SCHEME_MODULES:
         try:
             m = importlib.import_module(module)
             schemes[m.SCHEME_NAME] = m.get_metadata

--- a/backend/engine/metadata/util.py
+++ b/backend/engine/metadata/util.py
@@ -14,9 +14,13 @@ def is_name_in_patterns(name, patterns: list) -> bool:
     return False
 
 
-def load_schemes() -> dict:
+def load_schemes(scheme_modules: list[str]=None) -> dict:
     """
-    Load the metadata processing plugin modules and populate the schemes dictionary
+    Load the metadata processing plugin modules and populate the schemes dictionary.
+
+    If the list scheme modules is omitted, then the list will be loaded from the global configuration.
+
+    Any modules that fail to load are skipped.
     """
     # The schemes dictionary takes the following format:
     #
@@ -71,7 +75,7 @@ def load_schemes() -> dict:
     # It is required that each module has a SCHEME_NAME string and a method called get_metadata to
     # facilitate building of the schemes mapping dictionary.
     schemes = {}
-    for module in METADATA_SCHEME_MODULES:
+    for module in (scheme_modules if scheme_modules != None else METADATA_SCHEME_MODULES):
         try:
             m = importlib.import_module(module)
             schemes[m.SCHEME_NAME] = m.get_metadata


### PR DESCRIPTION
This enables unit tests to directly provide the allowed metadata schemes on a per-test basis, without relying on or modifying the global configuration.

## Description

`metadata.get_all_metadata()` now takes an optional loaded metadata schemes argument, which is in turn generated by the calling `metadata.load_schemes()` with the optional list of plugins to load.

## Motivation and Context

When developing custom metadata scheme plugins, we want the unit tests to limit the schemes to only our plugin so that other plugins (which might be loaded from the global configuration) won't interfere.

## How Has This Been Tested?

Modified unit tests in a custom plugin to use this facility rather than setting environment variables (which affect all tests, not just for the plugin).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
