### PR TITLE
Add service field to child loggers

### DIFF
--- a/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_bitbucket.py
+++ b/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_bitbucket.py
@@ -7,9 +7,10 @@ from aws_lambda_powertools import Logger
 
 from heimdall_orgs.const import TIMEOUT
 from heimdall_utils.aws_utils import GetProxySecret
+from heimdall_utils.env import APPLICATION
 from heimdall_utils.variables import REV_PROXY_DOMAIN_SUBSTRING, REV_PROXY_SECRET_HEADER
 
-log = Logger(name=__name__, child=True)
+log = Logger(service=APPLICATION, name=__name__, child=True)
 
 
 class BitbucketOrgs:

--- a/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_gitlab.py
+++ b/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_gitlab.py
@@ -6,9 +6,10 @@ from aws_lambda_powertools import Logger
 
 from heimdall_orgs.const import TIMEOUT
 from heimdall_utils.aws_utils import GetProxySecret
+from heimdall_utils.env import APPLICATION
 from heimdall_utils.variables import REV_PROXY_DOMAIN_SUBSTRING, REV_PROXY_SECRET_HEADER
 
-log = Logger(name=__name__, child=True)
+log = Logger(service=APPLICATION, name=__name__, child=True)
 
 
 class GitlabOrgs:

--- a/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_private_github.py
+++ b/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_private_github.py
@@ -6,10 +6,11 @@ from aws_lambda_powertools import Logger
 
 from heimdall_orgs.const import TIMEOUT
 from heimdall_utils.aws_utils import GetProxySecret
+from heimdall_utils.env import APPLICATION
 from heimdall_utils.utils import JSONUtils
 from heimdall_utils.variables import REV_PROXY_DOMAIN_SUBSTRING, REV_PROXY_SECRET_HEADER
 
