### PR TITLE
Add plugin for Trufflehog v3

### DIFF
--- a/backend/Dockerfiles/Dockerfile.dind
+++ b/backend/Dockerfiles/Dockerfile.dind
@@ -5,6 +5,8 @@ LABEL maintainer=$MAINTAINER
 
 ARG TRIVY_VER=v0.49.1
 ARG TRIVY_COMMIT=6ccc0a554b07b05fd049f882a1825a0e1e0aabe1
+ARG TRUFFLEHOG_VER=v3.79.0
+ARG TRUFFLEHOG_COMMIT=f37f2eff68c31620fd88bc37ff2b7d57ea0c700c
 ARG SNYK_VER=v1.889.0
 ARG SNYK_FLAG
 
@@ -28,11 +30,13 @@ RUN apk update && apk add git unzip python3 py3-pip libgcc libstdc++ && \
     pip3 install /src/artemisdb && \
     rm -r /src
 
+RUN wget -O - https://raw.githubusercontent.com/trufflesecurity/trufflehog/$TRUFFLEHOG_COMMIT/scripts/install.sh | sh -s -- -b /usr/local/bin $TRUFFLEHOG_VER
+
 RUN if [ "${SNYK_FLAG}" = "true" ]; then \
-        wget https://github.com/snyk/snyk/releases/download/$SNYK_VER/snyk-alpine && \
-        wget https://github.com/snyk/snyk/releases/download/$SNYK_VER/snyk-alpine.sha256 && \
-        sha256sum -c snyk-alpine.sha256 && \
-        rm snyk-alpine.sha256 && \
-        mv snyk-alpine snyk && \
-        install snyk /usr/local/bin/; \
+    wget https://github.com/snyk/snyk/releases/download/$SNYK_VER/snyk-alpine && \
+    wget https://github.com/snyk/snyk/releases/download/$SNYK_VER/snyk-alpine.sha256 && \
+    sha256sum -c snyk-alpine.sha256 && \
+    rm snyk-alpine.sha256 && \
+    mv snyk-alpine snyk && \
+    install snyk /usr/local/bin/; \
     fi;

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+SpirunnerHELL := /bin/bash
 
 ###############################################################################
 # Output formatting helpers
@@ -208,6 +208,10 @@ PHP_SCANNER_VER := 1.0.0
 # Trivy
 TRIVY_COMMIT := 6ccc0a554b07b05fd049f882a1825a0e1e0aabe1
 TRIVY_VER := v0.49.1
+
+# Trufflehog Version
+TRUFFLEHOG_COMMIT := f37f2eff68c31620fd88bc37ff2b7d57ea0c700c
+TRUFFLEHOG_VER := 3.79.0
 
 # Snyk
 SNYK_VER := v1.889.0
@@ -519,6 +523,8 @@ dist/docker/dind: Dockerfiles/Dockerfile.dind
 		--build-arg MAINTAINER=${MAINTAINER} \
 		--build-arg TRIVY_VER=${TRIVY_VER} \
 		--build-arg TRIVY_COMMIT=${TRIVY_COMMIT} \
+		--build-arg TRUFFLEHOG_VER=${TRUFFLEHOG_VER} \
+		--build-arg TRUFFLEHOG_COMMIT=${TRUFFLEHOG_COMMIT} \
 		--build-arg SNYK_VER=${SNYK_VER} \
 		--build-arg SNYK_FLAG=${SNYK_FLAG}
 	mkdir -p ${DIST_DIR}/docker

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -1,4 +1,4 @@
-SpirunnerHELL := /bin/bash
+SHELL := /bin/bash
 
 ###############################################################################
 # Output formatting helpers

--- a/backend/engine/plugins/truffle_hog/settings.json
+++ b/backend/engine/plugins/truffle_hog/settings.json
@@ -1,5 +1,5 @@
 {
-    "name": "TruffleHog Scanner",
+    "name": "Trufflehog (Legacy) Scanner",
     "type": "secrets",
     "image": "$ECR/artemis/python:3-latest"
 }

--- a/backend/engine/plugins/trufflehog/main.py
+++ b/backend/engine/plugins/trufflehog/main.py
@@ -17,11 +17,7 @@ def main(in_args=None):
         in_args,
     )
 
-    error_dict = {
-        "errors": [],
-        "alerts": [],
-        "debug": []
-    } 
+    error_dict = {"errors": [], "alerts": [], "debug": []}
 
     scan_results = run_security_checker(args.path, error_dict, depth=args.engine_vars.get("depth"))
     cleaned_results = scrub_results(scan_results, error_dict)

--- a/backend/engine/plugins/trufflehog/main.py
+++ b/backend/engine/plugins/trufflehog/main.py
@@ -17,8 +17,14 @@ def main(in_args=None):
         in_args,
     )
 
-    scan_results = run_security_checker(args.path, depth=args.engine_vars.get("depth"))
-    cleaned_results = scrub_results(scan_results)
+    error_dict = {
+        "errors": [],
+        "alerts": [],
+        "debug": []
+    } 
+
+    scan_results = run_security_checker(args.path, error_dict, depth=args.engine_vars.get("depth"))
+    cleaned_results = scrub_results(scan_results, error_dict)
 
     # Print the results to stdout
     print(
@@ -27,20 +33,23 @@ def main(in_args=None):
                 "success": not cleaned_results["results"],
                 "details": cleaned_results["results"],
                 "event_info": cleaned_results["event_info"],
+                "errors": error_dict["errors"],
+                "alerts": error_dict["alerts"],
+                "debug": error_dict["debug"],
             }
         )
     )
 
 
 def get_source_metadata(finding):
-    return finding.get("SourceMetadata", {}).get("Data", {}).get("Git", None) 
+    return finding.get("SourceMetadata", {}).get("Data", {}).get("Git", None)
 
 
 def get_finding_type(finding):
     return finding.get("DetectorName").lower()
 
 
-def scrub_results(scan_results: list) -> list:
+def scrub_results(scan_results: list, error_dict: dict) -> list:
     cleaned_records = []
     event_info = {}
     allowlist = SystemAllowList(al_type="secret")
@@ -48,6 +57,12 @@ def scrub_results(scan_results: list) -> list:
     for record in scan_results:
         add_to_list = True
         source_metadata = get_source_metadata(record)
+
+        if not source_metadata:
+            source_metadata_str = json.dumps(record.get("SourceMetadata", "No SourceMetadata"))
+            error_dict["errors"].append(f"Could not get SourceMetadata of record. Metadata is: {source_metadata_str}")
+            continue
+
         path = source_metadata.get("file")
 
         for prefix in STARTS:
@@ -76,13 +91,13 @@ def scrub_results(scan_results: list) -> list:
                 "author-timestamp": source_metadata.get("timestamp"),
             }
 
-            event_info[item_id] = {"match": [ finding_raw ], "type": record_json["type"]}
+            event_info[item_id] = {"match": [finding_raw], "type": record_json["type"]}
             cleaned_records.append(record_json)
 
     return {"results": cleaned_records, "event_info": event_info}
 
 
-def run_security_checker(scan_path: str, depth=None) -> list:
+def run_security_checker(scan_path: str, error_dict: dict, depth=None) -> list:
     log.info("Running trufflehog (depth limit: %s)", depth)
 
     if depth:

