### PR TITLE
Improve unit test coverage and isolation

### DIFF
--- a/backend/engine/tests/test_metadata.py
+++ b/backend/engine/tests/test_metadata.py
@@ -3,7 +3,7 @@ import unittest
 from unittest.mock import MagicMock, patch
 from copy import deepcopy
 
-from metadata import metadata
+from metadata import metadata, util
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 TEST_REPO = "WarnerMedia/artemis"
@@ -56,3 +56,14 @@ class TestMetadata(unittest.TestCase):
         plugin.assert_not_called()
         self.assertEqual(result, {})
         self.assertEqual(timestamps, {})
+
+    @patch.object(util, "METADATA_SCHEME_MODULES", ["xx_fake_metadata_plugin"])
+    def test_load_schemes_default_invalid(self):
+        with self.assertLogs("metadata.util", "ERROR") as lc:
+            actual = metadata.load_schemes()
+            self.assertEqual(actual, {})  # No valid modules.
+            self.assertEqual(len(lc.output), 1)
+            self.assertIn(
+                "Unable to load metadata processing module xx_fake_metadata_plugin",
+                lc.output[0],
+            )

--- a/backend/engine/tests/test_metadata.py
+++ b/backend/engine/tests/test_metadata.py
@@ -1,0 +1,58 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+from copy import deepcopy
+
+from metadata import metadata
+
+TEST_DIR = os.path.dirname(os.path.abspath(__file__))
+TEST_REPO = "WarnerMedia/artemis"
+TEST_SERVICE = "test_service"
+TEST_APP_METADATA = {"test_metadata": {"include": ["*"], "exclude": []}}
+
+
+class TestMetadata(unittest.TestCase):
+    def test_get_all_metadata_default_schemes_empty(self):
+        with patch.object(metadata, "default_schemes", {}):
+            result, timestamps = metadata.get_all_metadata(TEST_APP_METADATA, TEST_SERVICE, TEST_REPO, TEST_DIR)
+            self.assertEqual(result, {})
+            self.assertEqual(timestamps, {})
+
+    def test_get_all_metadata_default_schemes_loaded(self):
+        plugin = MagicMock(return_value=({"foo": 1}, 12345))
+        schemes = {"test_metadata": plugin}
+        with patch.object(metadata, "default_schemes", schemes):
+            result, timestamps = metadata.get_all_metadata(TEST_APP_METADATA, TEST_SERVICE, TEST_REPO, TEST_DIR)
+            plugin.assert_called_with(TEST_SERVICE, TEST_REPO, TEST_DIR)
+            self.assertEqual(result, {"test_metadata": {"foo": 1}})
+            self.assertEqual(timestamps, {"test_metadata": 12345})
+
+    def test_get_all_metadata_specified_schemes(self):
+        plugin = MagicMock(return_value=({"bar": 2}, 67890))
+        schemes = {"test_metadata": plugin}
+        result, timestamps = metadata.get_all_metadata(TEST_APP_METADATA, TEST_SERVICE, TEST_REPO, TEST_DIR, schemes)
+        plugin.assert_called_with(TEST_SERVICE, TEST_REPO, TEST_DIR)
+        self.assertEqual(result, {"test_metadata": {"bar": 2}})
+        self.assertEqual(timestamps, {"test_metadata": 67890})
+
+    # Note: The "included" case is covered by above, so we only check the "excluded" cases.
+
+    def test_get_all_metadata_settings_excluded(self):
+        plugin = MagicMock(return_value=({"baz": 3}, 13579))
+        schemes = {"test_metadata": plugin}
+        app_metadata_excluded = deepcopy(TEST_APP_METADATA)
+        app_metadata_excluded["test_metadata"]["exclude"] = ["WarnerMedia/*"]
+        result, timestamps = metadata.get_all_metadata(
+            app_metadata_excluded, TEST_SERVICE, TEST_REPO, TEST_DIR, schemes
+        )
+        plugin.assert_not_called()
+        self.assertEqual(result, {})
+        self.assertEqual(timestamps, {})
+
+    def test_get_all_metadata_settings_blank(self):
+        plugin = MagicMock(return_value=({"baz": 3}, 13579))
+        schemes = {"test_metadata": plugin}
+        result, timestamps = metadata.get_all_metadata({}, TEST_SERVICE, TEST_REPO, TEST_DIR, schemes)
+        plugin.assert_not_called()
+        self.assertEqual(result, {})
+        self.assertEqual(timestamps, {})

--- a/backend/lambdas/api/authorizer/tests/test_get_user.py
+++ b/backend/lambdas/api/authorizer/tests/test_get_user.py
@@ -147,6 +147,7 @@ class MockUser(object):
 _get_update_or_create_user = authorizer.handlers._get_update_or_create_user.__wrapped__
 
 