-log = Logger(name=__name__, child=True)
+log = Logger(service=APPLICATION, name=__name__, child=True)
 
 GITHUB_ORG_QUERY = """
 query getLogin($cursor: String) {

--- a/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/ado.py
+++ b/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/ado.py
@@ -5,7 +5,7 @@ from aws_lambda_powertools import Logger
 
 from heimdall_utils.artemis import redundant_scan_exists
 from heimdall_utils.aws_utils import queue_service_and_org
-from heimdall_utils.env import DEFAULT_API_TIMEOUT
+from heimdall_utils.env import DEFAULT_API_TIMEOUT, APPLICATION
 from heimdall_utils.utils import JSONUtils, ScanOptions, ServiceInfo
 
 API_VERSION = "6.0"
@@ -18,7 +18,7 @@ PROJECT_PAGE_SIZE = 1
 
 REF_PAGE_SIZE = 50
 
-log = Logger(name="ADORepoProcessor", child=True)
+log = Logger(service=APPLICATION, name="ADORepoProcessor", child=True)
 
 
 class ADORepoProcessor:

--- a/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/bitbucket_utils.py
+++ b/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/bitbucket_utils.py
@@ -10,10 +10,11 @@ from heimdall_repos.objects.cloud_bitbucket_class import CloudBitbucket
 from heimdall_repos.objects.server_v1_bitbucket_class import ServerV1Bitbucket
 from heimdall_utils.artemis import redundant_scan_exists
 from heimdall_utils.aws_utils import GetProxySecret, queue_service_and_org, queue_branch_and_repo
+from heimdall_utils.env import APPLICATION
 from heimdall_utils.utils import JSONUtils, ScanOptions, ServiceInfo
 from heimdall_utils.variables import REV_PROXY_DOMAIN_SUBSTRING, REV_PROXY_SECRET_HEADER
 
-log = Logger(name="ProcessBitbucketRepos", child=True)
+log = Logger(service=APPLICATION, name="ProcessBitbucketRepos", child=True)
 
 
 class ProcessBitbucketRepos:

--- a/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/github_utils.py
+++ b/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/github_utils.py
@@ -14,12 +14,12 @@ from heimdall_repos.repo_layer_env import (
 )
 from heimdall_utils.artemis import redundant_scan_exists
 from heimdall_utils.aws_utils import GetProxySecret, queue_service_and_org, queue_branch_and_repo
-from heimdall_utils.env import DEFAULT_API_TIMEOUT
+from heimdall_utils.env import DEFAULT_API_TIMEOUT, APPLICATION
 from heimdall_utils.github.app import GithubApp
 from heimdall_utils.utils import JSONUtils, ServiceInfo, ScanOptions
 from heimdall_utils.variables import REV_PROXY_DOMAIN_SUBSTRING, REV_PROXY_SECRET_HEADER
 
-log = Logger(name="ProcessGithubRepos", child=True)
+log = Logger(service=APPLICATION, name="ProcessGithubRepos", child=True)
 
 
 class ProcessGithubRepos:

--- a/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/gitlab_utils.py
+++ b/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/gitlab_utils.py
@@ -12,12 +12,12 @@ from aws_lambda_powertools import Logger
 from heimdall_repos.repo_layer_env import GITLAB_REPO_QUERY
 from heimdall_utils.artemis import redundant_scan_exists
 from heimdall_utils.aws_utils import GetProxySecret, queue_service_and_org
-from heimdall_utils.env import DEFAULT_API_TIMEOUT
+from heimdall_utils.env import DEFAULT_API_TIMEOUT, APPLICATION
 from heimdall_utils.utils import JSONUtils, ServiceInfo, ScanOptions
 from heimdall_utils.variables import REV_PROXY_DOMAIN_SUBSTRING, REV_PROXY_SECRET_HEADER
 
 
-log = Logger(name="ProcessGitlabRepos", child=True)
+log = Logger(service=APPLICATION, name="ProcessGitlabRepos", child=True)
 
 
 class ProcessGitlabRepos:

--- a/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/objects/cloud_bitbucket_class.py
+++ b/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/objects/cloud_bitbucket_class.py
@@ -9,8 +9,9 @@ from heimdall_repos.repo_layer_env import (
     BITBUCKET_PUBLIC_DEFAULT_BRANCH_QUERY,
 )
 from heimdall_repos.objects.abstract_bitbucket_class import AbstractBitbucket
+from heimdall_utils.env import APPLICATION
 
-log = Logger(name="CloudBitbucket", child=True)
+log = Logger(service=APPLICATION, name="CloudBitbucket", child=True)
 
 
 class CloudBitbucket(AbstractBitbucket):

--- a/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/objects/server_v1_bitbucket_class.py
+++ b/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/objects/server_v1_bitbucket_class.py
@@ -9,8 +9,9 @@ from heimdall_repos.repo_layer_env import (
     BITBUCKET_PRIVATE_SINGLE_REPO_QUERY,
 )
 from heimdall_repos.objects.abstract_bitbucket_class import AbstractBitbucket
+from heimdall_utils.env import APPLICATION
 
-log = Logger(name="ServerBitbucket", child=True)
+log = Logger(service=APPLICATION, name="ServerBitbucket", child=True)
 
 
 class ServerV1Bitbucket(AbstractBitbucket):

--- a/orchestrator/lambdas/layers/heimdall_utils/heimdall_utils/artemis.py
+++ b/orchestrator/lambdas/layers/heimdall_utils/heimdall_utils/artemis.py
@@ -5,9 +5,9 @@ from http import HTTPStatus
 import requests
 from aws_lambda_powertools import Logger
 
-from heimdall_utils.env import ARTEMIS_API, DEFAULT_API_TIMEOUT
+from heimdall_utils.env import APPLICATION, ARTEMIS_API, DEFAULT_API_TIMEOUT
 
-LOG = Logger(name=__name__, child=True)
+LOG = Logger(service=APPLICATION, name=__name__, child=True)
 
 
 def redundant_scan_exists(

--- a/orchestrator/lambdas/layers/heimdall_utils/heimdall_utils/aws_utils.py
+++ b/orchestrator/lambdas/layers/heimdall_utils/heimdall_utils/aws_utils.py
@@ -10,7 +10,7 @@ from aws_lambda_powertools import Logger
 from heimdall_utils.env import APPLICATION, DEFAULT_API_TIMEOUT
 from heimdall_utils.variables import REGION, REV_PROXY_SECRET, REV_PROXY_SECRET_REGION
 
-log = Logger(name=__name__, child=True)
+log = Logger(service=APPLICATION, name=__name__, child=True)
 
 
 def get_sqs_connection(region):

--- a/orchestrator/lambdas/layers/heimdall_utils/heimdall_utils/get_services.py
+++ b/orchestrator/lambdas/layers/heimdall_utils/heimdall_utils/get_services.py
@@ -4,9 +4,10 @@ import os
 from aws_lambda_powertools import Logger
 
 from heimdall_utils.aws_utils import get_s3_connection
+from heimdall_utils.env import APPLICATION
 from heimdall_utils.variables import ARTEMIS_S3_BUCKET, REGION, ROOT_DIR
 
-log = Logger(name=__name__, child=True)
+log = Logger(service=APPLICATION, name=__name__, child=True)
 
 
 def _get_services_from_file(service_file):

--- a/orchestrator/lambdas/layers/heimdall_utils/heimdall_utils/github/app.py
+++ b/orchestrator/lambdas/layers/heimdall_utils/heimdall_utils/github/app.py
@@ -7,6 +7,7 @@ from aws_lambda_powertools import Logger
 
 from heimdall_utils.aws_utils import get_key
 from heimdall_utils.datetime import get_utc_datetime
+from heimdall_utils.env import APPLICATION
 
 GITHUB_APP_ID = os.environ.get("HEIMDALL_GITHUB_APP_ID")
 GITHUB_PRIVATE_KEY = os.environ.get("HEIMDALL_GITHUB_PRIVATE_KEY", "heimdall/github-app-private-key")
@@ -27,7 +28,7 @@ class GithubApp:
 
         if cls._instance is None:
             cls._instance = super(GithubApp, cls).__new__(cls)
-            cls._instance.log = Logger(name=__name__, child=True)
+            cls._instance.log = Logger(service=APPLICATION, name=__name__, child=True)
 
             cls._jwt = None
             cls._jwt_expiration = None

--- a/orchestrator/lambdas/repo_scan/repo_scan/aws_connect.py
+++ b/orchestrator/lambdas/repo_scan/repo_scan/aws_connect.py
@@ -6,11 +6,12 @@ from botocore.exceptions import ClientError
 from aws_lambda_powertools import Logger
 
 from heimdall_utils.aws_utils import get_dynamodb_connection, get_sqs_connection
+from heimdall_utils.env import APPLICATION
 
 REGION = os.environ.get("REGION", "us-east-2")
 RETRY_EXCEPTIONS = ["ProvisionedThroughputExceededException", "ThrottlingException"]
 
-log = Logger(name=__name__, child=True)
+log = Logger(service=APPLICATION, name=__name__, child=True)
 
 
 def get_queue_size(repo_queue: str):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The logs from child loggers do not have the additional keys declared in top level loggers([org_queue.py](https://github.com/WarnerMedia/artemis/blob/main/orchestrator/lambdas/org_queue/org_queue/org_queue.py#L23), [repo_queue.py](https://github.com/WarnerMedia/artemis/blob/main/orchestrator/lambdas/repo_queue/repo_queue/repo_queue.py#L18) etc...)

Adding the `service` field registers the child loggers to the right service

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested in a dev environment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Pic
![Embed something funny here](https://giphy.com/trending-gifs)