### PR TITLE
Make RDS CA configurable per-environment

### DIFF
--- a/backend/terraform/modules/analyzer/db.tf
+++ b/backend/terraform/modules/analyzer/db.tf
@@ -20,6 +20,7 @@ module "aurora" {
   preferred_maintenance_window    = "Mon:00:00-Mon:03:00"
   preferred_backup_window         = "03:30-06:30"
   deletion_protection             = true
+  ca_cert_identifier              = var.db_ca_cert_identifier
 
   database_name = "analyzer"
   port          = 5432

--- a/backend/terraform/modules/analyzer/variables.tf
+++ b/backend/terraform/modules/analyzer/variables.tf
@@ -74,6 +74,12 @@ variable "db_parameter_group_family" {
   default     = null
 }
 
+variable "db_ca_cert_identifier" {
+  description = "Certificate authority ID"
+  type        = string
+  default     = "rds-ca-2019"
+}
+
 variable "ui_origin_url" {
   description = "Origin URL for the UI"
 }


### PR DESCRIPTION
## Description

Enables each environment to specify the RDS Certificate Authority to use.

The default is set to `rds-ca-2019` to match [the version of the rds-aurora provider](https://registry.terraform.io/modules/terraform-aws-modules/rds-aurora/aws/2.29.0?tab=inputs) we're using.

## Motivation and Context

This will allow us to progressively switch the RDS CA to the newer `rds-ca-ecc384-g1`.  The current `rds-ca-2019` root certs expire 2024-08-22 and AWS has been warning about the upcoming expiration for months now.

## How Has This Been Tested?

Tested with `terraform plan`.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.