### PR TITLE
Avoid re-downloading external tools used in backend unit tests

### DIFF
--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -15,6 +15,11 @@ jobs:
           python-version: "3.9"
           cache: pipenv
           cache-dependency-path: backend/Pipfile.lock
+      - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # actions/cache@v4.0.2
+        with:
+          # Tool versions are defined in the Makefile.
+          key: backend-unit-test-tools-${{ runner.os }}-${{ hashFiles('backend/Makefile') }}
+          path: backend/.temp
       - name: Install Test Dependencies
         run: |
           pip install --upgrade pipenv wheel

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -260,7 +260,8 @@ get-detekt: $(ROOT_DIR)/.temp/detekt/detekt.jar $(ROOT_DIR)/.temp/detekt/detekt
 
 ${ROOT_DIR}/.temp/shellcheck/shellcheck:
 	mkdir -p ${ROOT_DIR}/.temp/shellcheck
-	wget -q https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECKVER}/shellcheck-v${SHELLCHECKVER}.${OSFLAG}.x86_64.tar.xz -O ${ROOT_DIR}/.temp/shellcheck.tar.xz
+	utilities/shellcheck-release-url.sh ${SHELLCHECKVER} > ${ROOT_DIR}/.temp/shellcheck-release.txt
+	wget -q -i ${ROOT_DIR}/.temp/shellcheck-release.txt -O ${ROOT_DIR}/.temp/shellcheck.tar.xz
 	tar -xJf ${ROOT_DIR}/.temp/shellcheck.tar.xz -C ${ROOT_DIR}/.temp/shellcheck --strip-components=1
 
 get-shell-check: ${ROOT_DIR}/.temp/shellcheck/shellcheck

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -266,9 +266,9 @@ get-shell-check:
 
 # This copies a script which mocks swiftlint for unit tests
 # The script gets renamed from "swiftlint_mock.sh" to simply "swiftlint" to match the real binary name
-$(ROOT_DIR)/.temp/swiftlint/swiftlint:
+$(ROOT_DIR)/.temp/swiftlint/swiftlint: ${ROOT_DIR}/engine/tests/data/swiftlint/swiftlint_mock.sh
 	mkdir -p $(@D)
-	cp ${ROOT_DIR}/engine/tests/data/swiftlint/swiftlint_mock.sh $@
+	cp $< $@
 
 get-mock-swiftlint: $(ROOT_DIR)/.temp/swiftlint/swiftlint
 .PHONY: get-mock-swiftlint

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -251,9 +251,9 @@ $(ROOT_DIR)/.temp/detekt/detekt.jar:
 
 # The detekt wrapper script is renamed from detekt.sh to "detekt"
 # This is for compatability with installations done via a package manager
-$(ROOT_DIR)/.temp/detekt/detekt:
+$(ROOT_DIR)/.temp/detekt/detekt: ${ROOT_DIR}/engine/plugins/detekt/detekt.sh
 	mkdir -p $(@D)
-	cp ${ROOT_DIR}/engine/plugins/detekt/detekt.sh $@
+	cp $< $@
 
 get-detekt: $(ROOT_DIR)/.temp/detekt/detekt.jar $(ROOT_DIR)/.temp/detekt/detekt
 .PHONY: get-detekt

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -245,26 +245,26 @@ help:  ## Print this help text
 # Testing targets
 ###############################################################################
 
-$(ROOT_DIR)/.temp/detekt/detekt.jar:
+$(ROOT_DIR)/.temp/detekt-${DETEKT_VER}/detekt.jar:
 	mkdir -p $(@D)
 	curl -sL "https://github.com/detekt/detekt/releases/download/v${DETEKT_VER}/detekt-cli-${DETEKT_VER}-all.jar" >$@
 
 # The detekt wrapper script is renamed from detekt.sh to "detekt"
 # This is for compatability with installations done via a package manager
-$(ROOT_DIR)/.temp/detekt/detekt: ${ROOT_DIR}/engine/plugins/detekt/detekt.sh
+$(ROOT_DIR)/.temp/detekt-${DETEKT_VER}/detekt: ${ROOT_DIR}/engine/plugins/detekt/detekt.sh
 	mkdir -p $(@D)
 	cp $< $@
 
