### PR TITLE
Support Requeueing branches in Bitbucket Cloud v2

### DIFF
--- a/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/bitbucket_utils.py
+++ b/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/bitbucket_utils.py
@@ -74,12 +74,9 @@ class ProcessBitbucketRepos:
         if not resp:
             return []
 
-        nodes = resp.get("values", None)
+        nodes = resp.get("values", [])
         if not nodes and "slug" in resp:
             nodes = [resp]
-
-        if not nodes:
-            return []
 
         repos = self._process_repos(nodes)
 
@@ -243,7 +240,7 @@ class ProcessBitbucketRepos:
                 default_branch = "HEAD"
                 return default_branch
 
-            default_branch = self.service_helper._get_default_branch_name(response)
+            default_branch = self.service_helper.get_default_branch_name(response)
         return default_branch
 
     def _get_branch_timestamp(self, repo: str, ref: dict):

--- a/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/objects/cloud_bitbucket_class.py
+++ b/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/objects/cloud_bitbucket_class.py
@@ -4,6 +4,7 @@ from heimdall_repos.repo_layer_env import (
     BITBUCKET_PUBLIC_COMMIT_QUERY,
     BITBUCKET_PUBLIC_ORG_QUERY,
     BITBUCKET_PUBLIC_REPO_QUERY,
+    BITBUCKET_PUBLIC_SINGLE_REPO_QUERY,
     BITBUCKET_PUBLIC_DEFAULT_BRANCH_QUERY,
 )
 from heimdall_repos.objects.abstract_bitbucket_class import AbstractBitbucket
@@ -35,23 +36,26 @@ class CloudBitbucket(AbstractBitbucket):
             return href.split("/refs/branches/")[1]
         return None
 
+    def get_default_branch_name(self, response_dict: dict):
+        return response_dict.get("main_branch", {}).get("name", None)
+
     def construct_bitbucket_org_url(self, url: str, org: str, cursor: str) -> str:
         return Template(BITBUCKET_PUBLIC_ORG_QUERY).substitute(service_url=url, org=org, cursor=cursor)
 
     def construct_bitbucket_repo_url(self, url: str, org: str, repo: str, cursor: str) -> str:
         return Template(BITBUCKET_PUBLIC_REPO_QUERY).substitute(service_url=url, org=org, repo=repo, cursor=cursor)
 
-    def construct_bitbucket_branch_url(self, url: str, org: str, repo: str, cursor: str, default: bool = False):
-        if not default:
-            return Template(BITBUCKET_PUBLIC_BRANCH_QUERY).substitute(
-                service_url=url, org=org, repo=repo, cursor=cursor
-            )
-        return Template(BITBUCKET_PUBLIC_DEFAULT_BRANCH_QUERY).substitute(
-            service_url=url, org=org, repo=repo, cursor=cursor
-        )
+    def construct_bitbucket_branch_url(self, url: str, org: str, repo: str, cursor: str):
+        return Template(BITBUCKET_PUBLIC_BRANCH_QUERY).substitute(service_url=url, org=org, repo=repo, cursor=cursor)
 
     def construct_bitbucket_commit_url(self, url: str, org: str, repo: str, commit_id: str):
         return Template(BITBUCKET_PUBLIC_COMMIT_QUERY).substitute(service_url=url, org=org, repo=repo, commit=commit_id)
+
+    def construct_bitbucket_default_branch_url(self, url: str, org: str, repo: str):
+        return Template(BITBUCKET_PUBLIC_DEFAULT_BRANCH_QUERY).substitute(service_url=url, org=org, repo=repo)
+
+    def construct_bitbucket_single_repo_url(self, url: str, org: str, repo: str):
+        return Template(BITBUCKET_PUBLIC_SINGLE_REPO_QUERY).substitute(service_url=url, org=org, repo=repo)
 
     def get_default_cursor(self):
         return "1"

--- a/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/objects/server_v1_bitbucket_class.py
+++ b/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/objects/server_v1_bitbucket_class.py
@@ -5,6 +5,7 @@ from heimdall_repos.repo_layer_env import (
     BITBUCKET_PRIVATE_ORG_QUERY,
     BITBUCKET_PRIVATE_REPO_QUERY,
     BITBUCKET_PRIVATE_DEFAULT_BRANCH_QUERY,
+    BITBUCKET_PRIVATE_SINGLE_REPO_QUERY,
 )
 from heimdall_repos.objects.abstract_bitbucket_class import AbstractBitbucket
 
@@ -28,25 +29,28 @@ class ServerV1Bitbucket(AbstractBitbucket):
     def get_branch_name(self, ref: dict) -> str:
         return ref.get("displayId")
 
+    def get_default_branch_name(self, response_dict: dict) -> str:
+        return self.get_branch_name(response_dict)
+
     def construct_bitbucket_org_url(self, url: str, org: str, cursor: str) -> str:
         return Template(BITBUCKET_PRIVATE_ORG_QUERY).substitute(service_url=url, org=org, cursor=cursor)
 
     def construct_bitbucket_repo_url(self, url: str, org: str, repo: str, cursor: str) -> str:
         return Template(BITBUCKET_PRIVATE_REPO_QUERY).substitute(service_url=url, org=org, repo=repo, cursor=cursor)
 
