### PR TITLE
Replace "pipenv install" with "pipenv sync"

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -286,7 +286,7 @@ define run-pytest
 	@echo "${INFO}Running $1"
 	export PATH='${ROOT_DIR}/.temp/shellcheck:${ROOT_DIR}/.temp/detekt:${ROOT_DIR}/.temp/swiftlint:${PATH}:'; \
 	export PIPENV_DONT_LOAD_ENV=1; \
-	${PYTHON} -m pipenv install --dev; \
+	${PYTHON} -m pipenv sync --dev; \
 	${PYTHON} -m pipenv run pytest -c pytest.ini $2 ${PYTEST_EXTRA_ARGS};
 	@echo "${OK}"
 endef
@@ -312,7 +312,7 @@ test: test-deps style-test
 
 style-test:
 	@echo "${INFO}Running code style checks"
-	${PYTHON} -m pipenv install --dev
+	${PYTHON} -m pipenv sync --dev
 	${PYTHON} -m pipenv run black --check .
 	@echo "${OK}"
 .PHONY: style-test

--- a/backend/engine/plugins/github_repo_health/cli/Makefile
+++ b/backend/engine/plugins/github_repo_health/cli/Makefile
@@ -1,10 +1,10 @@
 .PHONY: install install-dev build test format update-requirements
 
 install:
-	@python -m pipenv install
+	@python -m pipenv sync
 
 install-dev:
-	@python -m pipenv install --dev
+	@python -m pipenv sync --dev
 	@pip install --editable .
 
 build:

--- a/orchestrator/Makefile
+++ b/orchestrator/Makefile
@@ -79,7 +79,7 @@ define run-pytest
 	@echo "${INFO}Running $1"
 	export PIPENV_DONT_LOAD_ENV=1; \
 	$2 \
-	${PYTHON} -m pipenv install --dev; \
+	${PYTHON} -m pipenv sync --dev; \
 	${PYTHON} -m pipenv run pytest -c pytest.ini $3 ${PYTEST_EXTRA_ARGS};
 	@echo "${OK}"
 endef
@@ -108,7 +108,7 @@ test: style-test
 
 style-test:
 	@echo "${INFO}Running code style checks"
-	${PYTHON} -m pipenv install --dev
+	${PYTHON} -m pipenv sync --dev
 	${PYTHON} -m pipenv run black --check .
 	@echo "${OK}"
 .PHONY: style-test


### PR DESCRIPTION
## Description

Replaces most uses of `pipenv install` with the safer `pipenv sync`.

We retain the use of `pipenv install` in Dockerfile.engine since we use `--system` there, which is not supported by `pipenv sync` and it doesn't matter if the Pipfiles change during the image build.

## Motivation and Context

`pipenv install` can unexpectedly update the Pipfile and Pipfile.lock files, which in most scenarios is not what we intend.  See the note from the [documentation](https://pipenv.pypa.io/en/latest/commands.html):

> It has been confusing to many users of pipenv that running install will completely relock the lock file.
> ...
> For now, to install lock file versions (without modification of the lock file) use: pipenv sync

## How Has This Been Tested?

Tested locally and via CI.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
