### PR TITLE
Enable strict mode for pytest

### DIFF
--- a/backend/engine/processor/processor.py
+++ b/backend/engine/processor/processor.py
@@ -326,7 +326,7 @@ class EngineProcessor:
         # log any unexpected severities, so we can investigate or update the severity dictionary
         # if (not in the dict) & (not empty string) then log it
         if (item_severity_int == -1) & (isinstance(item_severity, str)) & (len(item_severity) > 0):
-            logger.warn(
+            logger.warning(
                 f"Received an unexpected item_severity: {item_severity}, caching most_severe value: {most_severe}."
             )
 

--- a/backend/lambdas/api/authorizer/tests/test_get_user.py
+++ b/backend/lambdas/api/authorizer/tests/test_get_user.py
@@ -13,7 +13,7 @@ EMAIL_DOMAIN_ALIASES = [
     {
         "new_domain": "company2.com",
         "old_domains": ["company2.com"],
-        "email_transformation": {"new_email_regex": "([a-z]+)\.([a-z]+)", "old_email_expr": "\\2.\\1"},
+        "email_transformation": {"new_email_regex": "([a-z]+)\\.([a-z]+)", "old_email_expr": "\\2.\\1"},
     },
     {
         "new_domain": "company3.com",

--- a/backend/lambdas/api/repo/repo/gitlab_util/process_gitlab_utils.py
+++ b/backend/lambdas/api/repo/repo/gitlab_util/process_gitlab_utils.py
@@ -23,7 +23,7 @@ def process_query_list(key, service_url, query_list, vars, batch_query=True):
             resp_data = resp["data"]
             # Parsing out the alias from the GraphQL query, so we can use it for mapping.
             # ex: query GetRepos($repo0: ID!) {repo0: project(fullPath: $repo0) {**}
-            repo = re.search("\$(repo[0-9]*):", query_item.strip()).group(1)
+            repo = re.search("\\$(repo[0-9]*):", query_item.strip()).group(1)
             response_dict["data"][repo] = resp_data[repo]
         else:
             log.error("Repo query failed to receive valid output: %s", query_item)

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,7 +1,9 @@
 [pytest]
 addopts = --strict-config --strict-markers --cov=. --cov-report html --cov-report term-missing -rsx -vv
 norecursedirs = .venv/* build/* venv/*
-pep8maxlinelength = 120
+markers =
+    end2end: End-to-end test
+    integtest: Integration test
 pythonpath =
     engine
     engine/plugins/repo_health/cli

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --cov=. --cov-report html --cov-report term-missing -rsx -vv --disable-pytest-warnings
+addopts = --strict-config --strict-markers --cov=. --cov-report html --cov-report term-missing -rsx -vv
 norecursedirs = .venv/* build/* venv/*
 pep8maxlinelength = 120
 pythonpath =

--- a/orchestrator/pytest.ini
+++ b/orchestrator/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --cov=. --cov-report html --cov-report term-missing -rsx -vv --disable-pytest-warnings
+addopts = --strict-config --strict-markers --cov=. --cov-report html --cov-report term-missing -rsx -vv
 norecursedirs = .venv/* build/* venv/*
 pep8maxlinelength = 120
 pep8ignore = E203

--- a/orchestrator/pytest.ini
+++ b/orchestrator/pytest.ini
@@ -1,8 +1,9 @@
 [pytest]
 addopts = --strict-config --strict-markers --cov=. --cov-report html --cov-report term-missing -rsx -vv
 norecursedirs = .venv/* build/* venv/*
-pep8maxlinelength = 120
-pep8ignore = E203
+markers =
+    end2end: End-to-end test
+    integtest: Integration test
 pythonpath =
     .
     lambdas/layers/heimdall_orgs


### PR DESCRIPTION
## Description

* Enables `--strict-config` and `--strict-markers` in pytest.
* Disables ignoring pytest warnings.
* Removed obsolete pytest config options.
* Defined custom markers.
* Cleaned up deprecation and syntax warnings detected by strict mode.

## Motivation and Context

Strict mode detects typos in marker names and obsolete config options.

## How Has This Been Tested?

Tested locally and in CI.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
