### PR TITLE
Pin docker version

### DIFF
--- a/backend/terraform/modules/analyzer/modules/engine_cluster/templates/user_data/engine.sh
+++ b/backend/terraform/modules/analyzer/modules/engine_cluster/templates/user_data/engine.sh
@@ -32,7 +32,7 @@ yum -y update
 
 # Install dependencies
 yum -y install jq
-amazon-linux-extras install -y docker
+amazon-linux-extras install -y docker=20.10.25
 
 # Allow ec2-user to use docker
 usermod -a -G docker ec2-user

--- a/backend/terraform/modules/analyzer/modules/engine_cluster/templates/user_data/engine.sh
+++ b/backend/terraform/modules/analyzer/modules/engine_cluster/templates/user_data/engine.sh
@@ -32,7 +32,7 @@ yum -y update
 
 # Install dependencies
 yum -y install jq
-amazon-linux-extras install -y docker=20.10.25
+yum -y install docker-20.10.25
 
 # Allow ec2-user to use docker
 usermod -a -G docker ec2-user


### PR DESCRIPTION
AWS is changing the latest stable version of docker to 25 from 20. Hardcoding to 20 until we confirm 25 won't break anything.

## How Has This Been Tested?
Tested in nonprod. Version is still the same.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
