### PR TITLE
Fix invalid escape sequences in ShellCheck plugin

### DIFF
--- a/backend/engine/plugins/shell_check/main.py
+++ b/backend/engine/plugins/shell_check/main.py
@@ -19,8 +19,8 @@ def get_files(path):
     """
     proc = subprocess.run(
         [
-            "find . -type f \( -name '*.sh' -o -name '*.bash' -o -name '*.ksh' -o -name '*.bashrc' -o -name "
-            "'*.bash_profile' -o -name '*.bash_login' -o -name '*.bash_logout' \)"
+            "find . -type f \\( -name '*.sh' -o -name '*.bash' -o -name '*.ksh' -o -name '*.bashrc' -o -name "
+            "'*.bash_profile' -o -name '*.bash_login' -o -name '*.bash_logout' \\)"
         ],
         cwd=path,
         capture_output=True,


### PR DESCRIPTION
## Description

Fixes the invalid string escape sequences which were producing warnings.

These produced [either a DeprecationWarning or SyntaxWarning](https://docs.python.org/3/reference/lexical_analysis.html#escape-sequences), depending on the version of Python.

## Motivation and Context

Detected warnings while running unit tests.

## How Has This Been Tested?

Tested locally and in CI.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
