### PR TITLE
artemislib: Fix type hints and handle unspecified bucket names

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -417,7 +417,7 @@ dist/lambdas/layers/artemislib.zip: ${SHARED_LIB_SRC}
 	@echo "${INFO}Building $@"
 	mkdir -p ${LAMBDA_LAYERS_BUILD_DIR}/artemislib/python
 	${PIP} install --upgrade --target ${LAMBDA_LAYERS_BUILD_DIR}/artemislib/python --python-version ${LAMBDA_PYTHON_VER} --no-deps ${ARTEMISLIB}
-	${PIP} install --upgrade --target ${LAMBDA_LAYERS_BUILD_DIR}/artemislib/python --python-version ${LAMBDA_PYTHON_VER} --only-binary=:all: pyjwt requests "urllib3<2"
+	${PIP} install --upgrade --target ${LAMBDA_LAYERS_BUILD_DIR}/artemislib/python --python-version ${LAMBDA_PYTHON_VER} --only-binary=:all: 'boto3~=1.34' 'boto3-stubs[ec2,lambda,s3,secretsmanager,sqs]~=1.34' pyjwt requests "urllib3<2"
 	${PIP} install --upgrade --target ${LAMBDA_LAYERS_BUILD_DIR}/artemislib/python --python-version ${LAMBDA_PYTHON_VER} --only-binary=:all: ${LAMBDA_PLATFORM_FLAGS} cryptography
 	mkdir -p ${DIST_DIR}/lambdas/layers/artemislib/python
 	cd ${LAMBDA_LAYERS_BUILD_DIR}/artemislib; zip -r ${DIST_DIR}/lambdas/layers/artemislib.zip *

--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -9,6 +9,7 @@ python_version = "3.9"
 [packages]
 awscli = "~=1.32"
 boto3 = "~=1.34"
+boto3-stubs = {extras = ["ec2", "lambda", "secretsmanager", "s3", "sqs"], version = "~=1.34"}
 cryptography = "~=42.0"
 cwe = "~=1.6"
 django = "~=3.2"
@@ -26,7 +27,6 @@ sqlparse = "~=0.5"
 aiohttp = "~=3.9"
 autopep8 = "~=2.1"
 black = "==22.3.0"  # Pending upgrade later.
-boto3-stubs = {extras = ["ec2", "lambda", "s3", "secretsmanager", "sqs"], version = "~=1.34"}
 cfn-lint = "==0.53.0"  # Must match version in Makefile.
 checkov = "==2.0.1065"  # Must match version in Makefile.
 flake8 = "~=7.0"

