### PR TITLE
Switch default RDS CA to rds-ca-ecc384-g1

### DIFF
--- a/backend/terraform/modules/analyzer/variables.tf
+++ b/backend/terraform/modules/analyzer/variables.tf
@@ -77,7 +77,7 @@ variable "db_parameter_group_family" {
 variable "db_ca_cert_identifier" {
   description = "Certificate authority ID"
   type        = string
-  default     = "rds-ca-2019"
+  default     = "rds-ca-ecc384-g1"
 }
 
 variable "ui_origin_url" {


### PR DESCRIPTION
## Description

Switches the default AWS RDS CA to `rds-ca-ecc384-g1`.

## Motivation and Context

The previous default, `rds-ca-2019`, expires on 2024-08-22.

## How Has This Been Tested?

Just changes the default value of the parameter, our deployments have already migrated by explicitly setting the `db_ca_cert_identifier` variable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.