### PR TITLE
Only show secrets from code in Artemis

### DIFF
--- a/backend/engine/plugins/ghas_secrets/main.py
+++ b/backend/engine/plugins/ghas_secrets/main.py
@@ -111,6 +111,9 @@ def _validate_location(location: dict, path: str) -> Tuple[bool, str, str]:
     valid = False
     author = None
     author_timestamp = None
+    if location["type"] != "commit":
+        LOG.debug("Location is not a commit, ignoring")
+        return valid, author, author_timestamp
 
     r = subprocess.run(
         ["git", "merge-base", "--is-ancestor", location["details"]["commit_sha"], "HEAD"], cwd=path, capture_output=True


### PR DESCRIPTION
## Description
Github secret scanning has started to include scanning for pull requests and wiki pages. This is causing an error, so we're ignoring those.

## How Has This Been Tested?
Tested locally, error is no longer showing up.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