--- a/backend/Pipfile.lock
+++ b/backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1264ff99aab80d6179e77c091e884de7ab707fa3c2140f65e381108774ba6df8"
+            "sha256": "7f51998499c391b3da8190e1f1dc4249a675e8cdde002d3c2890e59654cb13ef"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -34,19 +34,21 @@
         },
         "awscli": {
             "hashes": [
-                "sha256:19e0c0eec367776c2bdf1c77421d2ca19f4b18eeb290ad80dc431baf1444d974",
-                "sha256:8062a454dea01cb4bef334924927691dfb24ffb1dff82cb91a8db3eb1452830c"
+                "sha256:320e25e7d01cab4c5aa898c5eef6616c96971ee883868dacfc23c5be602dbab2",
+                "sha256:d0660e85684364687eb51db480529479ba7aa8bd919ce57a13c8943ce792e236"
             ],
             "index": "pypi",
-            "version": "==1.33.33"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.33.34"
         },
         "boto3": {
             "hashes": [
-                "sha256:30498a76b6f651ee2af7ae8edc1704379279ab8b91f1a8dd1f4ddf51259b0bc2",
-                "sha256:35bc76faacf1667d3fbb66c1966acf2230ef26206557efc26d9d9d79337bef43"
+                "sha256:92726a5be7083fd62585f8de251251ec7e53f4c7ee69c9c3168873fe979ec511",
+                "sha256:d34d7efe608b98cc10cfb43983bd2c511eb32efd5780ef72b171a3e3325462ff"
             ],
             "index": "pypi",
-            "version": "==1.34.151"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.34.152"
         },
         "boto3-stubs": {
             "extras": [
@@ -65,11 +67,11 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:0d0968e427a94378f295b49d59170dad539938487ec948de3d030f06092ec6dc",
-                "sha256:9018680d7d4a8060c26d127ceec5ab5b270879f423ea39b863d8a46f3e34c404"
+                "sha256:8531eb0f8d3b7913df8b32ca96d415d3187de8681e4ac908657803eacc87ac54",
+                "sha256:e291e425e34e9fdcdf32d7c37fc099be057335b58cccabf5ee7c945322dbcd87"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.151"
+            "version": "==1.34.152"
         },
         "botocore-stubs": {
             "hashes": [
@@ -285,6 +287,7 @@
                 "sha256:fff12c88a672ab9c9c1cf7b0c80e3ad9e2ebd9d828d955c126be4fd3e5578c9e"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==42.0.8"
         },
         "cwe": {
@@ -309,6 +312,7 @@
                 "sha256:a52ea7fcf280b16f7b739cec38fa6d3f8953a5456986944c3ca97e79882b4e38"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.6'",
             "version": "==3.2.25"
         },
         "docutils": {
@@ -321,11 +325,12 @@
         },
         "graphql-query": {
             "hashes": [
-                "sha256:5a2e771c9a78817fa2b9a7186f5fb7f7d6b02b5589bd4e80e5175cf4d4a4882e",
-                "sha256:d54e8d9edad1a9b769e3fd6711753aa0cc8ec0609737a2c429051c37ed488c28"
+                "sha256:1cfe5eeaad8b0ed67ac3d9c4023ee9743851f98c6b2f673c67088cf42ebb57bb",
+                "sha256:376ed550a7812425befbefb870daa21ce1696590fcb78c015215a43a5d7e51b7"
             ],
             "index": "pypi",
-            "version": "==1.3.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.4.0"
         },
         "idna": {
             "hashes": [
@@ -357,6 +362,7 @@
                 "sha256:d1151cdf9a64241b8cb46e7d67c5bfba10aecf364ef53b3a9109e90e8a621dca"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==0.11.1"
         },
         "markupsafe": {
@@ -466,6 +472,7 @@
                 "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.6'",
             "version": "==21.3"
         },
         "psycopg2-binary": {
@@ -544,6 +551,7 @@
                 "sha256:f9b5571d33660d5009a8b3c25dc1db560206e2d2f89d3df1cb32d72c0d117d52"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==2.9.9"
         },
         "pyasn1": {
@@ -671,15 +679,20 @@
                 "sha256:65b499728be3ce7b0cd2cd760da3b32f0f4d7bc55e5e0677617f90f6564e793e"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==2.3.0"
         },
         "pyjwt": {
+            "extras": [
+                "crypto"
+            ],
             "hashes": [
-                "sha256:57e28d156e3d5c10088e0c68abb90bfac3df82b40a71bd0daa20c65ccd5c23de",
-                "sha256:59127c392cc44c2da5bb3192169a91f429924e17aff6534d70fdc02ab3e04320"
+                "sha256:3b02fb0f44517787776cf48f2ae25d8e14f300e6d7545a4315cee571a415e850",
+                "sha256:7e1e5b56cc735432a7369cbfa0efe50fa113ebecdc04ae6922deba8b84582d0c"
             ],
             "index": "pypi",
-            "version": "==2.8.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.9.0"
         },
         "pynacl": {
             "hashes": [
@@ -783,6 +796,7 @@
                 "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==2.32.3"
         },
         "rsa": {
@@ -903,6 +917,7 @@
                 "sha256:ff836cd4041e16003549449cc0a5e372f6b6f871eb89007ab0ee18fb2800fded"
             ],
             "index": "pypi",
+            "markers": "python_version >= '2.5' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==3.19.2"
         },
         "six": {
@@ -919,6 +934,7 @@
                 "sha256:bb6b4df465655ef332548e24f08e205afc81b9ab86cb1c45657a7ff173a3a00e"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==0.5.1"
         },
         "types-awscrt": {
@@ -950,7 +966,7 @@
                 "sha256:37a0344459b199fce0e80b0d3569837ec6b6937435c5244e7fd73fa6006830f3",
                 "sha256:3e3d753a8618b86d7de333b4223005f68720bcd6a7d2bcb9fbd2229ec7c1e429"
             ],
-            "markers": "python_version < '3.10'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==1.26.19"
         },
         "wrapt": {
@@ -1040,11 +1056,11 @@
         },
         "aiohappyeyeballs": {
             "hashes": [
-                "sha256:77e15a733090547a1f5369a1287ddfc944bd30df0eb8993f585259c34b405f4e",
-                "sha256:903282fb08c8cfb3de356fd546b263248a477c99cb147e20a115e14ab942a4ae"
+                "sha256:40a16ceffcf1fc9e142fd488123b2e218abc4188cf12ac20c67200e1579baa42",
+                "sha256:7e1ae8399c320a8adec76f6c919ed5ceae6edd4c3672f4d9eae2b27e37c80ff6"
             ],
             "markers": "python_version >= '3.8' and python_version < '4.0'",
-            "version": "==2.3.2"
+            "version": "==2.3.4"
         },
         "aiohttp": {
             "hashes": [
@@ -1126,6 +1142,7 @@
                 "sha256:ff25d988fd6ce433b5c393094a5ca50df568bdccf90a8b340900e24e0d5fb45c"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==3.10.0"
         },
         "aiomultiprocess": {
@@ -1190,6 +1207,7 @@
                 "sha256:a203fe0fcad7939987422140ab17a930f684763bf7335bdb6709991dd7ef6c2d"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==2.3.1"
         },
         "aws-sam-translator": {
@@ -1243,46 +1261,25 @@
                 "sha256:fd57160949179ec517d32ac2ac898b5f20d68ed1a9c977346efbac9c2f1e779d"
             ],
             "index": "pypi",
+            "markers": "python_full_version >= '3.6.2'",
             "version": "==22.3.0"
         },
         "boto3": {
             "hashes": [
-                "sha256:30498a76b6f651ee2af7ae8edc1704379279ab8b91f1a8dd1f4ddf51259b0bc2",
-                "sha256:35bc76faacf1667d3fbb66c1966acf2230ef26206557efc26d9d9d79337bef43"
+                "sha256:92726a5be7083fd62585f8de251251ec7e53f4c7ee69c9c3168873fe979ec511",
+                "sha256:d34d7efe608b98cc10cfb43983bd2c511eb32efd5780ef72b171a3e3325462ff"
             ],
             "index": "pypi",
-            "version": "==1.34.151"
-        },
-        "boto3-stubs": {
-            "extras": [
-                "ec2",
-                "lambda",
-                "s3",
-                "secretsmanager",
-                "sqs"
-            ],
-            "hashes": [
-                "sha256:7c74775d5bca4693c9695526b95c80a572d6e1bf8059249698abff9596268671",
-                "sha256:8422368138fb74afb7c11965677726000c4d24b7b3b872d414f5c706372bf94f"
-            ],
-            "index": "pypi",
-            "version": "==1.34.151"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.34.152"
         },
         "botocore": {
             "hashes": [
-                "sha256:0d0968e427a94378f295b49d59170dad539938487ec948de3d030f06092ec6dc",
-                "sha256:9018680d7d4a8060c26d127ceec5ab5b270879f423ea39b863d8a46f3e34c404"
+                "sha256:8531eb0f8d3b7913df8b32ca96d415d3187de8681e4ac908657803eacc87ac54",
+                "sha256:e291e425e34e9fdcdf32d7c37fc099be057335b58cccabf5ee7c945322dbcd87"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.151"
-        },
-        "botocore-stubs": {
-            "hashes": [
-                "sha256:675f21efef0d8c533701e7449f765fd120b627e80a8ced41bafc43c34e021be5",
-                "sha256:89a50f631d74cd7ddd5ab02cf0d0c718d2fc36c1a7e54b84bd4be738d5a239da"
-            ],
-            "markers": "python_version >= '3.8' and python_version < '4.0'",
-            "version": "==1.34.151"
+            "version": "==1.34.152"
         },
         "cached-property": {
             "hashes": [
@@ -1371,6 +1368,7 @@
                 "sha256:d17359e3ca9477eccaea700fac4bf028f5bc368a338c017adde5187f2691cab8"
             ],
             "index": "pypi",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.53.0"
         },
         "charset-normalizer": {
@@ -1475,6 +1473,7 @@
                 "sha256:ea03142431d807b77f3344ffe94b6936932ccf2301e579a2b33231d2d7c733ea"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==2.0.1065"
         },
         "click": {
@@ -1614,6 +1613,7 @@
                 "sha256:fff12c88a672ab9c9c1cf7b0c80e3ad9e2ebd9d828d955c126be4fd3e5578c9e"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==42.0.8"
         },
         "cyclonedx-python-lib": {
@@ -1682,6 +1682,7 @@
                 "sha256:48a07b626b55236e0fb4784ee69a465fbf59d79eec1f5b4785c3d3bc57d17aa5"
             ],
             "index": "pypi",
+            "markers": "python_full_version >= '3.8.1'",
             "version": "==7.1.0"
         },
         "frozenlist": {
@@ -1819,6 +1820,7 @@
                 "sha256:8ca5e72a8d85860d5a3fa69b8745237f2939afe12dbf656afbcb47fe72d947a6"
             ],
             "index": "pypi",
+            "markers": "python_full_version >= '3.8.0'",
             "version": "==5.13.2"
         },
         "jinja2": {
@@ -1970,6 +1972,7 @@
                 "sha256:5e96aad5ccda4718e0a229ed94b2024df75cc2d55575ba5762d31f5767b8767d"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.6'",
             "version": "==5.1.0"
         },
         "moto": {
@@ -1984,7 +1987,7 @@
                 "sha256:606b641f4c6ef69f28a84147d6d6806d052011e7ae7b0fe46ae8858e7a27a0a3",
                 "sha256:bdba9bec0afcde9f99b58c5271d6458dbfcda0a0a1e9beaecd808d2591db65ea"
             ],
-            "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==5.0.11"
         },
         "multidict": {
@@ -2083,41 +2086,6 @@
             "markers": "python_version >= '3.7'",
             "version": "==6.0.5"
         },
-        "mypy-boto3-ec2": {
-            "hashes": [
-                "sha256:034f8d160535f5cf77fe35c95588454790cd2709f656274604bc36f76406211f",
-                "sha256:9f5b13d7ffcb7fb1d57688a728bcefbeb12ab74f2047ee5a4577b8064f7a3fe3"
-            ],
-            "version": "==1.34.149"
-        },
-        "mypy-boto3-lambda": {
-            "hashes": [
-                "sha256:7b81d2a5604fb592e92fe0b284ecd259de071703360a33b71c9b54df46d81c9c",
-                "sha256:e21022d2eef12aa731af80790410afdba9412b056339823252813bae2adbf553"
-            ],
-            "version": "==1.34.77"
-        },
-        "mypy-boto3-s3": {
-            "hashes": [
-                "sha256:47ded5f06accc10ff9db9d55c85cca88e4f028ec360d7cfcea90377e525cba56",
-                "sha256:7f9770d1f0e9f6fc2ced96daf5c0792b2dbbb4a4f874f28200ff3c940d0815c3"
-            ],
-            "version": "==1.34.138"
-        },
-        "mypy-boto3-secretsmanager": {
-            "hashes": [
-                "sha256:986511caa6626edfed7eb11b63c929801e9468c58e15927dc6fc0339c4eb34cb",
-                "sha256:e5a82c05cce68168a3709e5f0d35066cf250961db1d8670f0111da66206814c7"
-            ],
-            "version": "==1.34.145"
-        },
-        "mypy-boto3-sqs": {
-            "hashes": [
-                "sha256:bdbc623235ffc8127cb8753f49323f74a919df552247b0b2caaf85cf9bb495b8",
-                "sha256:e92aefacfa08e7094b79002576ef261e4075f5af9c25219fc47fb8452f53fc5f"
-            ],
-            "version": "==1.34.121"
-        },
         "mypy-extensions": {
             "hashes": [
                 "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d",
@@ -2148,6 +2116,7 @@
                 "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.6'",
             "version": "==21.3"
         },
         "pathspec": {
@@ -2410,6 +2379,7 @@
                 "sha256:a5d01678349454806cff6d886fb072294f56a58c4761278c97fb557d708e1eb3"
             ],
             "index": "pypi",
+            "markers": "python_full_version >= '3.8.0'",
             "version": "==3.2.6"
         },
         "pyparsing": {
@@ -2464,6 +2434,7 @@
                 "sha256:c132345d12ce551242c87269de812483f5bcc87cdbb4722e48487ba194f9fdce"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==8.3.2"
         },
         "pytest-cov": {
@@ -2472,6 +2443,7 @@
                 "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==5.0.0"
         },
         "pytest-subtests": {
@@ -2480,6 +2452,7 @@
                 "sha256:ab616a22f64cd17c1aee65f18af94dbc30c444f8683de2b30895c3778265e3bd"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==0.13.1"
         },
         "python-dateutil": {
@@ -2496,6 +2469,7 @@
                 "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==1.0.1"
         },
         "pyyaml": {
@@ -2655,6 +2629,7 @@
                 "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==2.32.3"
         },
         "responses": {
@@ -2663,6 +2638,7 @@
                 "sha256:617b9247abd9ae28313d57a75880422d55ec63c29d33d629697590a034358dba"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==0.25.3"
         },
         "ruff": {
@@ -2687,6 +2663,7 @@
                 "sha256:fe26fc46fa8c6e0ae3f47ddccfbb136253c831c3289bba044befe68f467bfb16"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==0.5.5"
         },
         "s3transfer": {
@@ -2807,22 +2784,6 @@
             ],
             "version": "==0.0.7"
         },
