### PR TITLE
Preparation for future tool dependency updates

### DIFF
--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -29,7 +29,6 @@ black = "==22.3.0"  # Pending upgrade later.
 cfn-lint = "==0.53.0"  # Must match version in Makefile.
 checkov = "==2.0.1065"  # Must match version in Makefile.
 flake8 = "~=7.0"
-gitpython = "~=3.1"
 isort = "~=5.12"
 mock = "~=5.1"
 moto = {extras = ["awslambda", "ec2", "s3", "secretsmanager", "sqs"], version = "~=5.0"}
@@ -39,3 +38,4 @@ pytest-cov = "~=5.0"
 pytest-subtests = "~=0.12"
 python-dotenv = "~=1.0"
 responses = "~=0.25.0"
+trufflehog = "==2.2.1"

--- a/backend/Pipfile.lock
+++ b/backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "78fcb35e3a49f4f1dad2779f71def745819f856c503f75846b684cbc68aedfc4"
+            "sha256": "20714ec9f6be0e52dac311eb8960e8c8f271e2781390d5e528f98814cf89f3de"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1684,14 +1684,19 @@
             "markers": "python_version >= '3.7'",
             "version": "==4.0.11"
         },
+        "gitdb2": {
+            "hashes": [
+                "sha256:0986cb4003de743f2b3aba4c828edd1ab58ce98e1c4a8acf72ef02760d4beb4e",
+                "sha256:a1c974e5fab8c2c90192c1367c81cbc54baec04244bda1816e9c8ab377d1cba3"
+            ],
+            "version": "==4.0.2"
+        },
         "gitpython": {
             "hashes": [
-                "sha256:35f314a9f878467f5453cc1fee295c3e18e52f1b99f10f6cf5b1682e968a9e7c",
-                "sha256:eec7ec56b92aad751f9912a73404bc02ba212a23adb2c7098ee668417051a1ff"
+                "sha256:5b5b7b29baa27680a7dff85f171a251d48ac37c5f04cba15d381b56991cc7a48"
             ],
-            "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==3.1.43"
+            "markers": "python_version >= '3.4'",
+            "version": "==3.0.6"
         },
         "idna": {
             "hashes": [
@@ -2636,6 +2641,21 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==4.66.4"
+        },
+        "trufflehog": {
+            "hashes": [
+                "sha256:7f0d09c8cda2a90ae42f81405e5944a3325d90a5842d2dde014471e4d65c71e4",
+                "sha256:ac411e29ffac06555cdc40ed1cbff0b3c74cb0ed26af2a0432ed15e61b94e6b5"
+            ],
+            "index": "pypi",
+            "version": "==2.2.1"
+        },
+        "trufflehogregexes": {
+            "hashes": [
+                "sha256:627e7cd246153135dea86bacd1253df262c525874f9008395ffe81eb63f92352",
+                "sha256:b81dfc60c86c1e353f436a0e201fd88edb72d5a574615a7858485c59edf32405"
+            ],
+            "version": "==0.0.7"
         },
         "types-setuptools": {
             "hashes": [

--- a/backend/engine/plugins/checkov/main.py
+++ b/backend/engine/plugins/checkov/main.py
@@ -1,6 +1,7 @@
 """
 Checkov Plugin
 """
+
 import json
 import subprocess
 import tempfile
@@ -101,7 +102,7 @@ def run_checkov(path: str, config: dict = {}) -> dict:
     return output
 
 
-def parse_checkov(checkov_output: list[dict], repo_path: str, config_dir: str, config: dict) -> (list, str):
+def parse_checkov(checkov_output: list[dict], repo_path: str, config_dir: str, config: dict) -> tuple[list, str]:
     """
     Parse the output of Checkov
     """
@@ -143,7 +144,7 @@ def parse_checkov(checkov_output: list[dict], repo_path: str, config_dir: str, c
     return (findings, error)
 
 
-def get_config_dir(repo_path: str, config: dict) -> (str, str):
+def get_config_dir(repo_path: str, config: dict) -> tuple[str, str]:
     """
     Determine if config directory should be from S3 or default (local)
     """
@@ -173,7 +174,7 @@ def get_config_dir(repo_path: str, config: dict) -> (str, str):
     return (config_dir, error)
 
 
-def get_ckv_severities(config_dir: str, config: dict) -> (dict, str):
+def get_ckv_severities(config_dir: str, config: dict) -> tuple[dict, str]:
     """
     Read Checkov severities from JSON file, and return them as dict
     """

--- a/backend/engine/tests/test_plugin_checkov.py
+++ b/backend/engine/tests/test_plugin_checkov.py
@@ -1,5 +1,6 @@
 import os
 import unittest
+from unittest.util import safe_repr
 
 from engine.plugins.checkov.main import run_checkov
 
@@ -9,39 +10,101 @@ CHECKOV_TEST_DIR1 = "data/checkov/findings"
 CHECKOV_TEST_DIR2 = "data/checkov/nofindings"
 CHECKOV_TEST_DIR3 = "data/checkov/nocheckov"
 
-CHECKOV_RESPONSE1 = {
-    "success": True,
-    "truncated": False,
-    "details": [
-        {
-            "type": "terraform",
-            "filename": "main.tf",
-            "line": 1,
-            "message": "CKV_AWS_144 - Ensure that S3 bucket has cross-region replication enabled - https://docs.bridgecrew.io/docs/ensure-that-s3-bucket-has-cross-region-replication-enabled",
-            "severity": "low",
-        },
-        {
-            "type": "terraform",
-            "filename": "main.tf",
-            "line": 28,
-            "message": "CKV_AWS_55 - Ensure S3 bucket has ignore public ACLs enabled - https://docs.bridgecrew.io/docs/bc_aws_s3_21",
-            "severity": "medium",
-        },
-    ],
-    "errors": [],
-}
-CHECKOV_RESPONSE2 = {"success": True, "truncated": False, "details": [], "errors": []}
+CHECKOV_EMPTY_RESPONSE = {"success": True, "truncated": False, "details": [], "errors": []}
 
 
 class TestCheckov(unittest.TestCase):
+    def _assertContainsFinding(
+        self,
+        details: list[dict],
+        type: str = "",
+        filename: str = "",
+        line: int = 0,
+        message: str = "",
+        severity: str = "",
+    ):
+        """
+        Checks if a finding is present in the list of findings.
+
+        We anticipate that Checkov may report the findings in any order or
+        change details of the message (e.g. to fix typos or to update the URL).
+
+        The message is only matched to the error code (e.g. "CKV_AWS_144") since the
+        message details may change from version to version but the code is expected
+        to be stable.
+        """
+        for detail in details:
+            if (
+                detail["type"] == type
+                and detail["filename"] == filename
+                and detail["line"] == line
+                and detail["severity"] == severity
+                and detail["message"].startswith(f"{message} - ")
+            ):
+                return
+        self.fail(
+            "%s not found in %s"
+            % (
+                safe_repr(
+                    {
+                        "type": type,
+                        "filename": filename,
+                        "line": line,
+                        "message": message,
+                        "severity": severity,
+                    }
+                ),
+                safe_repr(details),
+            )
+        )
+
     def test_with_findings(self):
         response = run_checkov(f"{SCRIPT_DIR}/{CHECKOV_TEST_DIR1}")
-        self.assertEqual(response, CHECKOV_RESPONSE1)
+        self.maxDiff = None
+        self.assertTrue(response["success"])
+        self.assertFalse(response["truncated"])
+        self.assertEqual(response["errors"], [])
+
+        details = response["details"]
+        self.assertEqual(len(details), 2)
+        self._assertContainsFinding(
+            details,
+            type="terraform",
+            filename="main.tf",
+            line=1,
+            message="CKV_AWS_144",  # Ensure that S3 bucket has cross-region replication enabled
+            severity="low",
+        )
+        self._assertContainsFinding(
+            details,
+            type="terraform",
+            filename="main.tf",
+            line=28,
+            message="CKV_AWS_55",  # Ensure S3 bucket has ignore public ACLs enabled
+            severity="medium",
+        )
+        # New findings in Checkov 3.2.
+        # self._assertContainsFinding(
+        #     details,
+        #     type="terraform",
+        #     filename="main.tf",
+        #     line=1,
+        #     message="CKV2_AWS_62",  # Ensure S3 buckets should have event notifications enabled
+        #     severity="low",
+        # )
+        # self._assertContainsFinding(
+        #     details,
+        #     type="terraform",
+        #     filename="main.tf",
+        #     line=1,
+        #     message="CKV2_AWS_61",  # Ensure that an S3 bucket has a lifecycle configuration
+        #     severity="low",
+        # )
 
     def test_without_findings(self):
         response = run_checkov(f"{SCRIPT_DIR}/{CHECKOV_TEST_DIR2}")
-        self.assertEqual(response, CHECKOV_RESPONSE2)
+        self.assertEqual(response, CHECKOV_EMPTY_RESPONSE)
 
     def test_no_checkov(self):
         response = run_checkov(f"{SCRIPT_DIR}/{CHECKOV_TEST_DIR3}")
-        self.assertEqual(response, CHECKOV_RESPONSE2)
+        self.assertEqual(response, CHECKOV_EMPTY_RESPONSE)


### PR DESCRIPTION
## Description

* Modifies the Checkov unit test to ignore changes to the ordering and message details of results.  For example, newer versions of Checkov change the URL in message details.
* Adds `trufflehog` as a dev dependency so we can detect potential dependency conflicts (in `Dockerfile.python3` in particular).
* Removed `gitpython` from `backend/Pipfile` since it's not a direct dependency.  Note that adding `trufflehog` downgrades the dependency (from 3.1 to 3.0) to the most recent compatible version.
* Fixes some lint warnings about type hints in the Checkov plugin.

## Motivation and Context

This prepares us for the future updates of Checkov (v3.2), cfn_lint, and TruffleHog (v3).  These three tools share a number of dependencies and are planned to be updated soon.

## How Has This Been Tested?

All docker images built locally, unit test changes tested with a locally-upgraded version of Checkcov (changes needed for Checkov 3.2 have been commented-out for now).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