-    def construct_bitbucket_branch_url(self, url: str, org: str, repo: str, cursor: str, default: bool = False):
-        if not default:
-            return Template(BITBUCKET_PRIVATE_BRANCH_QUERY).substitute(
-                service_url=url, org=org, repo=repo, cursor=cursor
-            )
-        return Template(BITBUCKET_PRIVATE_DEFAULT_BRANCH_QUERY).substitute(
-            service_url=url, org=org, repo=repo, cursor=cursor
-        )
+    def construct_bitbucket_branch_url(self, url: str, org: str, repo: str, cursor: str):
+        return Template(BITBUCKET_PRIVATE_BRANCH_QUERY).substitute(service_url=url, org=org, repo=repo, cursor=cursor)
 
     def construct_bitbucket_commit_url(self, url: str, org: str, repo: str, commit_id: str):
         return Template(BITBUCKET_PRIVATE_COMMIT_QUERY).substitute(
             service_url=url, org=org, repo=repo, commit=commit_id
         )
+
+    def construct_bitbucket_default_branch_url(self, url: str, org: str, repo: str):
+        return Template(BITBUCKET_PRIVATE_DEFAULT_BRANCH_QUERY).substitute(service_url=url, org=org, repo=repo)
+
+    def construct_bitbucket_single_repo_url(self, url: str, org: str, repo: str):
+        return Template(BITBUCKET_PRIVATE_SINGLE_REPO_QUERY).substitute(service_url=url, org=org, repo=repo)
 
     def get_default_cursor(self):
         return "0"

--- a/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/repo_layer_env.py
+++ b/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/repo_layer_env.py
@@ -10,7 +10,11 @@ BITBUCKET_PUBLIC_BRANCH_QUERY = "$service_url/repositories/$org/$repo/refs/branc
 
 BITBUCKET_PRIVATE_BRANCH_QUERY = "$service_url/projects/$org/repos/$repo/branches?start=$cursor"
 
-BITBUCKET_PUBLIC_DEFAULT_BRANCH_QUERY = "$service_url/projects/$org/repos/$repo/branches?page=$cursor"
+BITBUCKET_PUBLIC_SINGLE_REPO_QUERY = "$service_url/repositories/$org/$repo/"
+
+BITBUCKET_PRIVATE_SINGLE_REPO_QUERY = "$service_url/projects/$org/repos/$repo"
+
+BITBUCKET_PUBLIC_DEFAULT_BRANCH_QUERY = "$service_url/repositories/$org/$repo/"
 
 BITBUCKET_PRIVATE_DEFAULT_BRANCH_QUERY = "$service_url/projects/$org/repos/$repo/branches/default"
 

--- a/orchestrator/lambdas/tests/test_bitbucket_utils.py
+++ b/orchestrator/lambdas/tests/test_bitbucket_utils.py
@@ -77,10 +77,13 @@ class TestBitbucketUtils(unittest.TestCase):
             external_orgs=TEST_EXTERNAL_ORGS,
         )
 
+    @patch.object(bitbucket_utils.ProcessBitbucketRepos, "_query_bitbucket_api")
     @patch.object(bitbucket_utils.ProcessBitbucketRepos, "_get_branch_names")
-    def test_process_repos_cloud_not_private_and_external(self, get_branch_names):
+    def test_process_repos_cloud_not_private_and_external(self, get_branch_names, query_bitbucket_api):
         self.assertEqual(self.process_bitbucket_cloud._get_branch_names, get_branch_names)
+        self.assertEqual(self.process_bitbucket_cloud._query_bitbucket_api, query_bitbucket_api)
         get_branch_names.return_value = TEST_BRANCH_NAMES_RESPONSE
+        query_bitbucket_api.return_value = "main"
 
         expected_result = copy.deepcopy(EXPECTED_RESULT_PROCESS_REPOS)
         # In the test_repo_response, repo 'has-no-default-branch' is set as a public repo.
@@ -90,10 +93,13 @@ class TestBitbucketUtils(unittest.TestCase):
 
         self.assertEqual(expected_result, result)
 
+    @patch.object(bitbucket_utils.ProcessBitbucketRepos, "_query_bitbucket_api")
     @patch.object(bitbucket_utils.ProcessBitbucketRepos, "_get_branch_names")
-    def test_process_repos_cloud_pass(self, get_branch_names):
+    def test_process_repos_cloud_not_private_and_external(self, get_branch_names, query_bitbucket_api):
         self.assertEqual(self.process_bitbucket_cloud._get_branch_names, get_branch_names)
+        self.assertEqual(self.process_bitbucket_cloud._query_bitbucket_api, query_bitbucket_api)
         get_branch_names.return_value = TEST_BRANCH_NAMES_RESPONSE
+        query_bitbucket_api.return_value = "main"
 
         expected_result = copy.deepcopy(EXPECTED_RESULT_PROCESS_REPOS)
         # In the test_repo_response, repo 'has-no-default-branch' is set as a public repo.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR:
1. updates the `ProcessBitbucketRepos` library to support re-queueing branches in `Bitbucket Cloud v2`
2. Queues the default branch for scanning
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
1. `ProcessBitbucketRepos` only supports requeueing branches in [Bibtucket Server v1 ](https://docs.atlassian.com/bitbucket-server/rest/5.16.0/bitbucket-rest.html#idm8287366304). this PR extends the library to also support [Bitbucket Cloud v2](https://developer.atlassian.com/cloud/bitbucket/rest/api-group-refs/#api-repositories-workspace-repo-slug-refs-branches-name-get).

2. A scan on the default branch is triggered when the `branch` field is Null

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested locally and in a dev environment 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
