### PR TITLE
Clean up unused and duplicate imports

### DIFF
--- a/backend/engine/plugins/owasp_dependency_check/main.py
+++ b/backend/engine/plugins/owasp_dependency_check/main.py
@@ -6,7 +6,6 @@ import json
 import os
 import subprocess
 
-from typing import Any
 from engine.plugins.lib import utils
 
 log = utils.setup_logging("owasp_dependency_check")

--- a/backend/engine/processor/sbom_cdx.py
+++ b/backend/engine/processor/sbom_cdx.py
@@ -1,5 +1,3 @@
-import uuid
-
 import simplejson as json
 
 from artemisdb.artemisdb.models import License, Scan

--- a/backend/engine/tests/test_trivy_sbom.py
+++ b/backend/engine/tests/test_trivy_sbom.py
@@ -6,7 +6,6 @@ import secrets
 from docker import builder, remover
 from subprocess import CompletedProcess
 from unittest.mock import patch
-from docker import remover
 from engine.plugins.trivy_sbom import main as Trivy
 from engine.plugins.lib.sbom_common.go_installer import go_mod_download
 from engine.plugins.lib.sbom_common.yarn_installer import yarn_install

--- a/orchestrator/lambdas/tests/test_get_services.py
+++ b/orchestrator/lambdas/tests/test_get_services.py
@@ -1,8 +1,6 @@
 import os
 import unittest
 
-import pytest
-
 from heimdall_utils import get_services
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))


### PR DESCRIPTION
## Description

Cleans up some unused or duplicated imports.

## Motivation and Context

These were detected while [migrating from Black to Ruff](https://github.com/WarnerMedia/artemis/pull/219) -- this PR cleans them up.

## How Has This Been Tested?

Tested locally and via CI.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