-get-detekt: $(ROOT_DIR)/.temp/detekt/detekt.jar $(ROOT_DIR)/.temp/detekt/detekt
+get-detekt: $(ROOT_DIR)/.temp/detekt-${DETEKT_VER}/detekt.jar $(ROOT_DIR)/.temp/detekt-${DETEKT_VER}/detekt
 .PHONY: get-detekt
 
-${ROOT_DIR}/.temp/shellcheck/shellcheck:
-	mkdir -p ${ROOT_DIR}/.temp/shellcheck
+${ROOT_DIR}/.temp/shellcheck-${SHELLCHECKVER}/shellcheck:
+	mkdir -p $(@D)
 	utilities/shellcheck-release-url.sh ${SHELLCHECKVER} > ${ROOT_DIR}/.temp/shellcheck-release.txt
-	wget -q -i ${ROOT_DIR}/.temp/shellcheck-release.txt -O ${ROOT_DIR}/.temp/shellcheck.tar.xz
-	tar -xJf ${ROOT_DIR}/.temp/shellcheck.tar.xz -C ${ROOT_DIR}/.temp/shellcheck --strip-components=1
+	wget -q -i ${ROOT_DIR}/.temp/shellcheck-release.txt -O ${ROOT_DIR}/.temp/shellcheck-${SHELLCHECKVER}.tar.xz
+	tar -xJf ${ROOT_DIR}/.temp/shellcheck-${SHELLCHECKVER}.tar.xz -C $(@D) --strip-components=1
 
-get-shell-check: ${ROOT_DIR}/.temp/shellcheck/shellcheck
+get-shell-check: ${ROOT_DIR}/.temp/shellcheck-${SHELLCHECKVER}/shellcheck
 .PHONY: get-shell-check
 
 # This copies a script which mocks swiftlint for unit tests
@@ -276,12 +276,12 @@ $(ROOT_DIR)/.temp/swiftlint/swiftlint: ${ROOT_DIR}/engine/tests/data/swiftlint/s
 get-mock-swiftlint: $(ROOT_DIR)/.temp/swiftlint/swiftlint
 .PHONY: get-mock-swiftlint
 
-${ROOT_DIR}/.temp/trivy:
-	mkdir -p ${ROOT_DIR}/.temp/trivy; \
+${ROOT_DIR}/.temp/trivy-${TRIVY_VER}/trivy:
+	mkdir -p $(@D)
 	wget -O - https://raw.githubusercontent.com/aquasecurity/trivy/${TRIVY_COMMIT}/contrib/install.sh | \
-		sh -s -- -b ${ROOT_DIR}/.temp/trivy ${TRIVY_VER};
+		sh -s -- -b $(@D) ${TRIVY_VER};
 
-get-trivy: ${ROOT_DIR}/.temp/trivy
+get-trivy: ${ROOT_DIR}/.temp/trivy-${TRIVY_VER}/trivy
 .PHONY: get-trivy
 
 install-plugin-dependencies:
@@ -290,7 +290,7 @@ install-plugin-dependencies:
 
 define run-pytest
 	@echo "${INFO}Running $1"
-	export PATH='${ROOT_DIR}/.temp/shellcheck:${ROOT_DIR}/.temp/detekt:${ROOT_DIR}/.temp/swiftlint:${PATH}:'; \
+	export PATH='${ROOT_DIR}/.temp/shellcheck-${SHELLCHECKVER}:${ROOT_DIR}/.temp/detekt-${DETEKT_VER}:${ROOT_DIR}/.temp/swiftlint:${ROOT_DIR}/.temp/trivy-${TRIVY_VER}:${PATH}:'; \
 	export PIPENV_DONT_LOAD_ENV=1; \
 	${PYTHON} -m pipenv sync --dev; \
 	${PYTHON} -m pipenv run pytest -c pytest.ini $2 ${PYTEST_EXTRA_ARGS};

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -258,10 +258,12 @@ $(ROOT_DIR)/.temp/detekt/detekt:
 get-detekt: $(ROOT_DIR)/.temp/detekt/detekt.jar $(ROOT_DIR)/.temp/detekt/detekt
 .PHONY: get-detekt
 