--- a/backend/engine/plugins/trufflehog/main.py
+++ b/backend/engine/plugins/trufflehog/main.py
@@ -1,8 +1,6 @@
 import json
 import subprocess
-import sys
 import uuid
-from copy import copy
 
 from engine.plugins.lib import utils
 from engine.plugins.lib.common.system.allowlist import SystemAllowList
@@ -11,7 +9,7 @@ ENDS = {"lock", "lock.json", "DEPS"}
 STARTS = {"vendor"}
 
 
-log = utils.setup_logging("trufflehog_v3")
+log = utils.setup_logging("trufflehog")
 
 
 def main(in_args=None):
@@ -85,7 +83,7 @@ def scrub_results(scan_results: list) -> list:
 
 
 def run_security_checker(scan_path: str, depth=None) -> list:
-    log.info("Running trufflehog_v3 (depth limit: %s)", depth)
+    log.info("Running trufflehog (depth limit: %s)", depth)
 
     if depth:
         cmd = [

--- a/backend/engine/plugins/trufflehog/main.py
+++ b/backend/engine/plugins/trufflehog/main.py
@@ -30,16 +30,6 @@ def main(in_args=None):
                 "details": cleaned_results["results"],
                 "event_info": cleaned_results["event_info"],
             }
-        ), file=sys.stderr
-    )
-    # Print the results to stdout
-    print(
-        json.dumps(
-            {
-                "success": not cleaned_results["results"],
-                "details": cleaned_results["results"],
-                "event_info": cleaned_results["event_info"],
-            }
         )
     )
 

--- a/backend/engine/plugins/trufflehog/settings.json
+++ b/backend/engine/plugins/trufflehog/settings.json
@@ -1,5 +1,5 @@
 {
-    "name": "TruffleHog v3 Scanner",
+    "name": "Trufflehog Scanner",
     "type": "secrets",
     "image": "$ECR/artemis/dind:latest"
 }

--- a/backend/engine/plugins/trufflehog_v3/main.py
+++ b/backend/engine/plugins/trufflehog_v3/main.py
@@ -1,0 +1,127 @@
+import json
+import subprocess
+import sys
+import uuid
+from copy import copy
+
+from engine.plugins.lib import utils
+from engine.plugins.lib.common.system.allowlist import SystemAllowList
+
+ENDS = {"lock", "lock.json", "DEPS"}
+STARTS = {"vendor"}
+
+
+log = utils.setup_logging("trufflehog_v3")
+
+
+def main(in_args=None):
+    args = utils.parse_args(
+        in_args,
+    )
+
+    scan_results = run_security_checker(args.path, depth=args.engine_vars.get("depth"))
+    cleaned_results = scrub_results(scan_results)
+
+    # Print the results to stdout
+    print(
+        json.dumps(
+            {
+                "success": not cleaned_results["results"],
+                "details": cleaned_results["results"],
+                "event_info": cleaned_results["event_info"],
+            }
+        ), file=sys.stderr
+    )
+    # Print the results to stdout
+    print(
+        json.dumps(
+            {
+                "success": not cleaned_results["results"],
+                "details": cleaned_results["results"],
+                "event_info": cleaned_results["event_info"],
+            }
+        )
+    )
+
+
+def get_source_metadata(finding):
+    return finding.get("SourceMetadata", {}).get("Data", {}).get("Git", None) 
+
+
+def get_finding_type(finding):
+    return finding.get("DetectorName").lower()
+
+
+def scrub_results(scan_results: list) -> list:
+    cleaned_records = []
+    event_info = {}
+    allowlist = SystemAllowList(al_type="secret")
+
+    for record in scan_results:
+        add_to_list = True
+        source_metadata = get_source_metadata(record)
+        path = source_metadata.get("file")
+
+        for prefix in STARTS:
+            if path.startswith(prefix):
+                add_to_list = False
+        for suffix in ENDS:
+            if path.endswith(suffix):
+                add_to_list = False
+
+        if add_to_list:
+            item_id = str(uuid.uuid4())
+            finding_raw = record.get("Raw")
+
+            if allowlist.ignore_secret(path, finding_raw):
+                # No matches remaining so skip the finding altogether
+                log.info("Skipping secret that matched system allowlist in file '%s'", record["path"])
+                continue
+
+            record_json = {
+                "id": item_id,
+                "filename": path,
+                "line": source_metadata.get("line"),
+                "commit": source_metadata.get("commit"),
+                "type": get_finding_type(record),
+                "author": source_metadata.get("email"),
+                "author-timestamp": source_metadata.get("timestamp"),
+            }
+
+            event_info[item_id] = {"match": [ finding_raw ], "type": record_json["type"]}
+            cleaned_records.append(record_json)
+
+    return {"results": cleaned_records, "event_info": event_info}
+
+
+def run_security_checker(scan_path: str, depth=None) -> list:
+    log.info("Running trufflehog_v3 (depth limit: %s)", depth)
+
+    if depth:
+        cmd = [
+            "trufflehog",
+            "git",
+            "--json",
+            "--no-update",
+            "--max_depth",
+            str(depth),
+            "file://.",
+        ]
+    else:
+        cmd = ["trufflehog", "git", "--json", "--no-update", "file://."]
+
+    proc_results = subprocess.run(cmd, cwd=scan_path, capture_output=True, check=False)
+
+    if proc_results.stderr:
+        log.error(proc_results.stderr.decode("utf-8"))
+
+    lines = proc_results.stdout.decode("utf-8").split("\n")
+
+    del lines[-1]
+    results = [json.loads(line) for line in lines]
+
+    return results
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/engine/plugins/trufflehog_v3/settings.json
+++ b/backend/engine/plugins/trufflehog_v3/settings.json
@@ -1,0 +1,5 @@
+{
+    "name": "TruffleHog v3 Scanner",
+    "type": "secrets",
+    "image": "$ECR/artemis/dind:latest"
+}

