### PR TITLE
Update default timestamp

### DIFF
--- a/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/ado.py
+++ b/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/ado.py
@@ -6,7 +6,7 @@ from aws_lambda_powertools import Logger
 from heimdall_utils.artemis import redundant_scan_exists
 from heimdall_utils.aws_utils import queue_service_and_org
 from heimdall_utils.env import DEFAULT_API_TIMEOUT, APPLICATION
-from heimdall_utils.utils import JSONUtils, ScanOptions, ServiceInfo
+from heimdall_utils.utils import JSONUtils, ScanOptions, ServiceInfo, parse_timestamp
 
 API_VERSION = "6.0"
 CONTINUATION_HEADER = "x-ms-continuationtoken"
@@ -177,7 +177,8 @@ class ADORepoProcessor:
     def _get_commit_timestamp(self, project: str, repo: str, commit_id: str) -> str:
         """Get the timestamp for a commit"""
         resp = self._query_api(query=f"{project}/_apis/git/repositories/{repo}/commits/{commit_id}")
-        return resp.get("committer", {}).get("date", "1970-01-01T00:00:00Z")
+        timestamp = resp.get("committer", {}).get("date")
+        return parse_timestamp(timestamp)
 
     def _query_api(self, query: str, params: dict = None) -> dict:
         """Generic Azure API query method"""

--- a/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/bitbucket_utils.py
+++ b/orchestrator/lambdas/layers/heimdall_repos/heimdall_repos/bitbucket_utils.py
@@ -11,7 +11,7 @@ from heimdall_repos.objects.server_v1_bitbucket_class import ServerV1Bitbucket
 from heimdall_utils.artemis import redundant_scan_exists
 from heimdall_utils.aws_utils import GetProxySecret, queue_service_and_org, queue_branch_and_repo
 from heimdall_utils.env import APPLICATION
-from heimdall_utils.utils import JSONUtils, ScanOptions, ServiceInfo
+from heimdall_utils.utils import JSONUtils, ScanOptions, ServiceInfo, parse_timestamp
 from heimdall_utils.variables import REV_PROXY_DOMAIN_SUBSTRING, REV_PROXY_SECRET_HEADER
 
 log = Logger(service=APPLICATION, name="ProcessBitbucketRepos", child=True)
@@ -127,7 +127,8 @@ class ProcessBitbucketRepos:
 
         if self.scan_options.default_branch_only:
             branch_names = [default_branch]
-            timestamp = timestamps.get(default_branch, "1970-01-01T00:00:00Z")
+            timestamp = timestamps.get(default_branch)
+            timestamp = parse_timestamp(timestamp)
             timestamps = {default_branch: timestamp}
 
         for branch in branch_names:
@@ -188,7 +189,7 @@ class ProcessBitbucketRepos:
         response_dict = self.json_utils.get_json_from_response(response_text)
 
         if not response_dict:
-            log.warning("Unable to process branches in repo %s/%s", self.service_info.org, repo)
+            log.warning("Unable to process branches in repo %s/%s", self.service_info.org, repo, repo=repo)
             return list(ref_names), timestamps
 
         repo_refs = response_dict.get("values", [])
@@ -240,7 +241,12 @@ class ProcessBitbucketRepos:
             response = self._query_bitbucket_api(url)
             response = self.json_utils.get_json_from_response(response)
             if not response:
-                log.warning("Unable to retrieve Default Branch for repo: %s/%s", self.service_info.org, repo_name)
+                log.warning(
+                    "Unable to retrieve Default Branch for repo: %s/%s",
+                    self.service_info.org,
+                    repo_name,
+                    repo=repo_name,
+                )
                 default_branch = "HEAD"
                 return default_branch
 
@@ -256,7 +262,7 @@ class ProcessBitbucketRepos:
 
         commit_id = ref.get("latestCommit", None)
         if not commit_id:
-            return "1970-01-01T00:00:00Z"
+            return parse_timestamp()
 
         commit_url = self.service_helper.construct_bitbucket_commit_url(
             self.service_info.url, self.service_info.org, repo, commit_id

--- a/orchestrator/lambdas/repo_queue/repo_queue/repo_queue.py
+++ b/orchestrator/lambdas/repo_queue/repo_queue/repo_queue.py
@@ -79,7 +79,7 @@ def query(
     repo: str,
 ) -> list:
     """Retrieves a list of repository events to send to the Repo SQS Queue"""
-    log.append_keys(version_control_service=service, org=org, batch_id=batch_id, page=page)
+    log.append_keys(version_control_service=service, org=org, batch_id=batch_id, page=page, repo=repo)
     if not service_dict:
         log.error(f"Service {service} was not found and therefore deemed unsupported")
         return []


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add a function to generate the default timestamp for a date exactly 3 months prior to the current date and time.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
If a query does not have a timestamp in the response object, A default timestamp of "1970-01-01T00:00:00Z" is used. This PR updates the default timestamp to a date thats 3 months prior from the current date and time. And alerts when the default timestamp is used

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested in a dev environment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

## Pic
![Embed something funny here](https://giphy.com/trending-gifs)