### PR TITLE
Documentation and unit tests for authorizer

### DIFF
--- a/backend/lambdas/api/authorizer/README.md
+++ b/backend/lambdas/api/authorizer/README.md
@@ -1,1 +1,61 @@
 # API authorizer lambda
+
+API Gateway authorizer to enable authorization via AWS Cognito or API keys.
+
+## Endpoints
+
+Invoked via API Gateway.
+
+## Configuration
+
+### Standard environment variables
+
+* `ARTEMIS_DEFAULT_SCOPE`
+* `ARTEMIS_MAINTENANCE_MODE`
+* `ARTEMIS_MAINTENANCE_MODE_MESSAGE`
+* `ARTEMIS_MAINTENANCE_MODE_RETRY_AFTER`
+
+### Lambda-specific environment variables
+
+* `APP_CLIENT_ID` - AWS Cognito app client ID. This is used to vaidate that the token came from the expected AWS Cognito user pool.
+* `ARTEMIS_DEFAULT_SCOPE` - (Optional) JSON array of default repository scopes to assign to new users. Example: `["github/warnermedia/artemis"]`. Default: `[]`
+* `EMAIL_DOMAIN_ALIASES` - (Optional) JSON array of transformations to apply when matching users from Cognito to registered users within the app (see below). Default: `[]`
+* `REGION` - AWS region of the AWS Cognito user pool (e.g. `us-east-`).
+* `USERPOOL_ID` - ID of the AWS Cognito user pool.
+
+## Email domain aliases
+
+The `EMAIL_DOMAIN_ALIASES` configuration enables support for authentication systems where a given user may have multiple email addresses under different domains. A common case is a large organization which has changed names but kept the old email domain as an alias for the new domain.
+
+For example: A user logs in via Cognito as `jane.doe@example.com` but is registered in Artemis as `jane_doe@example.org`.
+
+`EMAIL_DOMAIN_ALIASES` is a JSON array. Example:
+
+```json
+[
+    {
+        "email_transformation": {
+            "new_email_regex": "[.]",
+            "old_email_expr": "_"
+        },
+        "new_domain": "example.com",
+        "old_domains": [
+            "example.org",
+            "example.net"
+        ]
+    },
+    {
+        "email_transformation": null,
+        "new_domain": "example.com",
+        "old_domains": [
+            "foo.example"
+        ]
+    }
+]
+```
+
+Each object in the array has these fields:
+
+* `email_transformation` - (Optional) Apply a search-and-replace on the localpart of the email address (i.e. the part before the `@`). `new_email_regex` is a [Python regular expression](https://docs.python.org/3/library/re.html) which is applied to the email address from Cognito (e.g. the _current_ email address the user uses to log in), with each match replaced by the [pattern](https://docs.python.org/3/library/re.html#re.sub) `old_email_expr` in order to search within Artemis.
+* `new_domain` - The current email domain the user uses to authenticate (passed to this lambda from Cognito).
+* `old_domains` - List of past email domains, i.e. if the user is already registered in Artemis, they may be using one of these old domains.

--- a/backend/lambdas/api/authorizer/tests/test_verify_token.py
+++ b/backend/lambdas/api/authorizer/tests/test_verify_token.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import patch
+
+from authorizer.handlers import _verify_claims, _verify_signature
+
+# JWK public key generated locally to be similar to what AWS Cognito generates.
+EXAMPLE_JWK_PUBLIC_KEY = {
+    "alg": "RS256",
+    "e": "AQAB",
+    "kid": "6c780a747988cfcd5fb0401553b23f7a2856f6c9",
+    "kty": "RSA",
+    "n": "0Y54hlQM_nRgUsoiLQ4NJETjZ8p0qVgM86kkC9oZBxxQMAgrlYFuFyYv9HxgcOu5WVqh3KemYiWw0SNBbZTRPWcFW1HPImgAqbNCy-iZrgEs_JDdgqAjEVqAjfq2YAxCBxp6QgNociDornGbMJPzcIihL4Mb8oEvKEh-Tc0hCJuJoJ4yDZTpAVSJR0z4GA-hADL-jKlhWpupLc7n3p04r7BAWZN1MGf7-fRjOfPDf_3Jr0VApv5ALhcYP2unKsglMgIxcxEN0Z6qsnXPHTR1hGceJOqiCFi_eOQEBAJc9dRZEI9x8bwJofmoLmKDYDU3YVzKXTj8AQF4EH6hB3gzvw",
+    "use": "sig",
+}
+EXAMPLE_APP_ID = "ooGh2xeroJohC6cobaenai7VaiSh3lue"
+
+VALID_CLAIMS = {
+    "exp": 32219614800,  # 2990-12-31
+    "aud": "ooGh2xeroJohC6cobaenai7VaiSh3lue",
+    "email": "jane.doe@example.com",
+    "name": "Jane Doe",
+}
+# Signed JWT representing VALID_CLAIMS.
+# Note: The signature is intentionally missing base64 padding.
+VALID_TOKEN = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjMyMjE5NjE0ODAwLCJhdWQiOiJvb0doMnhlcm9Kb2hDNmNvYmFlbmFpN1ZhaVNoM2x1ZSIsImVtYWlsIjoiamFuZS5kb2VAZXhhbXBsZS5jb20iLCJuYW1lIjoiSmFuZSBEb2UifQ.baaIlNqtkCMzRbpDJYUYcuRgdy9Yc7kaChQ74gGPSGHFUgmsWm2ddhkR6rOTEAPa60WYiP5sxw4bZ2NOS0fZ0YSU5GYIYTQ_iWq-p-ocdDJjwHuBgQvX4xkw9010XA8wIgrTYWwmPugiBGTVhDP-FsaLScipj96uUQ1B2-h2c7_r4lodPbBmjjbu7FZ08k0upyTAHDQ-BiuE16GNY4ykokVxS3yP4Ujx8u3E6dNKyJsLzDFMcZBQJGHRjRzMK9q54XtWPXy6FtMc8RUmrC__VmjC6AuDpwgD-suBdIyuwMQiNTBR_MTs5b4dI-ParkTan-P8EwhT_GdMXU6kw6q1tw"
+
+
+@patch("authorizer.handlers.APP_CLIENT_ID", EXAMPLE_APP_ID)
+class TestVerifyToken(unittest.TestCase):
+    def test_verify_signature_valid(self):
+        # Does not raise exception.
+        _verify_signature(VALID_TOKEN, EXAMPLE_JWK_PUBLIC_KEY)
+
+    def test_verify_signature_invalid_token(self):
+        with self.assertRaises(Exception) as ex:
+            _verify_signature("foo.bar.baz", EXAMPLE_JWK_PUBLIC_KEY)
+        self.assertEqual(str(ex.exception), "Unauthorized")
+
+    def test_verify_claims_valid(self):
+        # Does not raise exception.
+        _verify_claims(VALID_CLAIMS)
+
+    def test_verify_claims_expired(self):
+        claims = VALID_CLAIMS.copy()
+        claims["exp"] = 631170000  # 1990-01-01
+        with self.assertRaises(Exception) as ex:
+            _verify_claims(claims)
+        self.assertEqual(str(ex.exception), "Unauthorized")
+
+    def test_verify_claims_invalid_app_id(self):
+        claims = VALID_CLAIMS.copy()
+        claims["aud"] = "foobar"
+        with self.assertRaises(Exception) as ex:
+            _verify_claims(claims)
+        self.assertEqual(str(ex.exception), "Unauthorized")


### PR DESCRIPTION
## Description

* Add unit tests for the token signature verification and claims validation.
* Add README.md for the authorizer lambda.

> [!NOTE]
> The app ID and keypair for the unit tests were generated specifically for the tests and are not used anywhere else.

## Motivation and Context

Preparation for making changes to the authorizer lambda (migrating from python-jose to joserfc).

## How Has This Been Tested?

Tested locally and in CI.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