-get-shell-check:
-	mkdir -p ${ROOT_DIR}/.temp/shellcheck; \
-	wget -q https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECKVER}/shellcheck-v${SHELLCHECKVER}.${OSFLAG}.x86_64.tar.xz -O ${ROOT_DIR}/.temp/shellcheck.tar.xz; \
-    tar -xJf ${ROOT_DIR}/.temp/shellcheck.tar.xz -C ${ROOT_DIR}/.temp/shellcheck --strip-components=1;
+${ROOT_DIR}/.temp/shellcheck/shellcheck:
+	mkdir -p ${ROOT_DIR}/.temp/shellcheck
+	wget -q https://github.com/koalaman/shellcheck/releases/download/v${SHELLCHECKVER}/shellcheck-v${SHELLCHECKVER}.${OSFLAG}.x86_64.tar.xz -O ${ROOT_DIR}/.temp/shellcheck.tar.xz
+	tar -xJf ${ROOT_DIR}/.temp/shellcheck.tar.xz -C ${ROOT_DIR}/.temp/shellcheck --strip-components=1
+
+get-shell-check: ${ROOT_DIR}/.temp/shellcheck/shellcheck
 .PHONY: get-shell-check
 
 # This copies a script which mocks swiftlint for unit tests

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -273,10 +273,13 @@ $(ROOT_DIR)/.temp/swiftlint/swiftlint:
 get-mock-swiftlint: $(ROOT_DIR)/.temp/swiftlint/swiftlint
 .PHONY: get-mock-swiftlint
 
-get-trivy:
+${ROOT_DIR}/.temp/trivy:
 	mkdir -p ${ROOT_DIR}/.temp/trivy; \
 	wget -O - https://raw.githubusercontent.com/aquasecurity/trivy/${TRIVY_COMMIT}/contrib/install.sh | \
 		sh -s -- -b ${ROOT_DIR}/.temp/trivy ${TRIVY_VER};
+
+get-trivy: ${ROOT_DIR}/.temp/trivy
+.PHONY: get-trivy
 
 install-plugin-dependencies:
 	@echo "${INFO}Installing plugin dependencies..."

--- a/backend/utilities/shellcheck-release-url.sh
+++ b/backend/utilities/shellcheck-release-url.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Generate the download URL for a ShellCheck release tarball for the specified version.
+# This takes into account the current OS and architecture.
+
+set -o pipefail
+
+readonly version="$1"; shift
+if [[ $version == '' ]]; then
+  echo "Usage: $0 version" >&2
+  exit 1
+fi
+
+platform="$(uname | tr '[:upper:]' '[:lower:]')" || exit 1
+if [[ $platform != 'darwin' && $platform != 'linux' ]]; then
+  echo "Unsupported ShellCheck release platform: $platform" >&2
+  exit 1
+fi
+readonly platform
+
+arch="$(uname -m)" || exit 1
+case "$arch" in
+  aarch64|x86_64) ;;
+  arm64) arch=aarch64 ;;
+  *)
+    echo "Unsupported ShellCheck release architecture: $arch" >&2
+    exit 1
+esac
+readonly arch
+
+echo "https://github.com/koalaman/shellcheck/releases/download/v${version}/shellcheck-v${version}.${platform}.${arch}.tar.xz"


### PR DESCRIPTION
## Description

Speeds up running the backend unit tests by only downloading the tools as necessary.

* External tools are checked if they have been already been downloaded, and if so, they aren't downloaded again.
  * If a tool version number (as defined in the Makefile) changes, then it _will_ trigger a download.
* Fixed ShellCheck download on non-x86_64 platforms.
* Cache the downloaded tools in the GitHub Actions.

## Motivation and Context

The backend unit tests download a few external tools (such as ShellCheck and Trivy) in order to unit test the plugins. Previously, we were re-downloading these tools every time the backend unit tests were run, which 

## How Has This Been Tested?

Tested in local dev environment and in CI.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.