### PR TITLE
Fetch Detekt during build of the Java images

### DIFF
--- a/backend/Dockerfiles/Dockerfile.java
+++ b/backend/Dockerfiles/Dockerfile.java
@@ -5,6 +5,7 @@ ARG MAINTAINER
 LABEL maintainer=$MAINTAINER
 
 ARG DETEKT_VER
+ARG DETEKT_SHA
 ARG FSB_PATCH=""
 ARG FSB_VER=1.9.0
 ARG OWASP_DC=""
@@ -56,7 +57,8 @@ RUN chmod a+x findsecbugs.sh
 
 # Install detekt
 RUN wget -q -O /usr/local/bin/detekt.jar \
-    "https://github.com/detekt/detekt/releases/download/v${DETEKT_VER}/detekt-cli-${DETEKT_VER}-all.jar"
+        "https://github.com/detekt/detekt/releases/download/v${DETEKT_VER}/detekt-cli-${DETEKT_VER}-all.jar" && \
+    echo "$DETEKT_SHA  /usr/local/bin/detekt.jar" | sha256sum -c -
 ## The detekt wrapper script is renamed from detekt.sh to "detekt"
 ## This is for compatability with installations done via a package manager
 COPY ./engine/plugins/detekt/detekt.sh /usr/local/bin/detekt

--- a/backend/Dockerfiles/Dockerfile.java
+++ b/backend/Dockerfiles/Dockerfile.java
@@ -4,6 +4,7 @@ FROM openjdk:$OPENJDK_VER
 ARG MAINTAINER
 LABEL maintainer=$MAINTAINER
 
+ARG DETEKT_VER
 ARG FSB_PATCH=""
 ARG FSB_VER=1.9.0
 ARG OWASP_DC=""
@@ -54,8 +55,9 @@ RUN sed -i -e 's/\r$//' findsecbugs.sh
 RUN chmod a+x findsecbugs.sh
 
 # Install detekt
-COPY ./.temp/detekt/detekt.jar /usr/local/bin/detekt.jar
+RUN wget -q -O /usr/local/bin/detekt.jar \
+    "https://github.com/detekt/detekt/releases/download/v${DETEKT_VER}/detekt-cli-${DETEKT_VER}-all.jar"
 ## The detekt wrapper script is renamed from detekt.sh to "detekt"
 ## This is for compatability with installations done via a package manager
-COPY ./.temp/detekt/detekt /usr/local/bin/detekt
+COPY ./engine/plugins/detekt/detekt.sh /usr/local/bin/detekt
 RUN chmod a+x /usr/local/bin/detekt

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -536,12 +536,13 @@ dist/docker/golang: Dockerfiles/Dockerfile.golang
 	touch $@
 	@echo "${OK}"
 
-dist/docker/java7: Dockerfiles/Dockerfile.java get-detekt
+dist/docker/java7: Dockerfiles/Dockerfile.java
 	@echo "${INFO}Building $@"
 	$(DOCKER) build . --pull -t ${JAVA7_TAG} -f Dockerfiles/Dockerfile.java \
 		--no-cache --force-rm \
 		--build-arg MAINTAINER=${MAINTAINER} \
 		--build-arg OPENJDK_VER=7u201-jdk-alpine3.9 \
+		--build-arg DETEKT_VER=${DETEKT_VER} \
 		--build-arg FSB_VER=${FSB_VER} \
 		--build-arg FSB_PATCH=${FSB_PATCH}
 	mkdir -p ${DIST_DIR}/docker
@@ -550,12 +551,13 @@ dist/docker/java7: Dockerfiles/Dockerfile.java get-detekt
 	touch $@
 	@echo "${OK}"
 
-dist/docker/java8: Dockerfiles/Dockerfile.java get-detekt
+dist/docker/java8: Dockerfiles/Dockerfile.java
 	@echo "${INFO}Building $@"
 	$(DOCKER) build . --pull -t ${JAVA8_TAG} -f Dockerfiles/Dockerfile.java \
 		--no-cache --force-rm \
 		--build-arg MAINTAINER=${MAINTAINER} \
 		--build-arg OPENJDK_VER=8u201-jdk-alpine3.9 \
