### PR TITLE
Check Terraform formatting

### DIFF
--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -15,6 +15,7 @@ jobs:
           python-version: "3.9"
           cache: pipenv
           cache-dependency-path: backend/Pipfile.lock
+      - uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # hashicorp/setup-terraform@v3.1.1
       - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # actions/cache@v4.0.2
         with:
           # Tool versions are defined in the Makefile.

--- a/.github/workflows/test_orchestrator.yml
+++ b/.github/workflows/test_orchestrator.yml
@@ -17,6 +17,7 @@ jobs:
           architecture: "x64"
           cache: pipenv
           cache-dependency-path: orchestrator/Pipfile.lock
+      - uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # hashicorp/setup-terraform@v3.1.1
       - name: Install Test Dependencies
         run: |
           pip install --upgrade pipenv wheel

--- a/.github/workflows/test_ui.yml
+++ b/.github/workflows/test_ui.yml
@@ -22,6 +22,8 @@ jobs:
         with:
           node-version-file: "${{ env.UI_PATH }}/.nvmrc"
 
+      - uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # hashicorp/setup-terraform@v3.1.1
+
       - name: Set up the npm version
         run: npm install --global npm@$NPM_VERSION
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -34,6 +34,7 @@ TERRAFORM_DIR := ${WORKING_DIR}/terraform
 DOCKER := docker
 PYTHON := python3
 PIP := pip3
+TERRAFORM := terraform
 
 VERSION := 2.0.0
 
@@ -322,6 +323,9 @@ style-test:
 	@echo "${INFO}Running code style checks"
 	${PYTHON} -m pipenv sync --dev
 	${PYTHON} -m pipenv run black --check .
+#	Note: Not using TERRAFORM_DIR since we're only checking the local sources,
+#	not overrrides.
+	${TERRAFORM} fmt -check -recursive terraform
 	@echo "${OK}"
 .PHONY: style-test
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -29,7 +29,7 @@ WORKING_DIR := ${ROOT_DIR}
 BUILD_DIR := ${ROOT_DIR}/build
 DIST_DIR := ${ROOT_DIR}/dist
 STAGE_DIR := ${ROOT_DIR}/stage
-TERRAFORM := ${WORKING_DIR}/terraform
+TERRAFORM_DIR := ${WORKING_DIR}/terraform
 
 DOCKER := docker
 PYTHON := python3
@@ -47,7 +47,7 @@ ENV := nonprod
 include ${WORKING_DIR}/$(ENV).mk
 
 # Application name extracted from Terraform
-PREFIX := $(shell egrep "application\s+=\s+\".+\"" ${TERRAFORM}/environments/${ENV}/main.tf | sed 's:[ "]::g' | cut -d'=' -f2)
+PREFIX := $(shell egrep "application\s+=\s+\".+\"" ${TERRAFORM_DIR}/environments/${ENV}/main.tf | sed 's:[ "]::g' | cut -d'=' -f2)
 
 S3_BUCKET := ${PREFIX}-${ACCOUNT_ID}
 S3_DOCS_BUCKET := ${PREFIX}-docs-${ACCOUNT_ID}
@@ -144,7 +144,7 @@ DB_MAINT_TAG := ${DB_MAINT_PKG}:latest
 VERACODE_PKG := ${PREFIX}/veracode
 VERACODE_TAG := ${VERACODE_PKG}:latest
 # Context: egrep grabs the terraform line that notes whether veracode is enabled. sed removes all spacing. Cut grabs the bool.
-VERACODE_FLAG := $(shell egrep "veracode_enabled\s+=\s+(true|false)" ${TERRAFORM}/environments/${ENV}/main.tf | sed 's: ::g' | cut -d'=' -f2)
+VERACODE_FLAG := $(shell egrep "veracode_enabled\s+=\s+(true|false)" ${TERRAFORM_DIR}/environments/${ENV}/main.tf | sed 's: ::g' | cut -d'=' -f2)
 
 SWIFT_PKG := ${PREFIX}/swift
 SWIFT_TAG := ${SWIFT_PKG}:latest
@@ -211,7 +211,7 @@ TRIVY_VER := v0.49.1
 # Snyk
 SNYK_VER := v1.889.0
 # Context: egrep grabs the terraform line that notes whether Snyk is enabled. sed removes all spacing. Cut grabs the bool.
-SNYK_FLAG := $(shell egrep "snyk_enabled\s+=\s+(true|false)" ${TERRAFORM}/environments/${ENV}/main.tf | sed 's: ::g' | cut -d'=' -f2)
+SNYK_FLAG := $(shell egrep "snyk_enabled\s+=\s+(true|false)" ${TERRAFORM_DIR}/environments/${ENV}/main.tf | sed 's: ::g' | cut -d'=' -f2)
 
 # Detekt
 DETEKT_VER := 1.19.0