+@patch("authorizer.handlers.AuditLogger.__init__", lambda *x, **y: None)
 @patch("authorizer.handlers.AuditLogger.group_created", lambda *x, **y: None)
 @patch("authorizer.handlers.AuditLogger.group_modified", lambda *x, **y: None)
 @patch("authorizer.handlers.AuditLogger.user_created", lambda *x, **y: None)

--- a/backend/lambdas/api/groups/tests/test_groups_delete.py
+++ b/backend/lambdas/api/groups/tests/test_groups_delete.py
@@ -10,6 +10,7 @@ GROUP_ID = "87879daa-e6cb-4bf9-8575-649b00aff132"
 UNPARSED_EVENT_ID = {"pathParameters": {"id": GROUP_ID}}
 
 
+@patch("authorizer.handlers.AuditLogger.__init__", lambda *x, **y: None)
 class TestGroupsDelete(unittest.TestCase):
     @patch.object(groups_delete, "GroupsDBHelper")
     def test_delete_group_success_admin(self, db_caller):

--- a/backend/lambdas/api/groups/tests/test_groups_post.py
+++ b/backend/lambdas/api/groups/tests/test_groups_post.py
@@ -9,6 +9,8 @@ from tests.stubs.mock_group import MockGroup
 from tests.stubs.parsed_event import ParsedEventStub
 
 
+@patch("authorizer.handlers.AuditLogger.__init__", lambda *x, **y: None)
+@patch("authorizer.handlers.AuditLogger.group_modified", lambda *x, **y: None)
 class TestGroupsPost(unittest.TestCase):
     @patch.object(groups_post, "GroupsDBHelper")
     def test_post_group_with_parent(self, db_caller):

--- a/backend/lambdas/api/groups/tests/test_groups_put.py
+++ b/backend/lambdas/api/groups/tests/test_groups_put.py
@@ -28,6 +28,8 @@ GROUP_RECORD = {
 GROUP_1 = Group(group_id=1, name="test", description="test group", created_by=None, scope=["*"], features={})
 
 
+@patch("authorizer.handlers.AuditLogger.__init__", lambda *x, **y: None)
+@patch("authorizer.handlers.AuditLogger.group_modified", lambda *x, **y: None)
 class TestGroupsPut(unittest.TestCase):
     def test_non_group_admin(self):
         with patch("artemisdb.artemisdb.models.GroupMembership.objects.get") as mock_get_group_membership:

--- a/backend/lambdas/api/groups_keys/tests/test_groups_keys_delete.py
+++ b/backend/lambdas/api/groups_keys/tests/test_groups_keys_delete.py
@@ -15,6 +15,7 @@ GROUP_AUTH_GROUP_ADMIN = {GROUP_ID: True}
 GROUP_AUTH_NON_GROUP_ADMIN = {GROUP_ID: False}
 
 
+@patch("authorizer.handlers.AuditLogger.__init__", lambda *x, **y: None)
 class TestGroupsKeysDelete(unittest.TestCase):
     def test_key_id_not_provided(self):
         event = {"pathParameters": {"id": GROUP_ID}}

--- a/backend/lambdas/api/groups_keys/tests/test_groups_keys_post.py
+++ b/backend/lambdas/api/groups_keys/tests/test_groups_keys_post.py
@@ -19,6 +19,7 @@ GROUP_AUTH_GROUP_ADMIN = {GROUP_ID: True}
 GROUP_AUTH_NON_GROUP_ADMIN = {GROUP_ID: False}
 
 
+@patch("authorizer.handlers.AuditLogger.__init__", lambda *x, **y: None)
 class TestGroupsKeysPost(unittest.TestCase):
     def test_key_id_provided(self):
         event = {

--- a/backend/lambdas/api/groups_members/tests/test_groups_members_delete.py
+++ b/backend/lambdas/api/groups_members/tests/test_groups_members_delete.py
@@ -23,6 +23,8 @@ GROUP_AUTH_GROUP_ADMIN = {GROUP_ID: True}
 GROUP_AUTH_NON_GROUP_ADMIN = {GROUP_ID: False}
 
 
+@patch("authorizer.handlers.AuditLogger.__init__", lambda *x, **y: None)
+@patch("authorizer.handlers.AuditLogger.group_member_removed", lambda *x, **y: None)
 class TestGroupsMembersDelete(unittest.TestCase):
     def test_only_admins_can_delete(self):
         with patch("artemisdb.artemisdb.models.GroupMembership.objects.get") as mock_get_group_membership, patch(

--- a/backend/lambdas/api/groups_members/tests/test_groups_members_post.py
+++ b/backend/lambdas/api/groups_members/tests/test_groups_members_post.py
@@ -22,6 +22,8 @@ GROUP_AUTH_GROUP_ADMIN = {GROUP_ID: True}
 GROUP_AUTH_NON_GROUP_ADMIN = {GROUP_ID: False}
 
 
+@patch("authorizer.handlers.AuditLogger.__init__", lambda *x, **y: None)
+@patch("authorizer.handlers.AuditLogger.group_member_added", lambda *x, **y: None)
 class TestGroupsMembersPost(unittest.TestCase):
     def test_non_group_admin(self):
         event = {"pathParameters": {"id": GROUP_ID, "uid": EMAIL2}, "body": json.dumps({"group_admin": False})}

--- a/backend/lambdas/api/groups_members/tests/test_groups_members_put.py
+++ b/backend/lambdas/api/groups_members/tests/test_groups_members_put.py
@@ -22,6 +22,8 @@ GROUP_AUTH_GROUP_ADMIN = {GROUP_ID: True}
 GROUP_AUTH_NON_GROUP_ADMIN = {GROUP_ID: False}
 
 
+@patch("authorizer.handlers.AuditLogger.__init__", lambda *x, **y: None)
+@patch("authorizer.handlers.AuditLogger.group_member_modified", lambda *x, **y: None)
 class TestGroupsMembersPut(unittest.TestCase):
     def test_non_group_admin(self):
         event = {"pathParameters": {"id": GROUP_ID, "uid": EMAIL2}, "body": json.dumps({"group_admin": False})}

--- a/backend/lambdas/api/users/tests/test_put.py
+++ b/backend/lambdas/api/users/tests/test_put.py
@@ -20,6 +20,8 @@ USER_RECORD = {
 }
 
 
+@patch("authorizer.handlers.AuditLogger.__init__", lambda *x, **y: None)
+@patch("authorizer.handlers.AuditLogger.user_modified", lambda *x, **y: None)
 class TestPut(unittest.TestCase):
     def test_nonadmin(self):
         event = {"pathParameters": {"id": EMAIL}}

--- a/backend/lambdas/api/users_services/tests/test_users_services_post.py
+++ b/backend/lambdas/api/users_services/tests/test_users_services_post.py
@@ -1,7 +1,7 @@
 import json
 import unittest
 from copy import deepcopy
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from artemislib.datetime import format_timestamp, get_utc_datetime
 from users_services.handlers import handler
@@ -62,8 +62,8 @@ def _add_user_service(user_services, admin: bool, params: dict):
     }
 
     with patch("users_services.post.get_github_username") as mock_get_github_username, patch(
-        "users_services.post.AWSConnect.invoke_lambda"
-    ) as mock_invoke_lambda, patch("artemisdb.artemisdb.models.User.objects.get") as mock_get_user:
+        "users_services.post.AWSConnect"
+    ) as mock_aws_connect, patch("artemisdb.artemisdb.models.User.objects.get") as mock_get_user:
 
         get_obj = deepcopy(EMPTY_OBJECT)
         get_obj.userservice_set = deepcopy(EMPTY_OBJECT)
@@ -72,8 +72,11 @@ def _add_user_service(user_services, admin: bool, params: dict):
             "", (), {"service": x["service"], "username": x["username"], "created": TIMESTAMP}
         )()
 