-        "types-awscrt": {
-            "hashes": [
-                "sha256:0839fe12f0f914d8f7d63ed777c728cb4eccc2d5d79a26e377d12b0604e7bf0e",
-                "sha256:84a9f4f422ec525c314fdf54c23a1e73edfbcec968560943ca2d41cfae623b38"
-            ],
-            "markers": "python_version >= '3.7' and python_version < '4.0'",
-            "version": "==0.21.2"
-        },
-        "types-s3transfer": {
-            "hashes": [
-                "sha256:02154cce46528287ad76ad1a0153840e0492239a0887e8833466eccf84b98da0",
-                "sha256:49a7c81fa609ac1532f8de3756e64b58afcecad8767933310228002ec7adff74"
-            ],
-            "markers": "python_version >= '3.8' and python_version < '4.0'",
-            "version": "==0.10.1"
-        },
         "types-setuptools": {
             "hashes": [
                 "sha256:85ba28e9461bb1be86ebba4db0f1c2408f2b11115b1966334ea9dc464e29303e",
@@ -2859,7 +2820,7 @@
                 "sha256:37a0344459b199fce0e80b0d3569837ec6b6937435c5244e7fd73fa6006830f3",
                 "sha256:3e3d753a8618b86d7de333b4223005f68720bcd6a7d2bcb9fbd2229ec7c1e429"
             ],
-            "markers": "python_version < '3.10'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==1.26.19"
         },
         "wcwidth": {

--- a/backend/Pipfile.lock
+++ b/backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0fedec3d53cb82265b542e741878f952b45172073ebe8db4d5b2d72d741dbcb1"
+            "sha256": "1264ff99aab80d6179e77c091e884de7ab707fa3c2140f65e381108774ba6df8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -48,12 +48,35 @@
             "index": "pypi",
             "version": "==1.34.151"
         },