@@ -221,7 +221,7 @@ DETEKT_SHA := 4bc545c95c3711daeedd7766a9884ac50f2a49a0b472cef2b14dae332c58294d
 PSYCOPG2_VER := 2.9.3
 
 # Lambdas
-LAMBDA_PLATFORM := $(shell tr -d '[:blank:]"' <${TERRAFORM}/environments/${ENV}/main.tf | grep -xE 'lambda_architecture=(x86_64|arm64)' | cut -d '=' -f 2 | sed 's/arm64/aarch64/g')
+LAMBDA_PLATFORM := $(shell tr -d '[:blank:]"' <${TERRAFORM_DIR}/environments/${ENV}/main.tf | grep -xE 'lambda_architecture=(x86_64|arm64)' | cut -d '=' -f 2 | sed 's/arm64/aarch64/g')
 LAMBDA_PYTHON_VER := 3.9
 LAMBDA_PLATFORM_FLAGS := --platform manylinux2010_$(LAMBDA_PLATFORM) --platform manylinux2014_$(LAMBDA_PLATFORM) --platform manylinux_2_24_${LAMBDA_PLATFORM}
 LAMBDA_LAYERS_BUILD_DIR := $(BUILD_DIR)/lambdas/layers

--- a/backend/terraform/environments/example/variables.tf
+++ b/backend/terraform/environments/example/variables.tf
@@ -1,14 +1,14 @@
 variable "maintenance_mode" {
   description = "Whether Artemis is in maintenance mode"
-  default = false
+  default     = false
 }
 
 variable "maintenance_mode_message" {
   description = "Message to accompany maintenance mode"
-  default = ""
+  default     = ""
 }
 
 variable "maintenance_mode_retry_after" {
   description = "ISO 8601 timestamp of when maintenance mode is estimated to end"
-  default = ""
+  default     = ""
 }

--- a/backend/terraform/modules/IAM/main.tf
+++ b/backend/terraform/modules/IAM/main.tf
@@ -1,5 +1,5 @@
 
 resource "aws_accessanalyzer_analyzer" "access_analyzer" {
   analyzer_name = "${var.app}-access-analyzer"
-  tags = var.tags
+  tags          = var.tags
 }

