### PR TITLE
Split format checks into separate "style-test"

### DIFF
--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -16,6 +16,8 @@ jobs:
       - name: Install Test Dependencies
         run: |
           pip install --upgrade pipenv wheel
+      - name: Run code style tests
+        run: make -C backend style-test ENV=example
       - name: Run backend tests
         env:
           ANALYZER_DJANGO_SECRET_KEY: ${{ secrets.TEST_DJANGO_SECRET_KEY }}

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -326,16 +326,16 @@ end2end-test: test-deps
 	$(call run-pytest,end to end tests,-m "end2end")
 .PHONY: end2end-test
 
-test: test-deps format-test
+test: test-deps style-test
 	$(call run-pytest,all tests)
 .PHONY: test
 
-format-test:
-	@echo "${INFO}Running format checks"
+style-test:
+	@echo "${INFO}Running code style checks"
 	${PYTHON} -m pipenv install --dev
 	${PYTHON} -m pipenv run black --check .
 	@echo "${OK}"
-.PHONY: format-test
+.PHONY: style-test
 
 lint_api_spec:
 	@echo "${INFO}Linting API spec"

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -326,9 +326,16 @@ end2end-test: test-deps
 	$(call run-pytest,end to end tests,-m "end2end")
 .PHONY: end2end-test
 
-test: test-deps
+test: test-deps format-test
 	$(call run-pytest,all tests)
 .PHONY: test
+
+format-test:
+	@echo "${INFO}Running format checks"
+	${PYTHON} -m pipenv install --dev
+	${PYTHON} -m pipenv run black --check .
+	@echo "${OK}"
+.PHONY: format-test
 
 lint_api_spec:
 	@echo "${INFO}Linting API spec"

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --black --cov=. --cov-report html --cov-report term-missing -rsx -vv --disable-pytest-warnings
+addopts = --cov=. --cov-report html --cov-report term-missing -rsx -vv --disable-pytest-warnings
 norecursedirs = .venv/* build/* venv/*
 pep8maxlinelength = 120
 # pep8ignore = ALL


### PR DESCRIPTION
Significantly speed up unit tests by splitting out the Black style checks into a separate test.

## Description

This significantly speeds up the backend unit tests:

```text
CI Before:  5m 35s
CI After:   2m 9s
```

* In local development, we assume that most folks will have the editor-of-choice run the formatter (i.e. Black) on save already.
* In CI where we can't rely on the pytest cache, running Black on all files at once is much faster than pytest-black since it can parallelize the checks -- pytest-black starts a new child process of Black for each individual file, which is very slow.

The `make test` target, being the "test everything" target, now includes running `style-test`.

## Motivation and Context

Running the backend unit tests was particularly slow due to the way pytest-black works -- it spawns a new Black subprocess for every file, so Black can't take advantage of parallelization.

This only updates the backend tests for now, since they are the slowest to run.

## How Has This Been Tested?

Ran tests locally and in CI.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