+        mock_aws_connect_inst = MagicMock()
+        mock_aws_connect_inst.invoke_lambda.return_value = None
+        mock_aws_connect.return_value = mock_aws_connect_inst
+
         mock_get_github_username.return_value = SERVICE_USERNAME
-        mock_invoke_lambda.return_value = None
         mock_get_user.return_value = get_obj
 
         return handler(event, {})

--- a/backend/lambdas/events/event_dispatch/tests/test_sm_process.py
+++ b/backend/lambdas/events/event_dispatch/tests/test_sm_process.py
@@ -4,7 +4,7 @@ import botocore.exceptions
 
 try:
     from event_dispatch.event_dispatch import determine_secrets_management_processes
-except (botocore.exceptions.ClientError, botocore.exceptions.NoCredentialsError):
+except (botocore.exceptions.ClientError, botocore.exceptions.NoCredentialsError, botocore.exceptions.ProfileNotFound):
     raise unittest.SkipTest("Unit Test requires AWS Credentials to run. Skipping.")
 
 SERVICES = {


### PR DESCRIPTION
## Description

* Better isolation for tests that invoke AWS services as a side-effect by patching-out AuditLogger and AWSConnect as necessary.
* Adds unit tests for the metadata module, which was previously modified to better support unit tests for external metadata plugins.

## Motivation and Context

A number of unit tests are affected by global configuration (e.g. the AWS profile), which can cause tests to fail in one environment but succeed in other.

This attempts to avoid such situations by patching-out the bits that depend on global configuration, particularly AWS configuration.

## How Has This Been Tested?

This only touches the unit tests, so tested in separate local dev environments with separate configurations (setting the `AWS_PROFILE` environment variable to a fake value was particularly fruitful).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
