### PR TITLE
Enable grouped Dependabot PRs for GitHub Actions

### DIFF
--- a/.github/.dependabot
+++ b/.github/.dependabot
@@ -1,0 +1,20 @@
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        # Group together updates from common, official sources.
+        applies-to: version-updates
+        dependency-type: production
+        patterns:
+          - "actions/*"
+          - "aws-actions/*"
+          - "docker/*"
+          - "hashicorp/*"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Description

This enables generating PRs by Dependabot for updates to the GitHub Actions workflows.

To keep the number of PRs low, we group all updates from common low-risk official sources into a single PR.  This makes it easier to review and merge during our biweekly dependency update cycle.

We are only focusing on GitHub Actions for now since we pin to version hashes in our workflows, which is difficult to do correctly manually.

## Motivation and Context

Dependabot can generate PRs for updates. Currently, we are only doing this for security updates, and only generate them manually from the Dependabot alerts.

We aim to update our dependencies on a biweekly cadence, and GitHub Actions workflows are particularly difficult since we pin versions by hash.  Dependabot recognizes this style and generates PRs to match.

Using the grouping feature, this will generate a single PR that contains all of the release notes of affected low-risk updates in a single PR that can be reviewed and tested together rather than individually for each action.

## How Has This Been Tested?

A similar configuration has been tested in a separate private repository for several weeks, with good results.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