+		--build-arg DETEKT_VER=${DETEKT_VER} \
 		--build-arg FSB_VER=${FSB_VER} \
 		--build-arg FSB_PATCH=${FSB_PATCH} \
 		--build-arg OWASP_DC=${OWASP_DC} \
@@ -566,12 +568,13 @@ dist/docker/java8: Dockerfiles/Dockerfile.java get-detekt
 	touch $@
 	@echo "${OK}"
 
-dist/docker/java13: Dockerfiles/Dockerfile.java get-detekt
+dist/docker/java13: Dockerfiles/Dockerfile.java
 	@echo "${INFO}Building $@"
 	$(DOCKER) build . --pull  -t ${JAVA13_TAG} -f Dockerfiles/Dockerfile.java \
 		--no-cache --force-rm \
 		--build-arg MAINTAINER=${MAINTAINER} \
 		--build-arg OPENJDK_VER=13-ea-14-jdk-alpine3.9 \
+		--build-arg DETEKT_VER=${DETEKT_VER} \
 		--build-arg FSB_VER=${FSB_VER} \
 		--build-arg FSB_PATCH=${FSB_PATCH}
 	mkdir -p ${DIST_DIR}/docker
@@ -580,12 +583,13 @@ dist/docker/java13: Dockerfiles/Dockerfile.java get-detekt
 	touch $@
 	@echo "${OK}"
 
-dist/docker/java17: Dockerfiles/Dockerfile.java get-detekt
+dist/docker/java17: Dockerfiles/Dockerfile.java
 	@echo "${INFO}Building $@"
 	$(DOCKER) build . --pull -t ${JAVA17_TAG} -f Dockerfiles/Dockerfile.java \
 		--no-cache --force-rm \
 		--build-arg MAINTAINER=${MAINTAINER} \
 		--build-arg OPENJDK_VER=17-ea-14-jdk-alpine3.12 \
+		--build-arg DETEKT_VER=${DETEKT_VER} \
 		--build-arg FSB_VER=${FSB_VER} \
 		--build-arg FSB_PATCH=${FSB_PATCH}
 	mkdir -p ${DIST_DIR}/docker

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -246,18 +246,18 @@ help:  ## Print this help text
 # Testing targets
 ###############################################################################
 
-$(ROOT_DIR)/.temp/detekt/detekt.jar:
+$(ROOT_DIR)/.temp/detekt-${DETEKT_VER}/detekt.jar:
 	mkdir -p $(@D)
 	curl -sL "https://github.com/detekt/detekt/releases/download/v${DETEKT_VER}/detekt-cli-${DETEKT_VER}-all.jar" >$@
 	echo "${DETEKT_SHA} $@" | sha256sum -c -
 
 # The detekt wrapper script is renamed from detekt.sh to "detekt"
 # This is for compatability with installations done via a package manager
-$(ROOT_DIR)/.temp/detekt/detekt:
+$(ROOT_DIR)/.temp/detekt-${DETEKT_VER}/detekt:
 	mkdir -p $(@D)
 	cp ${ROOT_DIR}/engine/plugins/detekt/detekt.sh $@
 
-get-detekt: $(ROOT_DIR)/.temp/detekt/detekt.jar $(ROOT_DIR)/.temp/detekt/detekt
+get-detekt: $(ROOT_DIR)/.temp/detekt-${DETEKT_VER}/detekt.jar $(ROOT_DIR)/.temp/detekt-${DETEKT_VER}/detekt
 .PHONY: get-detekt
 
 ${ROOT_DIR}/.temp/shellcheck-${SHELLCHECKVER}/shellcheck:
@@ -292,7 +292,7 @@ install-plugin-dependencies:
 
 define run-pytest
 	@echo "${INFO}Running $1"