--- a/backend/engine/tests/test_plugin_truffle_hog.py
+++ b/backend/engine/tests/test_plugin_truffle_hog.py
@@ -1,0 +1,84 @@
+import io
+import unittest
+from contextlib import redirect_stdout
+
+from mock import MagicMock, patch
+
+from engine.plugins.lib import utils
+from engine.plugins.truffle_hog import main as truffle_hog
+
+
+class TestPluginTruffle_hog(unittest.TestCase):
+    @patch("engine.plugins.truffle_hog.main.run_security_checker")
+    @patch("engine.plugins.truffle_hog.main.scrub_results")
+    def test_main(self, mock_scrub_results, mock_security_checker):
+        test = {"results": [{"scrubbing": "bubbles"}], "event_info": {}}
+        mock_scrub_results.return_value = test
+        stdout = io.StringIO()
+        with redirect_stdout(stdout):
+            truffle_hog.main([])
+        actual = stdout.getvalue()
+        expected = '{"success": false, "details": [{"scrubbing": "bubbles"}], "event_info": {}}\n'
+
+        self.assertEqual(actual, expected)
+
+    @patch("engine.plugins.truffle_hog.main.subprocess")
+    def test_run_security_checker(self, subproc):
+        test = (
+            b'{"branch": "master", "commit": "ab", "commitHash":"1", ' b'"date": "1-1-19", "diff": "changed_stuff"}\n'
+        )
+        mock_output = MagicMock()
+        mock_output.stdout = test
+        subproc.run.return_value = mock_output
+        actual = truffle_hog.run_security_checker(utils.CODE_DIRECTORY)
+        expected = [{"branch": "master", "commit": "ab", "commitHash": "1", "date": "1-1-19", "diff": "changed_stuff"}]
+        self.assertEqual(actual, expected)
+
+    @patch("engine.plugins.truffle_hog.main.SystemAllowList._load_al")
+    def test_run_scrub_results(self, mock_load_al):
+        mock_load_al.return_value = []
+        data1 = {
+            "path": "The Pacific Crest Trail",
+            "branch": "main_library_branch",
+            "commitHash": "corned_beef_hash",
+            "stringsFound": ["YER' A STRING 'ARRY"],
+            "reason": "AWS API Key",
+            "diff": "@@ -1,1 0,1\n",
+        }
+        data2 = {
+            "path": "package.lock",
+            "branch": "master",
+            "commitHash": "1",
+            "stringsFound": ["This is the story of a string, who didn't make it into the output"],
+            "reason": "pytest",
+            "diff": "@@ -1,1 0,1\n",
+        }
+
+        data3 = {
+            "path": "vendor/home",
+            "branch": "pepsi",
+            "commitHash": "42",
+            "stringsFound": ["an off brand coke."],
+            "reason": "pytest",
+            "diff": "@@ -1,1 0,1\n",
+        }
+
+        def fake_commit_author(scan_path, commit):
+            return ("test@example.com", "2020-01-01T00:00:00.000000+00:00")
+
+        truffle_hog.commit_author = fake_commit_author
+        test = [data1, data2, data3]
+        actual = truffle_hog.scrub_results(test, ".")
+        expected1 = {
+            "id": actual["results"][0]["id"],
+            "filename": "The Pacific Crest Trail",
+            "line": 1,
+            "commit": "corned_beef_hash",
+            "type": "aws",
+            "author": "test@example.com",
+            "author-timestamp": "2020-01-01T00:00:00.000000+00:00",
+        }
+        expected_event = {actual["results"][0]["id"]: {"match": ["YER' A STRING 'ARRY"], "type": "aws"}}
+        expected = {"results": [expected1], "event_info": expected_event}
+
+        self.assertEqual(actual, expected)

