### PR TITLE
Fix subscript error when using default schemes.

### DIFF
--- a/backend/engine/metadata/metadata.py
+++ b/backend/engine/metadata/metadata.py
@@ -15,7 +15,9 @@ def get_all_metadata(app_metadata_settings, service, repo, working_dir, schemes:
     """
     result = {}
     timestamps = {}
-    for scheme in schemes if schemes != None else default_schemes:
+    if schemes == None:
+        schemes = default_schemes
+    for scheme in schemes:
         if scheme in app_metadata_settings:
             metadata = app_metadata_settings[scheme]
             if is_name_in_patterns(repo, metadata["include"]) and not is_name_in_patterns(repo, metadata["exclude"]):


### PR DESCRIPTION
## Description

This fixes an issue that was introduced in https://github.com/WarnerMedia/artemis/pull/125.  When the schemes is not specified (i.e. fallback to the default schemes loaded from global config), the function would fail with:

```
TypeError: 'NoneType' object is not subscriptable
```

## Motivation and Context

Fixes scans not starting.

## How Has This Been Tested?

Tested in nonprod environment.

Note: We currently do not have good test coverage for this function.  We will add unit tests later, this PR is to fix the issue first.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