-	export PATH='${ROOT_DIR}/.temp/shellcheck-${SHELLCHECKVER}:${ROOT_DIR}/.temp/detekt:${ROOT_DIR}/.temp/swiftlint:${ROOT_DIR}/.temp/trivy-${TRIVY_VER}:${PATH}:'; \
+	export PATH='${ROOT_DIR}/.temp/shellcheck-${SHELLCHECKVER}:${ROOT_DIR}/.temp/detekt-${DETEKT_VER}:${ROOT_DIR}/.temp/swiftlint:${ROOT_DIR}/.temp/trivy-${TRIVY_VER}:${PATH}:'; \
 	export PIPENV_DONT_LOAD_ENV=1; \
 	${PYTHON} -m pipenv sync --dev; \
 	${PYTHON} -m pipenv run pytest -c pytest.ini $2 ${PYTEST_EXTRA_ARGS};

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -215,6 +215,7 @@ SNYK_FLAG := $(shell egrep "snyk_enabled\s+=\s+(true|false)" ${TERRAFORM}/enviro
 
 # Detekt
 DETEKT_VER := 1.19.0
+DETEKT_SHA := 4bc545c95c3711daeedd7766a9884ac50f2a49a0b472cef2b14dae332c58294d
 
 # psycopg2
 PSYCOPG2_VER := 2.9.3
@@ -248,6 +249,7 @@ help:  ## Print this help text
 $(ROOT_DIR)/.temp/detekt/detekt.jar:
 	mkdir -p $(@D)
 	curl -sL "https://github.com/detekt/detekt/releases/download/v${DETEKT_VER}/detekt-cli-${DETEKT_VER}-all.jar" >$@
+	echo "${DETEKT_SHA} $@" | sha256sum -c -
 
 # The detekt wrapper script is renamed from detekt.sh to "detekt"
 # This is for compatability with installations done via a package manager
@@ -543,6 +545,7 @@ dist/docker/java7: Dockerfiles/Dockerfile.java
 		--build-arg MAINTAINER=${MAINTAINER} \
 		--build-arg OPENJDK_VER=7u201-jdk-alpine3.9 \
 		--build-arg DETEKT_VER=${DETEKT_VER} \
+		--build-arg DETEKT_SHA=${DETEKT_SHA} \
 		--build-arg FSB_VER=${FSB_VER} \
 		--build-arg FSB_PATCH=${FSB_PATCH}
 	mkdir -p ${DIST_DIR}/docker
@@ -558,6 +561,7 @@ dist/docker/java8: Dockerfiles/Dockerfile.java
 		--build-arg MAINTAINER=${MAINTAINER} \
 		--build-arg OPENJDK_VER=8u201-jdk-alpine3.9 \
 		--build-arg DETEKT_VER=${DETEKT_VER} \
+		--build-arg DETEKT_SHA=${DETEKT_SHA} \
 		--build-arg FSB_VER=${FSB_VER} \
 		--build-arg FSB_PATCH=${FSB_PATCH} \
 		--build-arg OWASP_DC=${OWASP_DC} \
@@ -575,6 +579,7 @@ dist/docker/java13: Dockerfiles/Dockerfile.java
 		--build-arg MAINTAINER=${MAINTAINER} \
 		--build-arg OPENJDK_VER=13-ea-14-jdk-alpine3.9 \
 		--build-arg DETEKT_VER=${DETEKT_VER} \
+		--build-arg DETEKT_SHA=${DETEKT_SHA} \
 		--build-arg FSB_VER=${FSB_VER} \
 		--build-arg FSB_PATCH=${FSB_PATCH}
 	mkdir -p ${DIST_DIR}/docker
@@ -590,6 +595,7 @@ dist/docker/java17: Dockerfiles/Dockerfile.java
 		--build-arg MAINTAINER=${MAINTAINER} \
 		--build-arg OPENJDK_VER=17-ea-14-jdk-alpine3.12 \
 		--build-arg DETEKT_VER=${DETEKT_VER} \
+		--build-arg DETEKT_SHA=${DETEKT_SHA} \
 		--build-arg FSB_VER=${FSB_VER} \
 		--build-arg FSB_PATCH=${FSB_PATCH}
 	mkdir -p ${DIST_DIR}/docker


### PR DESCRIPTION
## Description

* detekt.jar is now downloaded and installed within the Dockerfile.
* The download hash is now verified.
* Restored the embedded version in the unit test download path to account for changes in the specified tool version.

## Motivation and Context

This is consistent with how we fetch dependent tools; we do not rely on the artifacts from the unit tests and vice-versa.

The long-term plan is for the unit tests to not be dependent on the Makefile at all.

## How Has This Been Tested?

Deployed and tested in nonprod environment.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