--- a/backend/engine/tests/test_plugin_trufflehog.py
+++ b/backend/engine/tests/test_plugin_trufflehog.py
@@ -15,7 +15,7 @@ EXAMPLE_FINDING = {
     "SourceMetadata": {
         "Data": {
             "Git": {
-                "link": "https://example.com/example/example/blob/abcdef01234567890abcdef01234567890abcdef/exampmle.py#L1",
+                "link": "https://example.com/example/example/blob/abcdef01234567890abcdef01234567890abcdef/example.py#L1",
                 "repository": "https://example.com/example/example.git",
                 "commit": "abcdef01234567890abcdef01234567890abcdef",
                 "email": EXAMPLE_EMAIL,
@@ -45,7 +45,7 @@ EXAMPLE_LEGIT_FINDING = {
     "SourceMetadata": {
         "Data": {
             "Git": {
-                "link": "https://example.com/example/example/blob/abcdef01234567890abcdef01234567890abcdef/exampmle.py#L1",
+                "link": "https://example.com/example/example/blob/abcdef01234567890abcdef01234567890abcdef/example.py#L1",
                 "repository": "https://example.com/example/example.git",
                 "commit": "corned_beef_hash",
                 "email": EXAMPLE_EMAIL,
@@ -75,7 +75,7 @@ EXAMPLE_LOCKFILE_FINDING = {
     "SourceMetadata": {
         "Data": {
             "Git": {
-                "link": "https://example.com/example/example/blob/abcdef01234567890abcdef01234567890abcdef/exampmle.py#L1",
+                "link": "https://example.com/example/example/blob/abcdef01234567890abcdef01234567890abcdef/example.py#L1",
                 "repository": "https://example.com/example/example.git",
                 "commit": "1",
                 "email": EXAMPLE_EMAIL,
@@ -105,7 +105,7 @@ EXAMPLE_VENDOR_FINDING = {
     "SourceMetadata": {
         "Data": {
             "Git": {
-                "link": "https://example.com/example/example/blob/abcdef01234567890abcdef01234567890abcdef/exampmle.py#L1",
+                "link": "https://example.com/example/example/blob/abcdef01234567890abcdef01234567890abcdef/example.py#L1",
                 "repository": "https://example.com/example/example.git",
                 "commit": "42",
                 "email": EXAMPLE_EMAIL,

--- a/backend/engine/tests/test_plugin_trufflehog.py
+++ b/backend/engine/tests/test_plugin_trufflehog.py
@@ -200,7 +200,7 @@ class TestPluginTrufflehog(unittest.TestCase):
             "alerts": [],
             "debug": [],
         }
-        test = [ 
+        test = [
             {
                 "SourceMetadata": {
                     "This is not an expected field": True,

--- a/backend/engine/tests/test_plugin_trufflehog.py
+++ b/backend/engine/tests/test_plugin_trufflehog.py
@@ -1,84 +1,177 @@
 import io
+import json
 import unittest
 from contextlib import redirect_stdout
 
 from mock import MagicMock, patch
 
 from engine.plugins.lib import utils
-from engine.plugins.truffle_hog import main as truffle_hog
+from engine.plugins.trufflehog import main as trufflehog
 
+EXAMPLE_EMAIL = "email@example.com"
+
+
+EXAMPLE_FINDING = {
+    "SourceMetadata": {
+        "Data": {
+            "Git": {
+                "link": "https://example.com/example/example/blob/abcdef01234567890abcdef01234567890abcdef/exampmle.py#L1",
+                "repository": "https://example.com/example/example.git",
+                "commit": "abcdef01234567890abcdef01234567890abcdef",
+                "email": EXAMPLE_EMAIL,
+                "file": "example.py",
+                "timestamp": "2021-01-01 00:00:00 +0000",
+                "line": 1,
+                "visibility": 1
+            }
+        }
+    },
+    "SourceID": 1,
+    "SourceType": 7,
+    "SourceName": "trufflehog - git",
+    "DetectorType": 17,
+    "DetectorName": "URI",
+    "DecoderName": "PLAIN",
+    "Verified": False,
+    "VerificationError": "i/o timeout",
+    "Raw": "http://abc123:abc123@example.com:6379",
+    "RawV2": "http://abc123:abc123@example.com:6379",
+    "Redacted": "http://abc123:********@example.com:6379",
+    "ExtraData": None,
+    "StructuredData": None
+}
+
+EXAMPLE_LEGIT_FINDING = {
+    "SourceMetadata": {
+        "Data": {
+            "Git": {
+                "link": "https://example.com/example/example/blob/abcdef01234567890abcdef01234567890abcdef/exampmle.py#L1",
+                "repository": "https://example.com/example/example.git",
+                "commit": "corned_beef_hash",
+                "email": EXAMPLE_EMAIL,
+                "file": "The Pacific Crest Trail",
+                "timestamp": "2021-01-01 00:00:00 +0000",
+                "line": 1,
+                "visibility": 1
+            }
+        }
+    },
+    "SourceID": 1,
+    "SourceType": 7,
+    "SourceName": "trufflehog - git",
+    "DetectorType": 17,
+    "DetectorName": "AWS API Key",
+    "DecoderName": "PLAIN",
+    "Verified": False,
+    "VerificationError": "i/o timeout",
+    "Raw": "YER' A STRING 'ARRY",
+    "RawV2": "YER' A STRING 'ARRY",
+    "Redacted": "YER A ****** 'ARRY",
+    "ExtraData": None,
+    "StructuredData": None
+}
+
+EXAMPLE_LOCKFILE_FINDING = {
+    "SourceMetadata": {
+        "Data": {
+            "Git": {
+                "link": "https://example.com/example/example/blob/abcdef01234567890abcdef01234567890abcdef/exampmle.py#L1",
+                "repository": "https://example.com/example/example.git",
+                "commit": "1",
+                "email": EXAMPLE_EMAIL,
+                "file": "package.lock",
+                "timestamp": "2021-01-01 00:00:00 +0000",
+                "line": 1,
+                "visibility": 1
+            }
+        }
+    },
+    "SourceID": 1,
+    "SourceType": 7,
+    "SourceName": "trufflehog - git",
+    "DetectorType": 17,
+    "DetectorName": "pytest",
+    "DecoderName": "PLAIN",
+    "Verified": False,
+    "VerificationError": "i/o timeout",
+    "Raw": "This is the story of a string, who didn't make it into the output",
+    "RawV2": "This is the story of a string, who didn't make it into the output",
+    "Redacted": "This is the ***** of a string, who didn't make it into the ******",
+    "ExtraData": None,
+    "StructuredData": None
+}
+
+EXAMPLE_VENDOR_FINDING = {
+    "SourceMetadata": {
+        "Data": {
+            "Git": {
+                "link": "https://example.com/example/example/blob/abcdef01234567890abcdef01234567890abcdef/exampmle.py#L1",
+                "repository": "https://example.com/example/example.git",
+                "commit": "42",
+                "email": EXAMPLE_EMAIL,
+                "file": "vendor/home",
+                "timestamp": "2021-01-01 00:00:00 +0000",
+                "line": 1,
+                "visibility": 1
+            }
+        }
+    },
+    "SourceID": 1,
+    "SourceType": 7,
+    "SourceName": "trufflehog - git",
+    "DetectorType": 17,
+    "DetectorName": "pytest",
+    "DecoderName": "PLAIN",
+    "Verified": False,
+    "VerificationError": "i/o timeout",
+    "Raw": "an off brand coke",
+    "RawV2": "an off brand coke",
+    "Redacted": "an off brand ****",
+    "ExtraData": None,
+    "StructuredData": None
+}
 
 class TestPluginTrufflehog(unittest.TestCase):
-    @patch("engine.plugins.truffle_hog.main.run_security_checker")
-    @patch("engine.plugins.truffle_hog.main.scrub_results")
+    @patch("engine.plugins.trufflehog.main.run_security_checker")
+    @patch("engine.plugins.trufflehog.main.scrub_results")
     def test_main(self, mock_scrub_results, mock_security_checker):
         test = {"results": [{"scrubbing": "bubbles"}], "event_info": {}}
         mock_scrub_results.return_value = test
         stdout = io.StringIO()
         with redirect_stdout(stdout):
-            truffle_hog.main([])
+            trufflehog.main([])
         actual = stdout.getvalue()
         expected = '{"success": false, "details": [{"scrubbing": "bubbles"}], "event_info": {}}\n'
 
         self.assertEqual(actual, expected)
 
-    @patch("engine.plugins.truffle_hog.main.subprocess")
+    @patch("engine.plugins.trufflehog.main.subprocess")
     def test_run_security_checker(self, subproc):
-        test = (
-            b'{"branch": "master", "commit": "ab", "commitHash":"1", ' b'"date": "1-1-19", "diff": "changed_stuff"}\n'
-        )
+        test = f"{json.dumps(EXAMPLE_FINDING)}\n".encode('utf-8')
         mock_output = MagicMock()
         mock_output.stdout = test
         subproc.run.return_value = mock_output
-        actual = truffle_hog.run_security_checker(utils.CODE_DIRECTORY)
-        expected = [{"branch": "master", "commit": "ab", "commitHash": "1", "date": "1-1-19", "diff": "changed_stuff"}]
+        actual = trufflehog.run_security_checker(utils.CODE_DIRECTORY)
+        expected = [ EXAMPLE_FINDING ]
         self.assertEqual(actual, expected)
 
-    @patch("engine.plugins.truffle_hog.main.SystemAllowList._load_al")
+    @patch("engine.plugins.trufflehog.main.SystemAllowList._load_al")
     def test_run_scrub_results(self, mock_load_al):
         mock_load_al.return_value = []
-        data1 = {
-            "path": "The Pacific Crest Trail",
-            "branch": "main_library_branch",
-            "commitHash": "corned_beef_hash",
-            "stringsFound": ["YER' A STRING 'ARRY"],
-            "reason": "AWS API Key",
-            "diff": "@@ -1,1 0,1\n",
-        }
-        data2 = {
-            "path": "package.lock",
-            "branch": "master",
-            "commitHash": "1",
-            "stringsFound": ["This is the story of a string, who didn't make it into the output"],
-            "reason": "pytest",
-            "diff": "@@ -1,1 0,1\n",
-        }
 
-        data3 = {
-            "path": "vendor/home",
-            "branch": "pepsi",
-            "commitHash": "42",
-            "stringsFound": ["an off brand coke."],
-            "reason": "pytest",
-            "diff": "@@ -1,1 0,1\n",
-        }
-
-        def fake_commit_author(scan_path, commit):
-            return ("test@example.com", "2020-01-01T00:00:00.000000+00:00")
-
-        truffle_hog.commit_author = fake_commit_author
-        test = [data1, data2, data3]
-        actual = truffle_hog.scrub_results(test, ".")
+        test = [ EXAMPLE_LEGIT_FINDING, EXAMPLE_LOCKFILE_FINDING, EXAMPLE_VENDOR_FINDING ]
+        actual = trufflehog.scrub_results(test)
+        expected_type = EXAMPLE_LEGIT_FINDING.get("DetectorName").lower()
         expected1 = {
             "id": actual["results"][0]["id"],
             "filename": "The Pacific Crest Trail",
             "line": 1,
             "commit": "corned_beef_hash",
-            "type": "aws",
-            "author": "test@example.com",
-            "author-timestamp": "2020-01-01T00:00:00.000000+00:00",
+            "type": expected_type,
+            "author": EXAMPLE_EMAIL,
+            "author-timestamp": "2021-01-01 00:00:00 +0000",
         }
-        expected_event = {actual["results"][0]["id"]: {"match": ["YER' A STRING 'ARRY"], "type": "aws"}}
+        expected_event = {actual["results"][0]["id"]: {"match": ["YER' A STRING 'ARRY"], "type": expected_type}}
         expected = {"results": [expected1], "event_info": expected_event}
 
         self.assertEqual(actual, expected)

--- a/backend/lambdas/api/repo/repo/util/const.py
+++ b/backend/lambdas/api/repo/repo/util/const.py
@@ -32,7 +32,7 @@ PLUGIN_LIST_BY_CATEGORY = {
     "secret": {
         "gitsecrets": None,
         "truffle_hog": None,
-        "trufflehog_v3": None,
+        "trufflehog": None,
     },
     "static_analysis": {
         "brakeman": None,

--- a/backend/lambdas/api/repo/repo/util/const.py
+++ b/backend/lambdas/api/repo/repo/util/const.py
@@ -29,7 +29,11 @@ PLUGIN_LIST_BY_CATEGORY = {
         "trivy": None,
         "trivy_sca": None,
     },
-    "secret": {"gitsecrets": None, "truffle_hog": None},
+    "secret": {
+        "gitsecrets": None,
+        "truffle_hog": None,
+        "trufflehog_v3": None,
+    },
     "static_analysis": {
         "brakeman": None,
         "cfn_python_lint": None,

--- a/backend/lambdas/api/repo/tests/test_parse_event.py
+++ b/backend/lambdas/api/repo/tests/test_parse_event.py
@@ -227,6 +227,7 @@ EXPECTED_EVENT_RESULT_1 = {
         "-base_images",
         "-node_dependencies",
         "-truffle_hog",
+        "-trufflehog",
         "-bundler_audit",
         "-php_sensio_security_checker",
         "-github_repo_health",

--- a/backend/lambdas/api/spec.yaml
+++ b/backend/lambdas/api/spec.yaml
@@ -2079,7 +2079,7 @@ components:
               - python_code_checker
               - technology_discovery
               - truffle_hog
-              - trufflehog_v3
+              - trufflehog
               - brakeman
               - bundler_audit
               - bandit

--- a/backend/lambdas/api/spec.yaml
+++ b/backend/lambdas/api/spec.yaml
@@ -2079,6 +2079,7 @@ components:
               - python_code_checker
               - technology_discovery
               - truffle_hog
+              - trufflehog_v3
               - brakeman
               - bundler_audit
               - bandit

--- a/ui/src/api/__tests__/client.test.ts
+++ b/ui/src/api/__tests__/client.test.ts
@@ -290,7 +290,7 @@ describe("api client", () => {
 				expect.objectContaining({
 					data: expect.objectContaining({
 						categories: categories,
-						plugins: ["-ghas_secrets", "-truffle_hog"],
+						plugins: ["-ghas_secrets", "-truffle_hog", "-trufflehog"],
 					}),
 					url: `${data.vcsOrg}/${data.repo}`,
 				})

--- a/ui/src/app/scanPlugins.ts
+++ b/ui/src/app/scanPlugins.ts
@@ -59,8 +59,13 @@ export const secretPluginsKeys: ScanPluginKeys = {
 		group: GROUP_SECRETS,
 	},
 	truffle_hog: {
-		displayName: t`Truffle Hog`,
+		displayName: t`Trufflehog (Legacy)`,
 		apiName: "truffle_hog",
+		group: GROUP_SECRETS,
+	},
+	trufflehog: {
+		displayName: t`Trufflehog`,
+		apiName: "trufflehog",
 		group: GROUP_SECRETS,
 	},
 };

--- a/ui/src/locale/en/messages.po
+++ b/ui/src/locale/en/messages.po
@@ -97,7 +97,7 @@ msgstr "This should not be a real secret"
 msgid "View in external site"
 msgstr "View in external site"
 
-#: src/pages/UsersPage.tsx:1326
+#: src/pages/UsersPage.tsx:1324
 msgid "No users found. Click the + button to add a new user"
 msgstr "No users found. Click the + button to add a new user"
 
@@ -199,7 +199,7 @@ msgstr "Meta Data Sample1 / Sample2"
 #: src/components/EnhancedTable.tsx:760
 #: src/pages/SearchPage.tsx:1944
 #: src/pages/SearchPage.tsx:4131
-#: src/pages/UsersPage.tsx:1324
+#: src/pages/UsersPage.tsx:1322
 msgid "No results match current filters"
 msgstr "No results match current filters"
 
@@ -275,7 +275,7 @@ msgstr "Remove User"
 msgid "Name must be less than {NAME_LENGTH} characters"
 msgstr "Name must be less than {NAME_LENGTH} characters"
 
-#: src/pages/UsersPage.tsx:1328
+#: src/pages/UsersPage.tsx:1326
 msgid "Fetching users..."
 msgstr "Fetching users..."
 
@@ -285,7 +285,7 @@ msgstr "Component name required"
 
 #: src/pages/ResultsPage.tsx:2004
 #: src/pages/UserSettings.tsx:1839
-#: src/pages/UsersPage.tsx:1177
+#: src/pages/UsersPage.tsx:1175
 msgid "Adding..."
 msgstr "Adding..."
 
@@ -351,7 +351,7 @@ msgid "Artemis - User Management"
 msgstr "Artemis - User Management"
 
 #: src/pages/UserSettings.tsx:1727
-#: src/pages/UsersPage.tsx:1106
+#: src/pages/UsersPage.tsx:1104
 msgid "Add to scope"
 msgstr "Add to scope"
 
@@ -385,8 +385,8 @@ msgid "This scan option was not used"
 msgstr "This scan option was not used"
 
 #: src/app/scanPlugins.ts:62
-msgid "Truffle Hog"
-msgstr "Truffle Hog"
+#~ msgid "Truffle Hog"
+#~ msgstr "Truffle Hog"
 
 #: src/components/StatusCell.tsx:730
 msgid "Failed"
@@ -471,7 +471,7 @@ msgstr "Queued"
 msgid "Report Sections Tabs"
 msgstr "Report Sections Tabs"
 
-#: src/app/scanPlugins.ts:185
+#: src/app/scanPlugins.ts:190
 msgid "Snyk"
 msgstr "Snyk"
 
@@ -481,7 +481,7 @@ msgstr "Snyk"
 msgid "Search"
 msgstr "Search"
 
-#: src/app/scanPlugins.ts:85
+#: src/app/scanPlugins.ts:90
 msgid "Checkov (IaC)"
 msgstr "Checkov (IaC)"
 
@@ -530,7 +530,7 @@ msgstr "Component/commit must be less than {COMPONENT_LENGTH} characters"
 msgid "Must be a past date"
 msgstr "Must be a past date"
 
-#: src/app/scanPlugins.ts:75
+#: src/app/scanPlugins.ts:80
 msgid "Bandit (Python)"
 msgstr "Bandit (Python)"
 
@@ -558,7 +558,7 @@ msgstr "Start a new scan using the same options used in this scan?<0/>Initiating
 msgid "GitHub Advanced Security Secrets"
 msgstr "GitHub Advanced Security Secrets"
 
-#: src/app/scanPlugins.ts:130
+#: src/app/scanPlugins.ts:135
 msgid "Shell Check (Shell)"
 msgstr "Shell Check (Shell)"
 
@@ -682,7 +682,7 @@ msgid "Unknown"
 msgstr "Unknown"
 
 #: src/pages/ResultsPage.tsx:2001
-#: src/pages/UsersPage.tsx:1180
+#: src/pages/UsersPage.tsx:1178
 msgid "Update"
 msgstr "Update"
 
@@ -694,11 +694,11 @@ msgstr "Before"
 msgid "May only contain the characters: A-Z, a-z, 0-9, ., -, _, /"
 msgstr "May only contain the characters: A-Z, a-z, 0-9, ., -, _, /"
 
-#: src/app/scanPlugins.ts:120
+#: src/app/scanPlugins.ts:125
 msgid "NodeJS Scan (NodeJS)"
 msgstr "NodeJS Scan (NodeJS)"
 
-#: src/app/scanPlugins.ts:125
+#: src/app/scanPlugins.ts:130
 msgid "Pylint (Python)"
 msgstr "Pylint (Python)"
 
@@ -723,7 +723,7 @@ msgstr "No matching scans to display"
 #: src/pages/UserSettings.tsx:927
 #: src/pages/UserSettings.tsx:2050
 #: src/pages/UserSettings.tsx:2058
-#: src/pages/UsersPage.tsx:896
+#: src/pages/UsersPage.tsx:894
 msgid "Administrator"
 msgstr "Administrator"
 
@@ -777,11 +777,11 @@ msgstr "Restrict API key to only these repositories. Must be within a user's sca
 msgid "No License"
 msgstr "No License"
 
-#: src/pages/UsersPage.tsx:899
+#: src/pages/UsersPage.tsx:897
 msgid "Administrators can manage all other users and groups"
 msgstr "Administrators can manage all other users and groups"
 
-#: src/app/scanPlugins.ts:140
+#: src/app/scanPlugins.ts:145
 msgid "TFLint (Terraform)"
 msgstr "TFLint (Terraform)"
 
@@ -836,7 +836,7 @@ msgstr "Results may vary compared to scans run with other options. View scan res
 msgid "Remove this hidden finding? This finding will again appear in scan results for this repository."
 msgstr "Remove this hidden finding? This finding will again appear in scan results for this repository."
 
-#: src/app/scanPlugins.ts:187
+#: src/app/scanPlugins.ts:192
 msgid "Trivy Container Image"
 msgstr "Trivy Container Image"
 
@@ -857,11 +857,11 @@ msgid "Unable to get user keys"
 msgstr "Unable to get user keys"
 
 #: src/pages/UserSettings.tsx:1571
-#: src/pages/UsersPage.tsx:960
+#: src/pages/UsersPage.tsx:958
 msgid "Scope {0}"
 msgstr "Scope {0}"
 
-#: src/app/scanPlugins.ts:192
+#: src/app/scanPlugins.ts:197
 msgid "Trivy SCA"
 msgstr "Trivy SCA"
 
@@ -902,7 +902,7 @@ msgid "On-Demand Scan"
 msgstr "On-Demand Scan"
 
 #: src/pages/UserSettings.tsx:1695
-#: src/pages/UsersPage.tsx:1074
+#: src/pages/UsersPage.tsx:1072
 msgid "Click + icon to add this value to the Current Scope list above"
 msgstr "Click + icon to add this value to the Current Scope list above"
 
@@ -992,7 +992,7 @@ msgstr "No secrets found"
 msgid "Linked Accounts"
 msgstr "Linked Accounts"
 
-#: src/app/scanPlugins.ts:161
+#: src/app/scanPlugins.ts:166
 msgid "Aqua CLI Scanner (Docker)"
 msgstr "Aqua CLI Scanner (Docker)"
 
@@ -1047,7 +1047,7 @@ msgid "Allow this key to use additional scan features"
 msgstr "Allow this key to use additional scan features"
 
 #: src/pages/UserSettings.tsx:1476
-#: src/pages/UsersPage.tsx:913
+#: src/pages/UsersPage.tsx:911
 msgid "Current Scope"
 msgstr "Current Scope"
 
@@ -1061,7 +1061,7 @@ msgstr "Vulnerability Match"
 msgid "Found in source file:"
 msgstr "Found in source file:"
 
-#: src/app/scanPlugins.ts:110
+#: src/app/scanPlugins.ts:115
 msgid "FindSecBugs (Java 13)"
 msgstr "FindSecBugs (Java 13)"
 
@@ -1160,7 +1160,7 @@ msgid "After"
 msgstr "After"
 
 #: src/pages/UserSettings.tsx:1683
-#: src/pages/UsersPage.tsx:1062
+#: src/pages/UsersPage.tsx:1060
 msgid "This value has not been added to the Current Scope list above. Either click the + icon to add it or the X icon to clear the field"
 msgstr "This value has not been added to the Current Scope list above. Either click the + icon to add it or the X icon to clear the field"
 
@@ -1186,7 +1186,7 @@ msgstr "{hfCount, plural, one {{hfCount} hidden finding} other {{hfCount} hidden
 
 #: src/pages/UserSettings.tsx:740
 #: src/pages/UsersPage.tsx:542
-#: src/pages/UsersPage.tsx:1256
+#: src/pages/UsersPage.tsx:1254
 msgid "Email"
 msgstr "Email"
 
@@ -1275,7 +1275,7 @@ msgstr "Username:"
 msgid "Resource must be less than {RESOURCE_LENGTH} characters"
 msgstr "Resource must be less than {RESOURCE_LENGTH} characters"
 
-#: src/app/scanPlugins.ts:153
+#: src/app/scanPlugins.ts:158
 msgid "Enry Technology Discovery"
 msgstr "Enry Technology Discovery"
 
@@ -1297,7 +1297,7 @@ msgid "Unable to update hidden finding"
 msgstr "Unable to update hidden finding"
 
 #: src/pages/UserSettings.tsx:1585
-#: src/pages/UsersPage.tsx:974
+#: src/pages/UsersPage.tsx:972
 msgid "Remove scope {0}"
 msgstr "Remove scope {0}"
 
@@ -1331,7 +1331,7 @@ msgid "Components"
 msgstr "Components"
 
 #: src/pages/ResultsPage.tsx:1999
-#: src/pages/UsersPage.tsx:1175
+#: src/pages/UsersPage.tsx:1173
 msgid "Updating..."
 msgstr "Updating..."
 
@@ -1390,7 +1390,7 @@ msgstr "Error"
 msgid "Unable to link user service"
 msgstr "Unable to link user service"
 
-#: src/pages/UsersPage.tsx:1351
+#: src/pages/UsersPage.tsx:1349
 msgid "Users"
 msgstr "Users"
 
@@ -1443,11 +1443,11 @@ msgid "Required"
 msgstr "Required"
 
 #: src/pages/UserSettings.tsx:1731
-#: src/pages/UsersPage.tsx:1110
+#: src/pages/UsersPage.tsx:1108
 msgid "Add this item to scope"
 msgstr "Add this item to scope"
 
-#: src/app/scanPlugins.ts:95
+#: src/app/scanPlugins.ts:100
 msgid "ESlint (JavaScript)"
 msgstr "ESlint (JavaScript)"
 
@@ -1565,16 +1565,16 @@ msgstr "Teal"
 msgid "VCS/Org required"
 msgstr "VCS/Org required"
 
-#: src/app/scanPlugins.ts:171
+#: src/app/scanPlugins.ts:176
 msgid "NPM Audit (NodeJS)"
 msgstr "NPM Audit (NodeJS)"
 
 #: src/pages/UserSettings.tsx:1634
-#: src/pages/UsersPage.tsx:1012
+#: src/pages/UsersPage.tsx:1010
 msgid "Top"
 msgstr "Top"
 
-#: src/app/scanPlugins.ts:80
+#: src/app/scanPlugins.ts:85
 msgid "Brakeman (Ruby)"
 msgstr "Brakeman (Ruby)"
 
@@ -1610,7 +1610,7 @@ msgstr "Invalid date format"
 msgid "Invalid email address"
 msgstr "Invalid email address"
 
-#: src/app/scanPlugins.ts:90
+#: src/app/scanPlugins.ts:95
 msgid "Detekt (Kotlin)"
 msgstr "Detekt (Kotlin)"
 
@@ -1649,6 +1649,10 @@ msgstr "Vulnerability Raw: {count}"
 #: src/pages/SearchPage.tsx:3985
 msgid "Risk"
 msgstr "Risk"
+
+#: src/app/scanPlugins.ts:62
+msgid "Trufflehog (Legacy)"
+msgstr "Trufflehog (Legacy)"
 
 #: src/api/client.ts:174
 msgid "Not authorized"
@@ -1705,7 +1709,7 @@ msgstr "One or more file or directory paths separated by a comma or newline. Sup
 msgid "Include Paths ({0})"
 msgstr "Include Paths ({0})"
 
-#: src/app/scanPlugins.ts:115
+#: src/app/scanPlugins.ts:120
 msgid "GoSec (Golang)"
 msgstr "GoSec (Golang)"
 
@@ -1723,18 +1727,18 @@ msgstr "This will be the only time this key will be displayed! Do not close this
 msgid "Negligible"
 msgstr "Negligible"
 
-#: src/app/scanPlugins.ts:105
+#: src/app/scanPlugins.ts:110
 msgid "FindSecBugs (Java 8)"
 msgstr "FindSecBugs (Java 8)"
 
 #: src/pages/UserSettings.tsx:1096
 #: src/pages/UserSettings.tsx:1991
 #: src/pages/UsersPage.tsx:557
-#: src/pages/UsersPage.tsx:1265
+#: src/pages/UsersPage.tsx:1263
 msgid "Scope"
 msgstr "Scope"
 
-#: src/pages/UsersPage.tsx:788
+#: src/pages/UsersPage.tsx:786
 msgid "{0} {1} Plugin"
 msgstr "{0} {1} Plugin"
 
@@ -1764,8 +1768,8 @@ msgstr "Configuration: {count}"
 
 #: src/pages/UserSettings.tsx:1620
 #: src/pages/UserSettings.tsx:1631
-#: src/pages/UsersPage.tsx:999
-#: src/pages/UsersPage.tsx:1009
+#: src/pages/UsersPage.tsx:997
+#: src/pages/UsersPage.tsx:1007
 msgid "Scroll to top"
 msgstr "Scroll to top"
 
@@ -1821,7 +1825,7 @@ msgstr "{dt} / {elapsed} Elapsed"
 #: src/features/notifications/Notifications.tsx:18
 #: src/pages/ResultsPage.tsx:1215
 #: src/pages/UserSettings.tsx:1411
-#: src/pages/UsersPage.tsx:848
+#: src/pages/UsersPage.tsx:846
 msgid "error"
 msgstr "error"
 
@@ -1845,7 +1849,7 @@ msgstr "Batch Priority"
 #: src/pages/UserSettings.tsx:1852
 #: src/pages/UsersPage.tsx:525
 #: src/pages/UsersPage.tsx:532
-#: src/pages/UsersPage.tsx:1193
+#: src/pages/UsersPage.tsx:1191
 msgid "Cancel"
 msgstr "Cancel"
 
@@ -1867,7 +1871,7 @@ msgstr "No configuration findings detected"
 msgid "Moderate: {count}"
 msgstr "Moderate: {count}"
 
-#: src/app/scanPlugins.ts:100
+#: src/app/scanPlugins.ts:105
 msgid "FindSecBugs (Java 7)"
 msgstr "FindSecBugs (Java 7)"
 
@@ -1936,7 +1940,7 @@ msgstr "Close More Actions Menu"
 msgid "High: {count}"
 msgstr "High: {count}"
 
-#: src/app/scanPlugins.ts:176
+#: src/app/scanPlugins.ts:181
 msgid "OWASP Check (Java)"
 msgstr "OWASP Check (Java)"
 
@@ -1997,7 +2001,7 @@ msgstr "No repositories match current filters"
 msgid "<0><1>Hidden findings are global to this repository. They will be applied to <2>all</2> scan results for this repository (past, present, future, and for all branches), with the exception of \"Secret Raw\" types, that will only apply to future scans</1><3>Findings can be hidden on the applicable finding type scan results tab (\"Vulnerability\", \"Static Analysis\", \"Secrets\", \"Configuration\")</3><4>Once a finding is hidden, it can be viewed or managed (removed/modified) on the \"Hidden Findings\" scan results tab</4><5>Hiding a finding <6>DOES NOT</6> remediate the underlying security issue, it <7>only</7> prevents it from appearing in scan results. Hidden findings allow hiding of false-positive (F+) results or to temporarily hide a finding that does not yet have an upstream vendor fix available</5></0>"
 msgstr "<0><1>Hidden findings are global to this repository. They will be applied to <2>all</2> scan results for this repository (past, present, future, and for all branches), with the exception of \"Secret Raw\" types, that will only apply to future scans</1><3>Findings can be hidden on the applicable finding type scan results tab (\"Vulnerability\", \"Static Analysis\", \"Secrets\", \"Configuration\")</3><4>Once a finding is hidden, it can be viewed or managed (removed/modified) on the \"Hidden Findings\" scan results tab</4><5>Hiding a finding <6>DOES NOT</6> remediate the underlying security issue, it <7>only</7> prevents it from appearing in scan results. Hidden findings allow hiding of false-positive (F+) results or to temporarily hide a finding that does not yet have an upstream vendor fix available</5></0>"
 
-#: src/pages/UsersPage.tsx:871
+#: src/pages/UsersPage.tsx:869
 msgid "Email Address"
 msgstr "Email Address"
 
@@ -2016,7 +2020,7 @@ msgstr "Component license null must be either \"true\" or \"false\""
 
 #: src/pages/SearchPage.tsx:4151
 #: src/pages/UserSettings.tsx:338
-#: src/pages/UsersPage.tsx:1345
+#: src/pages/UsersPage.tsx:1343
 msgid "Back"
 msgstr "Back"
 
@@ -2033,6 +2037,10 @@ msgstr "Last Login"
 #: src/pages/SearchPage.tsx:4130
 msgid "Fetching results..."
 msgstr "Fetching results..."
+
+#: src/app/scanPlugins.ts:67
+msgid "Trufflehog"
+msgstr "Trufflehog"
 
 #: src/pages/SearchPage.tsx:2535
 msgid "License"
@@ -2215,7 +2223,7 @@ msgid "Add New API Key"
 msgstr "Add New API Key"
 
 #: src/pages/UserSettings.tsx:1654
-#: src/pages/UsersPage.tsx:1032
+#: src/pages/UsersPage.tsx:1030
 msgid "Add Scope"
 msgstr "Add Scope"
 
@@ -2258,7 +2266,7 @@ msgstr "Type:"
 msgid "yyyy/MM/dd HH:mm (24-hour)"
 msgstr "yyyy/MM/dd HH:mm (24-hour)"
 
-#: src/pages/UsersPage.tsx:921
+#: src/pages/UsersPage.tsx:919
 msgid "Restrict user to only these repositories. Must be a subset of scopes from groups user is a member of. Supports Unix-style path name pattern expansion syntax, e.g. vcs/org/repoprefix-*. * indicates all repositories."
 msgstr "Restrict user to only these repositories. Must be a subset of scopes from groups user is a member of. Supports Unix-style path name pattern expansion syntax, e.g. vcs/org/repoprefix-*. * indicates all repositories."
 
@@ -2266,7 +2274,7 @@ msgstr "Restrict user to only these repositories. Must be a subset of scopes fro
 msgid "Remediation Match"
 msgstr "Remediation Match"
 
-#: src/app/scanPlugins.ts:148
+#: src/app/scanPlugins.ts:153
 msgid "Base Images (Docker)"
 msgstr "Base Images (Docker)"
 
@@ -2289,7 +2297,7 @@ msgstr "Any"
 
 #: src/pages/ResultsPage.tsx:2006
 #: src/pages/UserSettings.tsx:1841
-#: src/pages/UsersPage.tsx:1182
+#: src/pages/UsersPage.tsx:1180
 msgid "Add"
 msgstr "Add"
 
@@ -2311,7 +2319,7 @@ msgstr "No Qualified Scans"
 msgid "Reset Filters"
 msgstr "Reset Filters"
 
-#: src/app/scanPlugins.ts:181
+#: src/app/scanPlugins.ts:186
 msgid "Sensio Security Check (PHP)"
 msgstr "Sensio Security Check (PHP)"
 
@@ -2319,7 +2327,7 @@ msgstr "Sensio Security Check (PHP)"
 msgid "Session expired, redirecting to login..."
 msgstr "Session expired, redirecting to login..."
 
-#: src/app/scanPlugins.ts:70
+#: src/app/scanPlugins.ts:75
 msgid "AWS CloudFormation Linter"
 msgstr "AWS CloudFormation Linter"
 
@@ -2384,7 +2392,7 @@ msgstr "Repositories"
 
 #: src/pages/ResultsPage.tsx:1939
 #: src/pages/UserSettings.tsx:1810
-#: src/pages/UsersPage.tsx:1146
+#: src/pages/UsersPage.tsx:1144
 msgid "This form contains unresolved errors. Please resolve these errors"
 msgstr "This form contains unresolved errors. Please resolve these errors"
 
@@ -2393,7 +2401,7 @@ msgstr "This form contains unresolved errors. Please resolve these errors"
 #: src/pages/ResultsPage.tsx:4070
 #: src/pages/ResultsPage.tsx:4360
 #: src/pages/ResultsPage.tsx:5195
-#: src/pages/UsersPage.tsx:1277
+#: src/pages/UsersPage.tsx:1275
 msgid "Clear all filters"
 msgstr "Clear all filters"
 
@@ -2693,7 +2701,7 @@ msgstr "Invalid component version matcher"
 msgid "Status"
 msgstr "Status"
 
-#: src/app/scanPlugins.ts:135
+#: src/app/scanPlugins.ts:140
 msgid "SwiftLint (Swift)"
 msgstr "SwiftLint (Swift)"
 
@@ -2712,7 +2720,7 @@ msgid "Open Table Menu"
 msgstr "Open Table Menu"
 
 #: src/pages/UserSettings.tsx:1331
-#: src/pages/UsersPage.tsx:724
+#: src/pages/UsersPage.tsx:722
 msgid "May only contain the characters: A-Z, a-z, 0-9, ., -, _, /, [, ], *, ?, !"
 msgstr "May only contain the characters: A-Z, a-z, 0-9, ., -, _, /, [, ], *, ?, !"
 
@@ -2761,7 +2769,7 @@ msgstr "Remove API key named \"{0}\"?"
 msgid "Start a new scan using the same options used in this scan?<0/>Initiating a new scan will navigate to the main scan page to display scan progress."
 msgstr "Start a new scan using the same options used in this scan?<0/>Initiating a new scan will navigate to the main scan page to display scan progress."
 
-#: src/app/scanPlugins.ts:197
+#: src/app/scanPlugins.ts:202
 msgid "Veracode SCA"
 msgstr "Veracode SCA"
 
@@ -2775,7 +2783,7 @@ msgid "{label}"
 msgstr "{label}"
 
 #: src/pages/UserSettings.tsx:1590
-#: src/pages/UsersPage.tsx:979
+#: src/pages/UsersPage.tsx:977
 msgid "Remove this scope item"
 msgstr "Remove this scope item"
 
@@ -2812,7 +2820,7 @@ msgid "Fetching secrets results..."
 msgstr "Fetching secrets results..."
 
 #: src/pages/UserSettings.tsx:1557
-#: src/pages/UsersPage.tsx:946
+#: src/pages/UsersPage.tsx:944
 msgid "No scope is currently defined"
 msgstr "No scope is currently defined"
 
@@ -2823,8 +2831,8 @@ msgstr "Must be between 1-254 characters"
 
 #: src/pages/UserSettings.tsx:1705
 #: src/pages/UserSettings.tsx:1709
-#: src/pages/UsersPage.tsx:1084
-#: src/pages/UsersPage.tsx:1088
+#: src/pages/UsersPage.tsx:1082
+#: src/pages/UsersPage.tsx:1086
 msgid "Clear"
 msgstr "Clear"
 
@@ -2832,7 +2840,7 @@ msgstr "Clear"
 msgid "End"
 msgstr "End"
 
-#: src/app/scanPlugins.ts:166
+#: src/app/scanPlugins.ts:171
 msgid "Bundler Audit (Ruby)"
 msgstr "Bundler Audit (Ruby)"
 
@@ -2935,7 +2943,7 @@ msgstr "OK"
 msgid "Unable to queue new scan"
 msgstr "Unable to queue new scan"
 
-#: src/pages/UsersPage.tsx:820
+#: src/pages/UsersPage.tsx:818
 msgid "Allow this user to use additional scan features"
 msgstr "Allow this user to use additional scan features"
 


### PR DESCRIPTION
Adds a Trufflehog v3 secrets plugin

## Description
- Adds a Trufflehog v3 secrets plugin
- Splitting off from Trufflehog v2 since the v2 custom secrets patterns are not supported in the same fashion in v3 (and there are similar analogs for all of our rules within v3)
- This PR does not surface verification status of findings. That will come later
- Changes the plain english name of the old Trufflehog plugin to `Trufflehog (Legacy)`

## Motivation and Context
- Trufflehog v3 is the latest version, but is meant to use its detectors rather than regular expressions. While it supports custom regular expressions, this support is described as "alpha", so we figured it'd be better to split off from v2.
  - That said, many of our custom regular expressions used for v2 have similar detectors in v3. We will look at data and see if it's safe to deprecate the v2 plugin if the false negative rate is low enough.

## How Has This Been Tested?
- API working locally
- UI working locally
- Tests pass locally

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
- [x] My code follows conforms to the coding standards.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Pic
![Trufflehog](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExYXFnZmNqY2FyemtoZHZycWU4dXp4eXN3OGp1a240MnJ4dWZva2xhNCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/5p3Eo0tx6FNgfCHOrA/giphy.webp)