### PR TITLE
Orchestrator integration test fixes

### DIFF
--- a/orchestrator/Makefile
+++ b/orchestrator/Makefile
@@ -102,7 +102,7 @@ integration-test: venv ## Run integration tests
 	export PYTHONPATH=${PYTHONPATH}:${TEST_DIRS}; \
 	${PYTHON} -m pipenv check; \
 	${PYTHON} -m pipenv install --dev; \
-	${PYTHON} -m pipenv run pytest -c "pytest.ini" -m "integtest" --no-pylint ${PYTEST_EXTRA_ARGS};
+	${PYTHON} -m pipenv run pytest -c "pytest.ini" -m "integtest" ${PYTEST_EXTRA_ARGS};
 
 test: unit-test \
 	  integration-test

--- a/orchestrator/Makefile
+++ b/orchestrator/Makefile
@@ -97,6 +97,7 @@ unit-test: venv ## Run unit tests
 
 integration-test: venv ## Run integration tests
 	export ARTEMIS_S3_BUCKET=${ARTEMIS_S3_BUCKET};\
+	export ARTEMIS_API=${ARTEMIS_API}; \
 	export SCAN_TABLE=$(shell terraform -chdir=${TERRAFORM}/environments/${ENV} output repo-scan-table-name); \
 	export PYTHONPATH=${PYTHONPATH}:${TEST_DIRS}; \
 	${PYTHON} -m pipenv check; \

--- a/orchestrator/lambdas/tests/data/services_integration.json
+++ b/orchestrator/lambdas/tests/data/services_integration.json
@@ -59,6 +59,20 @@
       "initial_page": {
         "cursor": "null"
       }
+    },
+    "git.example.com": {
+      "secret_loc": "example-api-key",
+      "type": "gitlab",
+      "hostname": null,
+      "url": "https://git.example.com/api/graphql",
+      "branch_url": "https://git.example.com/api/v4",
+      "allow_all": true,
+      "api_key_add": "oauth2:$key",
+      "use_deploy_key": false,
+      "batch_queries": true,
+      "initial_page": {
+        "cursor": "null"
+      }
     }
   },
   "repos": [

--- a/orchestrator/lambdas/tests/test_get_services_integration.py
+++ b/orchestrator/lambdas/tests/test_get_services_integration.py
@@ -8,13 +8,12 @@ from heimdall_utils import get_services
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 SERVICES_LOC = os.path.abspath(os.path.join(TEST_DIR, "data", "services.json"))
 SERVICE_KEYS = ["services", "repos", "scan_orgs", "external_orgs"]
-SERVICE_SERVICES = ["github", "gitlab", "bitbucket", "git.example.com"]
+SERVICE_SERVICES = ["azure", "github", "gitlab", "bitbucket", "git.example.com"]
 
 
-@pytest.mark.integtest
 class TestServices(unittest.TestCase):
     def setUp(self) -> None:
-        self.full_services_dict = get_services.get_services_dict("services.json")
+        self.full_services_dict = get_services.get_services_dict(SERVICES_LOC)
 
     def test_verify_json_keys(self):
         service_keys = self.full_services_dict.keys()


### PR DESCRIPTION
Work-in-progress minor fixes towards fixing the orchestrator integration tests.

## Description

* Updates the `services_integration.json` to include the "git.example.com" service which is referenced in the tests.
* Converts test_get_services_integration into a unit test.  To test the S3 integration in the future, we will use an S3 mock.
* Fixes a couple breaking issues when invoking the test via `make integration-test`.

## Motivation and Context

The orchestrator integration tests have been broken for some time; this PR is a step towards fixing them overall.

## How Has This Been Tested?

Tested in local dev environment (note: integration tests still fail, but get further now).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