--- a/backend/terraform/modules/metadata_events/main.tf
+++ b/backend/terraform/modules/metadata_events/main.tf
@@ -19,10 +19,10 @@ resource "aws_lambda_function" "metadata-events-handler" {
 
   environment {
     variables = {
-      APPLICATION                  = var.app
-      ENVIRONMENT                  = var.environment
-      ARTEMIS_SPLUNK_KEY           = aws_secretsmanager_secret.metadata-events-secret.name
-      ARTEMIS_SCRUB_NONPROD        = "false"
+      APPLICATION           = var.app
+      ENVIRONMENT           = var.environment
+      ARTEMIS_SPLUNK_KEY    = aws_secretsmanager_secret.metadata-events-secret.name
+      ARTEMIS_SCRUB_NONPROD = "false"
     }
   }
 
@@ -98,7 +98,7 @@ module "write-logs" {
   iam_role_names = [
     aws_iam_role.metadata-events-role.name
   ]
-  name      = "${var.app}-metadata-events-write-logs"
+  name = "${var.app}-metadata-events-write-logs"
   resources = [
     "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.app}*:*"
   ]

--- a/backend/terraform/modules/role_policy_attachment/main.tf
+++ b/backend/terraform/modules/role_policy_attachment/main.tf
@@ -21,7 +21,7 @@ resource "aws_iam_policy" "iam-policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "policy-attachment" {
-  count      = length(var.iam_role_names)
+  count = length(var.iam_role_names)
 
   role       = var.iam_role_names[count.index]
   policy_arn = aws_iam_policy.iam-policy.arn

--- a/backend/terraform/modules/role_policy_attachment/variables.tf
+++ b/backend/terraform/modules/role_policy_attachment/variables.tf
@@ -1,29 +1,29 @@
 variable "resources" {
   description = "List of ARNs of the resources in which to apply the policy"
-  type = list(string)
+  type        = list(string)
 }
 
 variable "actions" {
   description = "List of actions that will have the effect in the policy"
-  type = list(string)
+  type        = list(string)
 }
 
 variable "effect" {
-  default = "Allow"
+  default     = "Allow"
   description = "Whether to allow or deny the actions of the policy. Default is allow."
 }
 
 variable "name" {
   description = "name of the policy"
-  type = string
+  type        = string
 }
 
 variable "iam_role_names" {
   description = "name of the role to assign the policy"
-  type = list(string)
+  type        = list(string)
 }
 
 variable "conditions" {
   description = "conditions to apply to the policy"
-  default = []
+  default     = []
 }

--- a/backend/terraform/modules/vpc/variables.tf
+++ b/backend/terraform/modules/vpc/variables.tf
@@ -1,5 +1,5 @@
 variable "tags" {
-  type = map
+  type = map(any)
 }
 
 variable "vpc_cidr" {

--- a/orchestrator/Makefile
+++ b/orchestrator/Makefile
@@ -26,7 +26,7 @@ BUILD_DIR := ${ROOT_DIR}/build
 LAMBDA_LAYERS_BUILD_DIR := $(BUILD_DIR)/lambdas/layers
 DIST_DIR := ${ROOT_DIR}/dist
 STAGE_DIR := ${ROOT_DIR}/stage
-TERRAFORM := ${WORKING_DIR}/terraform
+TERRAFORM_DIR := ${WORKING_DIR}/terraform
 BACKEND := ${ROOT_DIR}/../backend
 
 PYTHON := python3
@@ -41,7 +41,7 @@ ENV := nonprod
 include ${WORKING_DIR}/$(ENV).mk
 
 # Application name extracted from Terraform
-PREFIX := $(shell egrep "application\s+=\s+\".+\"" ${TERRAFORM}/environments/${ENV}/main.tf | sed 's:[ "]::g' | cut -d'=' -f2)
+PREFIX := $(shell egrep "application\s+=\s+\".+\"" ${TERRAFORM_DIR}/environments/${ENV}/main.tf | sed 's:[ "]::g' | cut -d'=' -f2)
 
 S3_BUCKET := ${PREFIX}-${ACCOUNT_ID}
 ECR_URL := ${ACCOUNT_ID}.dkr.ecr.${REGION}.amazonaws.com/
@@ -62,7 +62,7 @@ HEIMDALL_ORGS_SRC = $(shell find ${HEIMDALL_ORGS_DIR} -type f -name '*.py' -o -n
 HEIMDALL_UTILS_SRC = $(shell find ${HEIMDALL_UTILS_DIR} -type f -name '*.py' -o -name '*.cfg')
 HEIMDALL_REPOS_SRC = $(shell find ${HEIMDALL_REPOS_DIR} -type f -name '*.py' -o -name '*.cfg')
 
-LAMBDA_PLATFORM := $(shell tr -d '[:blank:]"' <${TERRAFORM}/environments/${ENV}/main.tf | grep -xE 'lambda_architecture=(x86_64|arm64)' | cut -d '=' -f 2 | sed 's/arm64/aarch64/g')
+LAMBDA_PLATFORM := $(shell tr -d '[:blank:]"' <${TERRAFORM_DIR}/environments/${ENV}/main.tf | grep -xE 'lambda_architecture=(x86_64|arm64)' | cut -d '=' -f 2 | sed 's/arm64/aarch64/g')
 LAMBDA_PYTHON_VER := 3.9
 LAMBDA_PLATFORM_FLAGS := --platform manylinux2010_$(LAMBDA_PLATFORM) --platform manylinux2014_$(LAMBDA_PLATFORM) --platform manylinux_2_24_${LAMBDA_PLATFORM}
 

--- a/orchestrator/Makefile
+++ b/orchestrator/Makefile
@@ -31,6 +31,7 @@ BACKEND := ${ROOT_DIR}/../backend
 
 PYTHON := python3
 PIP := pip3
+TERRAFORM := terraform
 
 VERSION := 1.0.0
 
@@ -110,6 +111,9 @@ style-test:
 	@echo "${INFO}Running code style checks"
 	${PYTHON} -m pipenv sync --dev
 	${PYTHON} -m pipenv run black --check .
+#	Note: Not using TERRAFORM_DIR since we're only checking the local sources,
+#	not overrrides.
+	${TERRAFORM} fmt -check -recursive terraform
 	@echo "${OK}"
 .PHONY: style-test
 

--- a/ui/Makefile
+++ b/ui/Makefile
@@ -29,6 +29,7 @@ HADOLINT = $(shell which hadolint)
 ifeq ($(HADOLINT),)
 	HADOLINT := ${CURDIR}/hadolint
 endif
+TERRAFORM = terraform
 
 APP := artemis-ui
 PORT := 3000
@@ -199,6 +200,7 @@ test:  ## Run tests
 check: $(SRC)  ## Check code style
 	@echo "${INFO}Checking code style"
 	$(NPM) run prettier-check
+	$(TERRAFORM) fmt -check -recursive terraform
 	@echo "${OK}"
 
 # run coding standards auto-fix


### PR DESCRIPTION
## Description

* Adds Terraform formatting check to style tests.
* Fixes formatting in existing Terraform files.

## Motivation and Context

`terraform fmt` enforces the standard Terraform code style, but sometimes a manual merge or scripted edit will result in a mis-formatted file to slip through.  This adds a check for that.

## How Has This Been Tested?

Tested locally and in CI, before and after formatting fixes for existing files.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.