### PR TITLE
Disable trufflehog v3 plugin

### DIFF
--- a/backend/lambdas/api/repo/repo/util/const.py
+++ b/backend/lambdas/api/repo/repo/util/const.py
@@ -92,7 +92,7 @@ QUALIFIED_PLUGINS = {
 # to be specified in a scan request as a disabled plugin and not throw an error. Specifying them as
 # an explicitly enabled plugin will return an error but a different error than if a completely unknown
 # plugin name were to be included in the request.
-DISABLED_PLUGINS = []
+DISABLED_PLUGINS = [ "trufflehog" ]
 
 # Add in plugins that can be disabled per-environment and are enabled in this environment
 if AQUA_ENABLED:

--- a/backend/lambdas/api/repo/repo/util/const.py
+++ b/backend/lambdas/api/repo/repo/util/const.py
@@ -32,7 +32,6 @@ PLUGIN_LIST_BY_CATEGORY = {
     "secret": {
         "gitsecrets": None,
         "truffle_hog": None,
-        "trufflehog": None,
     },
     "static_analysis": {
         "brakeman": None,

--- a/backend/lambdas/api/repo/repo/util/const.py
+++ b/backend/lambdas/api/repo/repo/util/const.py
@@ -91,7 +91,7 @@ QUALIFIED_PLUGINS = {
 # to be specified in a scan request as a disabled plugin and not throw an error. Specifying them as
 # an explicitly enabled plugin will return an error but a different error than if a completely unknown
 # plugin name were to be included in the request.
-DISABLED_PLUGINS = [ "trufflehog" ]
+DISABLED_PLUGINS = []
 
 # Add in plugins that can be disabled per-environment and are enabled in this environment
 if AQUA_ENABLED:

--- a/backend/lambdas/api/repo/tests/test_parse_event.py
+++ b/backend/lambdas/api/repo/tests/test_parse_event.py
@@ -227,7 +227,6 @@ EXPECTED_EVENT_RESULT_1 = {
         "-base_images",
         "-node_dependencies",
         "-truffle_hog",
-        "-trufflehog",
         "-bundler_audit",
         "-php_sensio_security_checker",
         "-github_repo_health",

--- a/ui/src/api/__tests__/client.test.ts
+++ b/ui/src/api/__tests__/client.test.ts
@@ -290,7 +290,7 @@ describe("api client", () => {
 				expect.objectContaining({
 					data: expect.objectContaining({
 						categories: categories,
-						plugins: ["-ghas_secrets", "-truffle_hog", "-trufflehog"],
+						plugins: ["-ghas_secrets", "-truffle_hog"],
 					}),
 					url: `${data.vcsOrg}/${data.repo}`,
 				})

--- a/ui/src/app/scanPlugins.ts
+++ b/ui/src/app/scanPlugins.ts
@@ -211,7 +211,9 @@ export const nonDefaultPlugins: string[] = [];
 // any enabled plugins that should be excluded (not run) by default
 export const excludePlugins: string[] = ["nodejsscan"];
 
-export const pluginsDisabled: { [name: string]: boolean } = {};
+export const pluginsDisabled: { [name: string]: boolean } = {
+	trufflehog: true,
+};
 
 if (!APP_AQUA_ENABLED) {
 	pluginsDisabled["aqua_cli_scanner"] = true;


### PR DESCRIPTION
Trufflehog v3 plugin doesn't dedupe well enough from Trufflehog v2, so this disables the plugin

## Description
- Disables trufflehog v3 plugin, since it was creating too much noise in conjunction with v2. Will re-enable once we figure out a good solution to deduping results between the two of them.

## Motivation and Context
- Artemis is useful because it dedupes between many different findings. This Trufflehog v3 plugin doesn't try to consolidate between secret "types", so it causes unacceptable noise

## How Has This Been Tested?
- Tests are passing
- Working in nonprod

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.