+        "boto3-stubs": {
+            "extras": [
+                "ec2",
+                "lambda",
+                "s3",
+                "secretsmanager",
+                "sqs"
+            ],
+            "hashes": [
+                "sha256:310138d9997ab318cc0da762b6629e80cadb31badac89b148213f077ed155cf4",
+                "sha256:f1b3a6d5fdb6e2986196419a2447df8609e79826b0cc184720fb318d3c123b0d"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.34.152"
+        },
         "botocore": {
             "hashes": [
                 "sha256:0d0968e427a94378f295b49d59170dad539938487ec948de3d030f06092ec6dc",
                 "sha256:9018680d7d4a8060c26d127ceec5ab5b270879f423ea39b863d8a46f3e34c404"
             ],
             "markers": "python_version >= '3.8'",
+            "version": "==1.34.151"
+        },
+        "botocore-stubs": {
+            "hashes": [
+                "sha256:675f21efef0d8c533701e7449f765fd120b627e80a8ced41bafc43c34e021be5",
+                "sha256:89a50f631d74cd7ddd5ab02cf0d0c718d2fc36c1a7e54b84bd4be738d5a239da"
+            ],
+            "markers": "python_version >= '3.8' and python_version < '4.0'",
             "version": "==1.34.151"
         },
         "certifi": {
@@ -401,6 +424,41 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==2.1.5"
+        },
+        "mypy-boto3-ec2": {
+            "hashes": [
+                "sha256:034f8d160535f5cf77fe35c95588454790cd2709f656274604bc36f76406211f",
+                "sha256:9f5b13d7ffcb7fb1d57688a728bcefbeb12ab74f2047ee5a4577b8064f7a3fe3"
+            ],
+            "version": "==1.34.149"
+        },
+        "mypy-boto3-lambda": {
+            "hashes": [
+                "sha256:7b81d2a5604fb592e92fe0b284ecd259de071703360a33b71c9b54df46d81c9c",
+                "sha256:e21022d2eef12aa731af80790410afdba9412b056339823252813bae2adbf553"
+            ],
+            "version": "==1.34.77"
+        },
+        "mypy-boto3-s3": {
+            "hashes": [
+                "sha256:47ded5f06accc10ff9db9d55c85cca88e4f028ec360d7cfcea90377e525cba56",
+                "sha256:7f9770d1f0e9f6fc2ced96daf5c0792b2dbbb4a4f874f28200ff3c940d0815c3"
+            ],
+            "version": "==1.34.138"
+        },
+        "mypy-boto3-secretsmanager": {
+            "hashes": [
+                "sha256:986511caa6626edfed7eb11b63c929801e9468c58e15927dc6fc0339c4eb34cb",
+                "sha256:e5a82c05cce68168a3709e5f0d35066cf250961db1d8670f0111da66206814c7"
+            ],
+            "version": "==1.34.145"
+        },
+        "mypy-boto3-sqs": {
+            "hashes": [
+                "sha256:bdbc623235ffc8127cb8753f49323f74a919df552247b0b2caaf85cf9bb495b8",
+                "sha256:e92aefacfa08e7094b79002576ef261e4075f5af9c25219fc47fb8452f53fc5f"
+            ],
+            "version": "==1.34.121"
         },
         "packaging": {
             "hashes": [
@@ -862,6 +920,22 @@
             ],
             "index": "pypi",
             "version": "==0.5.1"
+        },
+        "types-awscrt": {
+            "hashes": [
+                "sha256:0839fe12f0f914d8f7d63ed777c728cb4eccc2d5d79a26e377d12b0604e7bf0e",
+                "sha256:84a9f4f422ec525c314fdf54c23a1e73edfbcec968560943ca2d41cfae623b38"
+            ],
+            "markers": "python_version >= '3.7' and python_version < '4.0'",
+            "version": "==0.21.2"
+        },
+        "types-s3transfer": {
+            "hashes": [
+                "sha256:02154cce46528287ad76ad1a0153840e0492239a0887e8833466eccf84b98da0",
+                "sha256:49a7c81fa609ac1532f8de3756e64b58afcecad8767933310228002ec7adff74"
+            ],
+            "markers": "python_version >= '3.8' and python_version < '4.0'",
+            "version": "==0.10.1"
         },
         "typing-extensions": {
             "hashes": [

--- a/backend/libs/artemislib/artemislib/aws.py
+++ b/backend/libs/artemislib/artemislib/aws.py
@@ -117,7 +117,7 @@ class AWSConnect:
         Raises ValueError if the bucket is not specified.
         """
         if s3_bucket is None:
-            raise ValueError("Source bucket must be specified")
+            raise ValueError("Target bucket must be specified")
         return self._S3[endpoint_url].Object(s3_bucket, s3_key)
 
     def copy_s3_object(
@@ -208,7 +208,7 @@ class AWSConnect:
         Raises botocore.exceptions.ClientError if the deletion fails.
         """
         if s3_bucket is None:
-            raise ValueError("Source bucket must be specified")
+            raise ValueError("Target bucket must be specified")
         count = 0
         bucket = self._S3[endpoint_url].Bucket(s3_bucket)
         resp = bucket.objects.filter(Prefix=prefix).delete()
@@ -226,7 +226,7 @@ class AWSConnect:
         Raises ValueError if the bucket is not specified.
         """
         if s3_bucket is None:
-            raise ValueError("Source bucket must be specified")
+            raise ValueError("Target bucket must be specified")
         self.log.debug("[get_s3_file_list] prefix=%s, bucket=%s, endpoint=%s", prefix, s3_bucket, endpoint_url)
         bucket = self._S3[endpoint_url].Bucket(s3_bucket)
         return bucket.objects.filter(Prefix=prefix)

--- a/backend/libs/artemislib/artemislib/aws.py
+++ b/backend/libs/artemislib/artemislib/aws.py
@@ -1,8 +1,14 @@
 import json
-from typing import Union
+from typing import Any, Optional
 
 import boto3
 from botocore.exceptions import ClientError
+from mypy_boto3_ec2 import EC2ServiceResource
+from mypy_boto3_lambda import LambdaClient
+from mypy_boto3_s3 import S3ServiceResource
+from mypy_boto3_s3.service_resource import BucketObjectsCollection, Object as S3Object
+from mypy_boto3_secretsmanager import SecretsManagerClient
+from mypy_boto3_sqs import SQSClient
 
 from artemislib.env import (
     APPLICATION_TAG,
@@ -12,7 +18,26 @@ from artemislib.env import (
     SCAN_DATA_S3_ENDPOINT,
     SQS_ENDPOINT,
 )
-from artemislib.logging import Logger
+from logging import Logger
+from artemislib.logging import Logger as ArtemisLogger
+
+
+def _client_error_code(e: ClientError) -> str:
+    """
+    Extracts the client error code from a generic ClientError.
+
+    Returns an empty string if the ClientError did not include a code.
+    """
+    return e.response.get("Error", {}).get("Code", "")
+
+
+def _client_error_message(e: ClientError) -> str:
+    """
+    Extracts the client error message from a generic ClientError.
+
+    Returns an empty string if the ClientError did not include a message.
+    """
+    return e.response.get("Error", {}).get("Message", "")
 
 
 class LambdaError(Exception):
@@ -21,14 +46,17 @@ class LambdaError(Exception):
 
 class AWSConnect:
     _instance = None
-    _SECRETS_MANAGER = None
-    _S3 = None
-    log = None
+    _EC2: EC2ServiceResource
+    _LAMBDA: LambdaClient
+    _SECRETS_MANAGER: SecretsManagerClient
+    _S3: dict[str, S3ServiceResource]
+    _SQS: SQSClient
+    log: Logger
 
-    def __new__(cls, region: str = AWS_DEFAULT_REGION, queue: str = None):
+    def __new__(cls, region: str = AWS_DEFAULT_REGION, queue: Optional[str] = None):
         if cls._instance is None:
             cls._instance = super(AWSConnect, cls).__new__(cls)
-            cls._instance.log = Logger("AWSConnect")
+            cls._instance.log = ArtemisLogger("AWSConnect")
             cls._instance._LAMBDA = boto3.client("lambda", region_name=region)
             cls._instance._S3 = {DEFAULT_S3_ENDPOINT: boto3.resource("s3", region_name=region)}
             if SCAN_DATA_S3_ENDPOINT != DEFAULT_S3_ENDPOINT:
@@ -40,19 +68,20 @@ class AWSConnect:
             cls._instance._EC2 = boto3.resource("ec2", region_name=region)
         return cls._instance
 
-    def get_secret(self, secret_name):
+    def get_secret(self, secret_name: str) -> Any:
         """
         Retrieves a JSON value from Secrets Manager.
 
         Returns None if the Secrets Manager value is not a string.
         Raises botocore.exceptions.ClientError if secret value is not set or cannot be decrypted.
+        Raises json.JSONDecodeError if the value is not a valid JSON string.
         """
         raw_secret = self.get_secret_raw(secret_name)
         if raw_secret is not None:
             return json.loads(raw_secret)
         return None
 
-    def get_secret_raw(self, secret_name):
+    def get_secret_raw(self, secret_name: str) -> Optional[str]:
         """
         Retrieves a raw Secrets Manager string value.
 
@@ -62,7 +91,7 @@ class AWSConnect:
         try:
             get_secret_value_response = self._SECRETS_MANAGER.get_secret_value(SecretId=secret_name)
         except ClientError as e:
-            if e.response["Error"]["Code"] in (
+            if _client_error_code(e) in (
                 "DecryptionFailureException",
                 "InternalServiceErrorException",
                 "InvalidParameterException",
@@ -70,7 +99,7 @@ class AWSConnect:
                 "ResourceNotFoundException",
             ):
                 raise e
-            self.log.error("Unable to get value: %s", e.response["Error"]["Message"])
+            self.log.error("Unable to get value: %s", _client_error_message(e))
         else:
             # Decrypts secret using the associated KMS CMK.
             # Depending on whether the secret is a string or binary, one of these
@@ -79,20 +108,38 @@ class AWSConnect:
                 return get_secret_value_response["SecretString"]
         return None
 
-    def get_s3_object(self, s3_key, s3_bucket=S3_BUCKET, endpoint_url: str = DEFAULT_S3_ENDPOINT):
-        self.log.debug("[get_s3_object] key=%s, bucket=%s, endpoint=%s", s3_key, s3_bucket, endpoint_url)
-        if s3_bucket:
-            return self._S3[endpoint_url].Object(s3_bucket, s3_key)
+    def get_s3_object(
+        self, s3_key: str, s3_bucket: Optional[str] = S3_BUCKET, endpoint_url: str = DEFAULT_S3_ENDPOINT
+    ) -> S3Object:
+        """
+        Creates a reference to an object in S3.
+
+        Raises ValueError if the bucket is not specified.
+        """
+        if s3_bucket is None:
+            raise ValueError("Source bucket must be specified")
+        return self._S3[endpoint_url].Object(s3_bucket, s3_key)
 
     def copy_s3_object(
-        self, s3_key, new_s3_key, s3_bucket=S3_BUCKET, new_s3_bucket=S3_BUCKET, endpoint_url: str = DEFAULT_S3_ENDPOINT
-    ):
+        self,
+        s3_key: str,
+        new_s3_key: str,
+        s3_bucket: Optional[str] = S3_BUCKET,
+        new_s3_bucket: Optional[str] = S3_BUCKET,
+        endpoint_url: str = DEFAULT_S3_ENDPOINT,
+    ) -> None:
         """
         Copies an S3 object from one location to another.
+
+        Raises ValueError if source or destination bucket is not specified.
         """
-        copy_source = {"Bucket": s3_bucket, "Key": s3_key}
+        if s3_bucket is None:
+            raise ValueError("Source bucket must be specified")
+        if new_s3_bucket is None:
+            raise ValueError("Destination bucket must be specified")
+
         new_obj = self._S3[endpoint_url].Bucket(new_s3_bucket).Object(new_s3_key)
-        new_obj.copy(copy_source)
+        new_obj.copy({"Bucket": s3_bucket, "Key": s3_key})
 
     def invoke_lambda(self, name: str, payload: dict) -> dict:
         resp = self._LAMBDA.invoke(FunctionName=name, InvocationType="RequestResponse", Payload=json.dumps(payload))
@@ -115,26 +162,53 @@ class AWSConnect:
         return [instance.id for instance in instances]
 
     def get_s3_file(
-        self, path: str, s3_bucket: str = S3_BUCKET, endpoint_url: str = DEFAULT_S3_ENDPOINT
-    ) -> Union[str, None]:
+        self, path: str, s3_bucket: Optional[str] = S3_BUCKET, endpoint_url: str = DEFAULT_S3_ENDPOINT
+    ) -> Optional[str]:
+        """
+        Retrieves a text object from S3 as a UTF-8 string.
+
+        This is best-effort; any retrieval error will be logged and None returned.
+
+        For non-text files, call get_s3_object() instead.
+
+        Returns None if the S3 object is unable to be retrieved.
+        Raises ValueError if the bucket is not specified.
+        """
         obj = self.get_s3_object(path, s3_bucket, endpoint_url)
         if obj:
             try:
                 return obj.get()["Body"].read().decode("utf-8")
             except ClientError as e:
-                self.log.error("Unable to get S3 file: %s", e.response["Error"]["Message"])
+                self.log.error("Unable to get S3 file: %s", _client_error_message(e))
                 return None
         self.log.error("Unable to get S3 object")
         return None
 
     def write_s3_file(
-        self, path: str, body: str, s3_bucket: str = S3_BUCKET, endpoint_url: str = DEFAULT_S3_ENDPOINT
+        self, path: str, body: str, s3_bucket: Optional[str] = S3_BUCKET, endpoint_url: str = DEFAULT_S3_ENDPOINT
     ) -> None:
+        """
+        Write a string to S3.
+
+        Raises ValueError if the bucket is not specified.
+        Raises botocore.exceptions.ClientError if the write fails.
+        """
         obj = self.get_s3_object(path, s3_bucket, endpoint_url)
         if obj:
             obj.put(Body=body)
 
-    def delete_s3_files(self, prefix: str, s3_bucket: str = S3_BUCKET, endpoint_url: str = DEFAULT_S3_ENDPOINT) -> int:
+    def delete_s3_files(
+        self, prefix: str, s3_bucket: Optional[str] = S3_BUCKET, endpoint_url: str = DEFAULT_S3_ENDPOINT
+    ) -> int:
+        """
+        Recursively delete S3 objects.
+
+        Returns the number of objects which were deleted.
+        Raises ValueError if the bucket is not specified.
+        Raises botocore.exceptions.ClientError if the deletion fails.
+        """
+        if s3_bucket is None:
+            raise ValueError("Source bucket must be specified")
         count = 0
         bucket = self._S3[endpoint_url].Bucket(s3_bucket)
         resp = bucket.objects.filter(Prefix=prefix).delete()
@@ -143,8 +217,16 @@ class AWSConnect:
         return count
 
     def get_s3_file_list(
-        self, prefix: str, s3_bucket: str = S3_BUCKET, endpoint_url: str = DEFAULT_S3_ENDPOINT
-    ) -> list:
+        self, prefix: str, s3_bucket: Optional[str] = S3_BUCKET, endpoint_url: str = DEFAULT_S3_ENDPOINT
+    ) -> BucketObjectsCollection:
+        """
+        Lists all objects matching a prefix.
+
+        Returns an iterable object collection.
+        Raises ValueError if the bucket is not specified.
+        """
+        if s3_bucket is None:
+            raise ValueError("Source bucket must be specified")
         self.log.debug("[get_s3_file_list] prefix=%s, bucket=%s, endpoint=%s", prefix, s3_bucket, endpoint_url)
         bucket = self._S3[endpoint_url].Bucket(s3_bucket)
         return bucket.objects.filter(Prefix=prefix)

--- a/backend/libs/artemislib/artemislib/db_cache.py
+++ b/backend/libs/artemislib/artemislib/db_cache.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import Tuple
+from typing import Optional
 
 from artemislib.singleton import Singleton
 
@@ -12,7 +12,7 @@ class DBLookupCache(metaclass=Singleton):
 
             self.cache_item_model = CacheItem
 
-    def lookup(self, key: str) -> Tuple[str, None]:
+    def lookup(self, key: str) -> Optional[str]:
         if self.cache_item_model is None or key is None:
             return None
 
@@ -28,6 +28,6 @@ class DBLookupCache(metaclass=Singleton):
         except self.cache_item_model.DoesNotExist:
             return None
 
-    def store(self, key: str, value: str, expires: datetime = None):
+    def store(self, key: str, value: str, expires: Optional[datetime] = None):
         if self.cache_item_model is not None:
             self.cache_item_model.objects.update_or_create(key=key, defaults={"value": value, "expires": expires})

--- a/backend/libs/artemislib/setup.py
+++ b/backend/libs/artemislib/setup.py
@@ -23,6 +23,7 @@ setup(
     setup_requires=["pytest-runner"],
     install_requires=[
         "boto3~=1.34",
+        "boto3-stubs[ec2,lambda,s3,secretsmanager,sqs]~=1.34",
         # pyjwt requires the cryptography library but it needs to be installed
         # separately because it contains platform-dependent pre-compiled code
         "pyjwt[crypto]~=2.8",

--- a/backend/libs/artemislib/tests/test_aws_connect.py
+++ b/backend/libs/artemislib/tests/test_aws_connect.py
@@ -1,4 +1,6 @@
+from typing import cast
 import boto3
+from json import JSONDecodeError
 from moto import mock_aws
 from botocore.exceptions import ClientError
 import unittest
@@ -17,16 +19,28 @@ class TestAWSConnect(unittest.TestCase):
         self.assertIsNotNone(b)
         self.assertEqual(a, b)
 
-    def test_get_secret(self):
-        secretsmgr: boto3.SecretsManager.Client = boto3.client("secretsmanager", region_name="us-east-1")
+    def test_get_secret_dict(self):
+        secretsmgr = boto3.client("secretsmanager", region_name="us-east-1")
         secretsmgr.create_secret(
             Name="secret_foo",
             SecretString='{"foo": "1234", "bar": "baz"}',
         )
         aws = AWSConnect(region=DEFAULT_REGION)
         actual = aws.get_secret("secret_foo")
+        self.assertIsInstance(actual, dict)
+        actual = cast(dict[str, str], actual)
         self.assertEqual(actual["foo"], "1234")
         self.assertEqual(actual["bar"], "baz")
+
+    def test_get_secret_invalid_json(self):
+        secretsmgr = boto3.client("secretsmanager", region_name="us-east-1")
+        secretsmgr.create_secret(
+            Name="secret_foo",
+            SecretString="iji};;ii",
+        )
+        aws = AWSConnect(region=DEFAULT_REGION)
+        with self.assertRaises(JSONDecodeError):
+            aws.get_secret("secret_foo")
 
     def test_get_secret_binary(self):
         secretsmgr = boto3.client("secretsmanager", region_name=DEFAULT_REGION)
@@ -65,6 +79,20 @@ class TestAWSConnect(unittest.TestCase):
         with self.assertRaises(ClientError):
             aws.get_secret_raw("secret_foo")
 
+    def test_get_s3_object(self):
+        s3 = boto3.client("s3", region_name=DEFAULT_REGION)
+        s3.create_bucket(Bucket="src")
+        s3.put_object(Bucket="src", Key="foo/bar", Body=b"baz")
+
+        aws = AWSConnect(region=DEFAULT_REGION)
+        obj = aws.get_s3_object("foo/bar", "src")
+        self.assertEqual(obj.get()["Body"].read(), b"baz")
+
+    def test_get_s3_object_missing_bucket(self):
+        aws = AWSConnect(region=DEFAULT_REGION)
+        with self.assertRaises(ValueError):
+            aws.get_s3_object("foo/bar", None)
+
     def test_copy_s3_object(self):
         s3 = boto3.client("s3", region_name=DEFAULT_REGION)
         s3.create_bucket(Bucket="src")
@@ -76,3 +104,90 @@ class TestAWSConnect(unittest.TestCase):
 
         res = s3.get_object(Bucket="dest", Key="baz/quux")
         self.assertEqual(res["Body"].read(), b"baz")
+
+    def test_copy_s3_object_missing_buckets(self):
+        aws = AWSConnect(region=DEFAULT_REGION)
+        with self.assertRaises(ValueError):
+            aws.copy_s3_object("foo/bar", "baz/quux", None, "dest")
+        with self.assertRaises(ValueError):
+            aws.copy_s3_object("foo/bar", "baz/quux", "src", None)
+
+    def test_get_s3_file(self):
+        s3 = boto3.client("s3", region_name=DEFAULT_REGION)
+        s3.create_bucket(Bucket="src")
+        s3.put_object(Bucket="src", Key="foo/bar", Body=b"quux")
+
+        aws = AWSConnect(region=DEFAULT_REGION)
+        actual = aws.get_s3_file("foo/bar", "src")
+        self.assertEqual(actual, "quux")
+
+    def test_get_s3_file_missing_bucket(self):
+        aws = AWSConnect(region=DEFAULT_REGION)
+        with self.assertRaises(ValueError):
+            aws.get_s3_file("nonexistent", None)
+
+    def test_get_s3_file_error(self):
+        aws = AWSConnect(region=DEFAULT_REGION)
+        actual = aws.get_s3_file("nonexistent", "nothing")
+        self.assertIsNone(actual)
+
+    def test_write_s3_file(self):
+        s3 = boto3.client("s3", region_name=DEFAULT_REGION)
+        s3.create_bucket(Bucket="dest")
+
+        aws = AWSConnect(region=DEFAULT_REGION)
+        aws.write_s3_file("foo/bar/baz.txt", "lorem ipsum", "dest")
+
+        resp = s3.get_object(Bucket="dest", Key="foo/bar/baz.txt")
+        self.assertEqual(resp["Body"].read().decode("utf-8"), "lorem ipsum")
+
+    def test_write_s3_file_missing_bucket(self):
+        aws = AWSConnect(region=DEFAULT_REGION)
+        with self.assertRaises(ValueError):
+            aws.write_s3_file("nonexistent", "foo bar", None)
+
+    def test_delete_s3_files(self):
+        s3 = boto3.client("s3", region_name=DEFAULT_REGION)
+        s3.create_bucket(Bucket="dest")
+        s3.put_object(Bucket="dest", Key="foo.md", Body=b"foo")
+        s3.put_object(Bucket="dest", Key="foo/bar.txt", Body=b"foo")
+        s3.put_object(Bucket="dest", Key="foo/bar/baz.txt", Body=b"foo")
+        s3.put_object(Bucket="dest", Key="foo/baz.txt", Body=b"foo")
+
+        aws = AWSConnect(region=DEFAULT_REGION)
+        count = aws.delete_s3_files("foo/", "dest")
+        self.assertEqual(count, 3)
+        # Confirm that only the prefixed files were deleted.
+        self.assertIsNotNone(aws.get_s3_file("foo.md", "dest"))
+        self.assertIsNone(aws.get_s3_file("foo/bar.txt", "dest"))
+        self.assertIsNone(aws.get_s3_file("foo/bar/baz.txt", "dest"))
+        self.assertIsNone(aws.get_s3_file("foo/baz.txt", "dest"))
+
+    def test_delete_s3_files_missing_bucket(self):
+        aws = AWSConnect(region=DEFAULT_REGION)
+        with self.assertRaises(ValueError):
+            aws.delete_s3_files("foo/", None)
+
+    def test_get_s3_file_list(self):
+        s3 = boto3.client("s3", region_name=DEFAULT_REGION)
+        s3.create_bucket(Bucket="list")
+        s3.put_object(Bucket="list", Key="foo.md", Body=b"foo")
+        s3.put_object(Bucket="list", Key="foo/bar.txt", Body=b"foo")
+        s3.put_object(Bucket="list", Key="foo/bar/baz.txt", Body=b"foo")
+        s3.put_object(Bucket="list", Key="foo/baz.txt", Body=b"foo")
+
+        aws = AWSConnect(region=DEFAULT_REGION)
+        actual = [x.key for x in aws.get_s3_file_list("foo/", "list")]
+        self.assertCountEqual(
+            actual,
+            [
+                "foo/bar.txt",
+                "foo/bar/baz.txt",
+                "foo/baz.txt",
+            ],
+        )
+
+    def test_get_s3_file_list_missing_bucket(self):
+        aws = AWSConnect(region=DEFAULT_REGION)
+        with self.assertRaises(ValueError):
+            aws.get_s3_file_list("foo/", None)

--- a/orchestrator/Pipfile
+++ b/orchestrator/Pipfile
@@ -16,7 +16,6 @@ pyjwt = "~=2.8"
 pyyaml = "~=6.0"
 requests = "~=2.31"
 aws-lambda-powertools = "==2.40.1"
-boto3-stubs = {extras = ["lambda", "secretsmanager", "ec2", "s3", "sqs"], version = "~=1.34"}
 
 [dev-packages]
 autopep8 = "~=2.1"

--- a/orchestrator/Pipfile
+++ b/orchestrator/Pipfile
@@ -9,17 +9,18 @@ python_version = "3.9"
 [packages]
 awscli = "~=1.32"
 boto3 = "~=1.34"
+boto3-stubs = {extras = ["ec2", "lambda", "secretsmanager", "s3", "sqs"], version = "~=1.34"}
 cryptography = "~=42.0"
 PyGithub = "~=2.1"
 pyjwt = "~=2.8"
 pyyaml = "~=6.0"
 requests = "~=2.31"
 aws-lambda-powertools = "==2.40.1"
+boto3-stubs = {extras = ["lambda", "secretsmanager", "ec2", "s3", "sqs"], version = "~=1.34"}
 
 [dev-packages]
 autopep8 = "~=2.1"
 black = "==22.3.0"  # Pending upgrade later.
-boto3-stubs = {extras = ["ec2", "lambda", "s3", "secretsmanager", "sqs"], version = "~=1.34"}
 cryptography = "~=42.0"
 flake8 = "~=7.0"
 mock = "~=5.1"

--- a/orchestrator/Pipfile.lock
+++ b/orchestrator/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c96c19e262874904ba370e4464385a2f61e2ebbad013ca7e5f68ad983254b193"
+            "sha256": "efd320c5c973c3900b173eaa0e104a77251ce5b391a6d8c3d3bfb5ff7fa510b0"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -22,23 +22,26 @@
                 "sha256:d7a1e2fdf4c8089e5d65fc54ac2f0f4e7fc46ae17f806737e6a1bec494095daf"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8' and python_full_version < '4.0.0'",
             "version": "==2.40.1"
         },
         "awscli": {
             "hashes": [
-                "sha256:b3047b2b8ab6d4a8b5bb04e28e4531be8e72fc87e5fb8f2588196eca9dd11dd0",
-                "sha256:e542f2ae56dc8ac0bb1774f835031e818af2e3a0e3fd133363d5932621e8e66c"
+                "sha256:320e25e7d01cab4c5aa898c5eef6616c96971ee883868dacfc23c5be602dbab2",
+                "sha256:d0660e85684364687eb51db480529479ba7aa8bd919ce57a13c8943ce792e236"
             ],
             "index": "pypi",
-            "version": "==1.33.26"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.33.34"
         },
         "boto3": {
             "hashes": [
-                "sha256:2f3e88b10b8fcc5f6100a9d74cd28230edc9d4fa226d99dd40a3ab38ac213673",
-                "sha256:b8433d481d50b68a0162c0379c0dd4aabfc3d1ad901800beb5b87815997511c1"
+                "sha256:92726a5be7083fd62585f8de251251ec7e53f4c7ee69c9c3168873fe979ec511",
+                "sha256:d34d7efe608b98cc10cfb43983bd2c511eb32efd5780ef72b171a3e3325462ff"
             ],
             "index": "pypi",
-            "version": "==1.34.144"
+            "markers": "python_version >= '3.8'",
+            "version": "==1.34.152"
         },
         "boto3-stubs": {
             "extras": [
@@ -57,11 +60,11 @@
         },
         "botocore": {
             "hashes": [
-                "sha256:4215db28d25309d59c99507f1f77df9089e5bebbad35f6e19c7c44ec5383a3e8",
-                "sha256:a2cf26e1bf10d5917a2285e50257bc44e94a1d16574f282f3274f7a5d8d1f08b"
+                "sha256:8531eb0f8d3b7913df8b32ca96d415d3187de8681e4ac908657803eacc87ac54",
+                "sha256:e291e425e34e9fdcdf32d7c37fc099be057335b58cccabf5ee7c945322dbcd87"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.144"
+            "version": "==1.34.152"
         },
         "botocore-stubs": {
             "hashes": [
@@ -277,6 +280,7 @@
                 "sha256:fff12c88a672ab9c9c1cf7b0c80e3ad9e2ebd9d828d955c126be4fd3e5578c9e"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==42.0.8"
         },
         "deprecated": {
@@ -368,16 +372,20 @@
                 "sha256:65b499728be3ce7b0cd2cd760da3b32f0f4d7bc55e5e0677617f90f6564e793e"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==2.3.0"
         },
         "pyjwt": {
-            "extras": [],
+            "extras": [
+                "crypto"
+            ],
             "hashes": [
-                "sha256:57e28d156e3d5c10088e0c68abb90bfac3df82b40a71bd0daa20c65ccd5c23de",
-                "sha256:59127c392cc44c2da5bb3192169a91f429924e17aff6534d70fdc02ab3e04320"
+                "sha256:3b02fb0f44517787776cf48f2ae25d8e14f300e6d7545a4315cee571a415e850",
+                "sha256:7e1e5b56cc735432a7369cbfa0efe50fa113ebecdc04ae6922deba8b84582d0c"
             ],
             "index": "pypi",
-            "version": "==2.8.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==2.9.0"
         },
         "pynacl": {
             "hashes": [
@@ -458,6 +466,7 @@
                 "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.6'",
             "version": "==6.0.1"
         },
         "requests": {
@@ -466,6 +475,7 @@
                 "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==2.32.3"
         },
         "rsa": {
@@ -521,7 +531,7 @@
                 "sha256:37a0344459b199fce0e80b0d3569837ec6b6937435c5244e7fd73fa6006830f3",
                 "sha256:3e3d753a8618b86d7de333b4223005f68720bcd6a7d2bcb9fbd2229ec7c1e429"
             ],
-            "markers": "python_version < '3.10'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==1.26.19"
         },
         "wrapt": {
@@ -604,11 +614,11 @@
     "develop": {
         "astroid": {
             "hashes": [
-                "sha256:3eae9ea67c11c858cdd2c91337d2e816bd019ac897ca07d7b346ac10105fceb3",
-                "sha256:7099b5a60985529d8d46858befa103b82d0d05a5a5e8b816b5303ed96075e1d9"
+                "sha256:0e14202810b30da1b735827f78f5157be2bbd4a7a59b7707ca0bfc2fb4c0063a",
+                "sha256:413658a61eeca6202a59231abb473f932038fbcbf1666587f66d482083413a25"
             ],
             "markers": "python_full_version >= '3.8.0'",
-            "version": "==3.2.3"
+            "version": "==3.2.4"
         },
         "autopep8": {
             "hashes": [
@@ -616,6 +626,7 @@
                 "sha256:a203fe0fcad7939987422140ab17a930f684763bf7335bdb6709991dd7ef6c2d"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==2.3.1"
         },
         "black": {
@@ -645,46 +656,25 @@
                 "sha256:fd57160949179ec517d32ac2ac898b5f20d68ed1a9c977346efbac9c2f1e779d"
             ],
             "index": "pypi",
+            "markers": "python_full_version >= '3.6.2'",
             "version": "==22.3.0"
         },
         "boto3": {
             "hashes": [
-                "sha256:2f3e88b10b8fcc5f6100a9d74cd28230edc9d4fa226d99dd40a3ab38ac213673",
-                "sha256:b8433d481d50b68a0162c0379c0dd4aabfc3d1ad901800beb5b87815997511c1"
+                "sha256:92726a5be7083fd62585f8de251251ec7e53f4c7ee69c9c3168873fe979ec511",
+                "sha256:d34d7efe608b98cc10cfb43983bd2c511eb32efd5780ef72b171a3e3325462ff"
             ],
             "index": "pypi",
-            "version": "==1.34.144"
-        },
-        "boto3-stubs": {
-            "extras": [
-                "ec2",
-                "lambda",
-                "s3",
-                "secretsmanager",
-                "sqs"
-            ],
-            "hashes": [
-                "sha256:7c74775d5bca4693c9695526b95c80a572d6e1bf8059249698abff9596268671",
-                "sha256:8422368138fb74afb7c11965677726000c4d24b7b3b872d414f5c706372bf94f"
-            ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.151"
+            "version": "==1.34.152"
         },
         "botocore": {
             "hashes": [
-                "sha256:4215db28d25309d59c99507f1f77df9089e5bebbad35f6e19c7c44ec5383a3e8",
-                "sha256:a2cf26e1bf10d5917a2285e50257bc44e94a1d16574f282f3274f7a5d8d1f08b"
+                "sha256:8531eb0f8d3b7913df8b32ca96d415d3187de8681e4ac908657803eacc87ac54",
+                "sha256:e291e425e34e9fdcdf32d7c37fc099be057335b58cccabf5ee7c945322dbcd87"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==1.34.144"
-        },
-        "botocore-stubs": {
-            "hashes": [
-                "sha256:5f3d9eca8a7173e450c903ee28b934a7152ab5c2da2bfe71f72f4a9e89ef4923",
-                "sha256:e2308ec1f983f7c93fc0e42c1b60f91c75746bcb564a9cb8240c742fd7d6483a"
-            ],
-            "markers": "python_version >= '3.8' and python_version < '4.0'",
-            "version": "==1.34.150"
+            "version": "==1.34.152"
         },
         "certifi": {
             "hashes": [
@@ -953,6 +943,7 @@
                 "sha256:fff12c88a672ab9c9c1cf7b0c80e3ad9e2ebd9d828d955c126be4fd3e5578c9e"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.7'",
             "version": "==42.0.8"
         },
         "dill": {
@@ -985,6 +976,7 @@
                 "sha256:48a07b626b55236e0fb4784ee69a465fbf59d79eec1f5b4785c3d3bc57d17aa5"
             ],
             "index": "pypi",
+            "markers": "python_full_version >= '3.8.1'",
             "version": "==7.1.0"
         },
         "idna": {
@@ -1107,6 +1099,7 @@
                 "sha256:5e96aad5ccda4718e0a229ed94b2024df75cc2d55575ba5762d31f5767b8767d"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.6'",
             "version": "==5.1.0"
         },
         "moto": {
@@ -1121,43 +1114,8 @@
                 "sha256:606b641f4c6ef69f28a84147d6d6806d052011e7ae7b0fe46ae8858e7a27a0a3",
                 "sha256:bdba9bec0afcde9f99b58c5271d6458dbfcda0a0a1e9beaecd808d2591db65ea"
             ],
-            "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==5.0.11"
-        },
-        "mypy-boto3-ec2": {
-            "hashes": [
-                "sha256:034f8d160535f5cf77fe35c95588454790cd2709f656274604bc36f76406211f",
-                "sha256:9f5b13d7ffcb7fb1d57688a728bcefbeb12ab74f2047ee5a4577b8064f7a3fe3"
-            ],
-            "version": "==1.34.149"
-        },
-        "mypy-boto3-lambda": {
-            "hashes": [
-                "sha256:7b81d2a5604fb592e92fe0b284ecd259de071703360a33b71c9b54df46d81c9c",
-                "sha256:e21022d2eef12aa731af80790410afdba9412b056339823252813bae2adbf553"
-            ],
-            "version": "==1.34.77"
-        },
-        "mypy-boto3-s3": {
-            "hashes": [
-                "sha256:47ded5f06accc10ff9db9d55c85cca88e4f028ec360d7cfcea90377e525cba56",
-                "sha256:7f9770d1f0e9f6fc2ced96daf5c0792b2dbbb4a4f874f28200ff3c940d0815c3"
-            ],
-            "version": "==1.34.138"
-        },
-        "mypy-boto3-secretsmanager": {
-            "hashes": [
-                "sha256:986511caa6626edfed7eb11b63c929801e9468c58e15927dc6fc0339c4eb34cb",
-                "sha256:e5a82c05cce68168a3709e5f0d35066cf250961db1d8670f0111da66206814c7"
-            ],
-            "version": "==1.34.145"
-        },
-        "mypy-boto3-sqs": {
-            "hashes": [
-                "sha256:bdbc623235ffc8127cb8753f49323f74a919df552247b0b2caaf85cf9bb495b8",
-                "sha256:e92aefacfa08e7094b79002576ef261e4075f5af9c25219fc47fb8452f53fc5f"
-            ],
-            "version": "==1.34.121"
         },
         "mypy-extensions": {
             "hashes": [
@@ -1232,19 +1190,21 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:32cd6c042b5004b8e857d727708720c54a676d1e22917cf1a2df9b4d4868abd6",
-                "sha256:e9b7171e242dcc6ebd0aaa7540481d1a72860748a0a7816b8fe6cf6c80a6fe7e"
+                "sha256:03c8e3baa1d9fb995b12c1dbe00aa6c4bcef210c2a2634374aedeb22fb4a8f8f",
+                "sha256:a5d01678349454806cff6d886fb072294f56a58c4761278c97fb557d708e1eb3"
             ],
             "index": "pypi",
-            "version": "==3.2.5"
+            "markers": "python_full_version >= '3.8.0'",
+            "version": "==3.2.6"
         },
         "pytest": {
             "hashes": [
-                "sha256:c434598117762e2bd304e526244f67bf66bbd7b5d6cf22138be51ff661980343",
-                "sha256:de4bb8104e201939ccdc688b27a89a7be2079b22e2bd2b07f806b6ba71117977"
+                "sha256:4ba08f9ae7dcf84ded419494d229b48d0903ea6407b030eaec46df5e6a73bba5",
+                "sha256:c132345d12ce551242c87269de812483f5bcc87cdbb4722e48487ba194f9fdce"
             ],
             "index": "pypi",
-            "version": "==8.2.2"
+            "markers": "python_version >= '3.8'",
+            "version": "==8.3.2"
         },
         "pytest-cov": {
             "hashes": [
@@ -1252,6 +1212,7 @@
                 "sha256:5837b58e9f6ebd335b0f8060eecce69b662415b16dc503883a02f45dfeb14857"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==5.0.0"
         },
         "python-dateutil": {
@@ -1317,6 +1278,7 @@
                 "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.6'",
             "version": "==6.0.1"
         },
         "requests": {
@@ -1325,6 +1287,7 @@
                 "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==2.32.3"
         },
         "responses": {
@@ -1333,6 +1296,7 @@
                 "sha256:617b9247abd9ae28313d57a75880422d55ec63c29d33d629697590a034358dba"
             ],
             "index": "pypi",
+            "markers": "python_version >= '3.8'",
             "version": "==0.25.3"
         },
         "ruff": {
@@ -1392,28 +1356,12 @@
             "markers": "python_version >= '3.8'",
             "version": "==0.13.0"
         },
-        "types-awscrt": {
-            "hashes": [
-                "sha256:0839fe12f0f914d8f7d63ed777c728cb4eccc2d5d79a26e377d12b0604e7bf0e",
-                "sha256:84a9f4f422ec525c314fdf54c23a1e73edfbcec968560943ca2d41cfae623b38"
-            ],
-            "markers": "python_version >= '3.7' and python_version < '4.0'",
-            "version": "==0.21.2"
-        },
-        "types-s3transfer": {
-            "hashes": [
-                "sha256:02154cce46528287ad76ad1a0153840e0492239a0887e8833466eccf84b98da0",
-                "sha256:49a7c81fa609ac1532f8de3756e64b58afcecad8767933310228002ec7adff74"
-            ],
-            "markers": "python_version >= '3.8' and python_version < '4.0'",
-            "version": "==0.10.1"
-        },
         "typing-extensions": {
             "hashes": [
                 "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d",
                 "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8"
             ],
-            "markers": "python_version < '3.10'",
+            "markers": "python_version >= '3.8'",
             "version": "==4.12.2"
         },
         "urllib3": {
@@ -1421,7 +1369,7 @@
                 "sha256:37a0344459b199fce0e80b0d3569837ec6b6937435c5244e7fd73fa6006830f3",
                 "sha256:3e3d753a8618b86d7de333b4223005f68720bcd6a7d2bcb9fbd2229ec7c1e429"
             ],
-            "markers": "python_version < '3.10'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
             "version": "==1.26.19"
         },
         "werkzeug": {

--- a/orchestrator/Pipfile.lock
+++ b/orchestrator/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "cfa8ec9593f98648ac62ad5e5d598d92fef8440ad21a6436b1b862906d0e75dd"
+            "sha256": "c96c19e262874904ba370e4464385a2f61e2ebbad013ca7e5f68ad983254b193"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -40,6 +40,21 @@
             "index": "pypi",
             "version": "==1.34.144"
         },
+        "boto3-stubs": {
+            "extras": [
+                "ec2",
+                "lambda",
+                "s3",
+                "secretsmanager",
+                "sqs"
+            ],
+            "hashes": [
+                "sha256:310138d9997ab318cc0da762b6629e80cadb31badac89b148213f077ed155cf4",
+                "sha256:f1b3a6d5fdb6e2986196419a2447df8609e79826b0cc184720fb318d3c123b0d"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.34.152"
+        },
         "botocore": {
             "hashes": [
                 "sha256:4215db28d25309d59c99507f1f77df9089e5bebbad35f6e19c7c44ec5383a3e8",
@@ -47,6 +62,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==1.34.144"
+        },
+        "botocore-stubs": {
+            "hashes": [
+                "sha256:675f21efef0d8c533701e7449f765fd120b627e80a8ced41bafc43c34e021be5",
+                "sha256:89a50f631d74cd7ddd5ab02cf0d0c718d2fc36c1a7e54b84bd4be738d5a239da"
+            ],
+            "markers": "python_version >= '3.8' and python_version < '4.0'",
+            "version": "==1.34.151"
         },
         "certifi": {
             "hashes": [
@@ -288,6 +311,41 @@
             "markers": "python_version >= '3.7'",
             "version": "==1.0.1"
         },
+        "mypy-boto3-ec2": {
+            "hashes": [
+                "sha256:034f8d160535f5cf77fe35c95588454790cd2709f656274604bc36f76406211f",
+                "sha256:9f5b13d7ffcb7fb1d57688a728bcefbeb12ab74f2047ee5a4577b8064f7a3fe3"
+            ],
+            "version": "==1.34.149"
+        },
+        "mypy-boto3-lambda": {
+            "hashes": [
+                "sha256:7b81d2a5604fb592e92fe0b284ecd259de071703360a33b71c9b54df46d81c9c",
+                "sha256:e21022d2eef12aa731af80790410afdba9412b056339823252813bae2adbf553"
+            ],
+            "version": "==1.34.77"
+        },
+        "mypy-boto3-s3": {
+            "hashes": [
+                "sha256:47ded5f06accc10ff9db9d55c85cca88e4f028ec360d7cfcea90377e525cba56",
+                "sha256:7f9770d1f0e9f6fc2ced96daf5c0792b2dbbb4a4f874f28200ff3c940d0815c3"
+            ],
+            "version": "==1.34.138"
+        },
+        "mypy-boto3-secretsmanager": {
+            "hashes": [
+                "sha256:986511caa6626edfed7eb11b63c929801e9468c58e15927dc6fc0339c4eb34cb",
+                "sha256:e5a82c05cce68168a3709e5f0d35066cf250961db1d8670f0111da66206814c7"
+            ],
+            "version": "==1.34.145"
+        },
+        "mypy-boto3-sqs": {
+            "hashes": [
+                "sha256:bdbc623235ffc8127cb8753f49323f74a919df552247b0b2caaf85cf9bb495b8",
+                "sha256:e92aefacfa08e7094b79002576ef261e4075f5af9c25219fc47fb8452f53fc5f"
+            ],
+            "version": "==1.34.121"
+        },
         "pyasn1": {
             "hashes": [
                 "sha256:3a35ab2c4b5ef98e17dfdec8ab074046fbda76e281c5a706ccd82328cfc8f64c",
@@ -433,6 +491,22 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
+        },
+        "types-awscrt": {
+            "hashes": [
+                "sha256:0839fe12f0f914d8f7d63ed777c728cb4eccc2d5d79a26e377d12b0604e7bf0e",
+                "sha256:84a9f4f422ec525c314fdf54c23a1e73edfbcec968560943ca2d41cfae623b38"
+            ],
+            "markers": "python_version >= '3.7' and python_version < '4.0'",
+            "version": "==0.21.2"
+        },
+        "types-s3transfer": {
+            "hashes": [
+                "sha256:02154cce46528287ad76ad1a0153840e0492239a0887e8833466eccf84b98da0",
+                "sha256:49a7c81fa609ac1532f8de3756e64b58afcecad8767933310228002ec7adff74"
+            ],
+            "markers": "python_version >= '3.8' and python_version < '4.0'",
+            "version": "==0.10.1"
         },
         "typing-extensions": {
             "hashes": [


### PR DESCRIPTION
## Description

Fixes a number of type hints in artemislib and make them more consistent.  Along with these fixes:

* Singleton instance fields are filled-in and typed.
* Cases where values can be `None` are accounted for:
  - Missing bucket names now raise `ValueError` instead of crashing unexpectedly down the line.
  - Handle cases where `ClientError`s are missing a code or message.
  - `Optional[T]` is used instead of `Union[T, None]` for consistency.
* Improved documentation.

Unit tests added and updated as necessary to cover the new cases.

> [!NOTE]
> The only cases where functionality changes are the missing bucket cases where we now raise `ValueError` early.  Almost none of the existing code that calls these functions handled the possibility of these functions failing or returning `None`, so this is an improvement by failing early at the site of the error rather than the failure happening later.  Code which _does_ handle the failure cases catch the exceptions, so nothing changes in those cases.

## Motivation and Context

This is a work-in-progress to gauge the impact of enabling [Pyright](https://microsoft.github.io/pyright/) type checks:

* What type errors are detected?
* What existing bugs / unhandled cases are revealed by type checking?
* What would it take to resolve these issues?

## How Has This Been Tested?

Testing in progress.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
