### PR TITLE
Expose Secret Validity in API

### DIFF
--- a/backend/engine/plugins/gitsecrets/main.py
+++ b/backend/engine/plugins/gitsecrets/main.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from engine.plugins.gitsecrets.secrets_processor import SecretProcessor
 from engine.plugins.lib import utils
 from engine.plugins.lib.common.system.allowlist import SystemAllowList
+from engine.plugins.lib.secrets_common.enums import SecretValidationType
 
 log = utils.setup_logging("gitsecrets")
 
@@ -64,6 +65,7 @@ def run_git_secrets(scan_path: str) -> GIT_SECRETS_RESULT:
             "type": processor.secret_type,
             "author": blame_result.name,
             "author-timestamp": blame_result.timestamp,
+            "validity": SecretValidationType.UNKNOWN,
         }
         results.append(item)
         event_info[item_id] = {"match": processor.secret, "type": item["type"]}

--- a/backend/engine/plugins/gitsecrets/main.py
+++ b/backend/engine/plugins/gitsecrets/main.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from engine.plugins.gitsecrets.secrets_processor import SecretProcessor
 from engine.plugins.lib import utils
 from engine.plugins.lib.common.system.allowlist import SystemAllowList
-from engine.plugins.lib.secrets_common.enums import SecretValidationType
+from engine.plugins.lib.secrets_common.enums import SecretValidity
 
 log = utils.setup_logging("gitsecrets")
 
@@ -65,7 +65,7 @@ def run_git_secrets(scan_path: str) -> GIT_SECRETS_RESULT:
             "type": processor.secret_type,
             "author": blame_result.name,
             "author-timestamp": blame_result.timestamp,
-            "validity": SecretValidationType.UNKNOWN,
+            "validity": SecretValidity.UNKNOWN,
         }
         results.append(item)
         event_info[item_id] = {"match": processor.secret, "type": item["type"]}

--- a/backend/engine/plugins/lib/secrets_common/enums.py
+++ b/backend/engine/plugins/lib/secrets_common/enums.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+
 class SecretValidationType(str, Enum):
     VALID = "valid"
     INVALID = "invalid"

--- a/backend/engine/plugins/lib/secrets_common/enums.py
+++ b/backend/engine/plugins/lib/secrets_common/enums.py
@@ -2,6 +2,6 @@ from enum import Enum
 
 
 class SecretValidationType(str, Enum):
-    VALID = "valid"
-    INVALID = "invalid"
+    ACTIVE = "active"
+    INACTIVE = "inactive"
     UNKNOWN = "unknown"

--- a/backend/engine/plugins/lib/secrets_common/enums.py
+++ b/backend/engine/plugins/lib/secrets_common/enums.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+class SecretValidationType(str, Enum):
+    VALID = "valid"
+    INVALID = "invalid"
+    UNKNOWN = "unknown"

--- a/backend/engine/plugins/lib/secrets_common/enums.py
+++ b/backend/engine/plugins/lib/secrets_common/enums.py
@@ -1,7 +1,7 @@
 from enum import Enum
 
 
-class SecretValidationType(str, Enum):
+class SecretValidity(str, Enum):
     ACTIVE = "active"
     INACTIVE = "inactive"
     UNKNOWN = "unknown"

--- a/backend/engine/plugins/truffle_hog/main.py
+++ b/backend/engine/plugins/truffle_hog/main.py
@@ -5,6 +5,7 @@ from copy import copy
 
 from engine.plugins.lib import utils
 from engine.plugins.lib.common.system.allowlist import SystemAllowList
+from engine.plugins.lib.secrets_common.enums import SecretValidationType
 
 ENDS = {"lock", "lock.json", "DEPS"}
 STARTS = {"vendor"}
@@ -60,7 +61,7 @@ def secret_type(reason: str) -> str:
     return stype
 
 
-def commit_author(scan_path: str, commit: str) -> str:
+def commit_author(scan_path: str, commit: str) -> tuple:
     author = "Unknown author"
     timestamp = ""
 
@@ -92,7 +93,7 @@ def line_number(diff: str) -> int:
         return -1
 
 
-def scrub_results(scan_results: list, scan_path: str) -> list:
+def scrub_results(scan_results: list, scan_path: str) -> dict:
     cleaned_records = []
     event_info = {}
     allowlist = SystemAllowList(al_type="secret")
@@ -124,13 +125,14 @@ def scrub_results(scan_results: list, scan_path: str) -> list:
                 "type": secret_type(record["reason"]),
                 "author": author,
                 "author-timestamp": timestamp,
+                "validity": SecretValidationType.UNKNOWN,
             }
             event_info[item_id] = {"match": matches, "type": record_json["type"]}
             cleaned_records.append(record_json)
     return {"results": cleaned_records, "event_info": event_info}
 
 
-def run_security_checker(scan_path: str, depth=None, rules: str = None) -> list:
+def run_security_checker(scan_path: str, depth=None, rules: str | None = None) -> list:
     log.info("Running trufflehog (depth limit: %s)", depth)
     if depth:
         cmd = [

--- a/backend/engine/plugins/truffle_hog/main.py
+++ b/backend/engine/plugins/truffle_hog/main.py
@@ -1,11 +1,13 @@
 import json
 import subprocess
 import uuid
+
 from copy import copy
+from typing import Optional
 
 from engine.plugins.lib import utils
 from engine.plugins.lib.common.system.allowlist import SystemAllowList
-from engine.plugins.lib.secrets_common.enums import SecretValidationType
+from engine.plugins.lib.secrets_common.enums import SecretValidity
 
 ENDS = {"lock", "lock.json", "DEPS"}
 STARTS = {"vendor"}
@@ -125,14 +127,14 @@ def scrub_results(scan_results: list, scan_path: str) -> dict:
                 "type": secret_type(record["reason"]),
                 "author": author,
                 "author-timestamp": timestamp,
-                "validity": SecretValidationType.UNKNOWN,
+                "validity": SecretValidity.UNKNOWN,
             }
             event_info[item_id] = {"match": matches, "type": record_json["type"]}
             cleaned_records.append(record_json)
     return {"results": cleaned_records, "event_info": event_info}
 
 
-def run_security_checker(scan_path: str, depth=None, rules: str | None = None) -> list:
+def run_security_checker(scan_path: str, depth=None, rules: Optional[str] = None) -> list:
     log.info("Running trufflehog (depth limit: %s)", depth)
     if depth:
         cmd = [

--- a/backend/engine/plugins/trufflehog/main.py
+++ b/backend/engine/plugins/trufflehog/main.py
@@ -50,7 +50,7 @@ def get_validity(finding):
     verified = finding.get("Verified")
 
     if verified == True:
-        return SecretValidationType.VALID
+        return SecretValidationType.ACTIVE
     else:
         # We can't be sure that the secret is invalid if `verified=false`, since there could have
         # been a verification error or Trufflehog did not attempt to verify. So, we set it to

--- a/backend/engine/plugins/trufflehog/main.py
+++ b/backend/engine/plugins/trufflehog/main.py
@@ -4,7 +4,7 @@ import uuid
 
 from engine.plugins.lib import utils
 from engine.plugins.lib.common.system.allowlist import SystemAllowList
-from engine.plugins.lib.secrets_common.enums import SecretValidationType
+from engine.plugins.lib.secrets_common.enums import SecretValidity
 
 ENDS = {"lock", "lock.json", "DEPS"}
 STARTS = {"vendor"}
@@ -50,12 +50,12 @@ def get_validity(finding):
     verified = finding.get("Verified")
 
     if verified == True:
-        return SecretValidationType.ACTIVE
+        return SecretValidity.ACTIVE
     else:
         # We can't be sure that the secret is invalid if `verified=false`, since there could have
         # been a verification error or Trufflehog did not attempt to verify. So, we set it to
         # unknown
-        return SecretValidationType.UNKNOWN
+        return SecretValidity.UNKNOWN
 
 
 def scrub_results(scan_results: list, error_dict: dict) -> dict:

--- a/backend/engine/plugins/trufflehog/main.py
+++ b/backend/engine/plugins/trufflehog/main.py
@@ -4,6 +4,7 @@ import uuid
 
 from engine.plugins.lib import utils
 from engine.plugins.lib.common.system.allowlist import SystemAllowList
+from engine.plugins.lib.secrets_common.enums import SecretValidationType
 
 ENDS = {"lock", "lock.json", "DEPS"}
 STARTS = {"vendor"}
@@ -45,7 +46,19 @@ def get_finding_type(finding):
     return finding.get("DetectorName").lower()
 
 
-def scrub_results(scan_results: list, error_dict: dict) -> list:
+def get_validity(finding):
+    verified = finding.get("Verified")
+
+    if verified == True:
+        return SecretValidationType.VALID
+    else:
+        # We can't be sure that the secret is invalid if `verified=false`, since there could have
+        # been a verification error or Trufflehog did not attempt to verify. So, we set it to
+        # unknown
+        return SecretValidationType.UNKNOWN
+
+
+def scrub_results(scan_results: list, error_dict: dict) -> dict:
     cleaned_records = []
     event_info = {}
     allowlist = SystemAllowList(al_type="secret")
@@ -85,6 +98,7 @@ def scrub_results(scan_results: list, error_dict: dict) -> list:
                 "type": get_finding_type(record),
                 "author": source_metadata.get("email"),
                 "author-timestamp": source_metadata.get("timestamp"),
+                "validity": get_validity(record),
             }
 
             event_info[item_id] = {"match": [finding_raw], "type": record_json["type"]}

--- a/backend/engine/tests/test_plugin_truffle_hog.py
+++ b/backend/engine/tests/test_plugin_truffle_hog.py
@@ -5,6 +5,7 @@ from contextlib import redirect_stdout
 from mock import MagicMock, patch
 
 from engine.plugins.lib import utils
+from engine.plugins.lib.secrets_common.enums import SecretValidity
 from engine.plugins.truffle_hog import main as truffle_hog
 
 
@@ -77,6 +78,7 @@ class TestPluginTruffle_hog(unittest.TestCase):
             "type": "aws",
             "author": "test@example.com",
             "author-timestamp": "2020-01-01T00:00:00.000000+00:00",
+            "validity": SecretValidity.UNKNOWN,
         }
         expected_event = {actual["results"][0]["id"]: {"match": ["YER' A STRING 'ARRY"], "type": "aws"}}
         expected = {"results": [expected1], "event_info": expected_event}

--- a/backend/engine/tests/test_plugin_trufflehog.py
+++ b/backend/engine/tests/test_plugin_trufflehog.py
@@ -6,6 +6,7 @@ from contextlib import redirect_stdout
 from mock import MagicMock, patch
 
 from engine.plugins.lib import utils
+from engine.plugins.lib.secrets_common.enums import SecretValidity
 from engine.plugins.trufflehog import main as trufflehog
 
 EXAMPLE_EMAIL = "email@example.com"
@@ -185,6 +186,7 @@ class TestPluginTrufflehog(unittest.TestCase):
             "type": expected_type,
             "author": EXAMPLE_EMAIL,
             "author-timestamp": "2021-01-01 00:00:00 +0000",
+            "validity": SecretValidity.UNKNOWN,
         }
         expected_event = {actual["results"][0]["id"]: {"match": ["YER' A STRING 'ARRY"], "type": expected_type}}
         expected = {"results": [expected1], "event_info": expected_event}

--- a/backend/lambdas/generators/json_report/json_report/results/secret.py
+++ b/backend/lambdas/generators/json_report/json_report/results/secret.py
@@ -54,7 +54,14 @@ def get_secrets(scan, params):
             # Build the full secrets results
             if s["filename"] not in secrets:
                 secrets[s["filename"]] = []
-            item = {"type": s.get("type"), "line": s.get("line"), "commit": s.get("commit")}
+
+            item = {
+                "type": s.get("type"),
+                "line": s.get("line"),
+                "commit": s.get("commit"),
+                "validity": s.get("validity"),
+            }
+
             if item not in secrets[s["filename"]]:
                 secrets[s["filename"]].append(item)
 

--- a/backend/lambdas/generators/json_report/json_report/results/secret.py
+++ b/backend/lambdas/generators/json_report/json_report/results/secret.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass, asdict
 from datetime import datetime, timezone
 
 from artemisdb.artemisdb.consts import PluginType
@@ -9,6 +10,21 @@ from json_report.results.results import PLUGIN_RESULTS, PluginErrors
 from json_report.util.util import dict_eq
 
 
+@dataclass
+class SecretFinding:
+    type: str
+    line: int
+    commit: str
+    validity: str
+
+    def to_dict(self):
+        return asdict(self)
+
+
+FindingDictType = dict[tuple[str, int, str], SecretFinding]
+FilenameDictType = dict[str, FindingDictType]
+
+
 def get_secrets(scan, params):
     # Unify the output of secrets plugins
 
@@ -18,7 +34,6 @@ def get_secrets(scan, params):
         secret = params["secret"]
 
     success = True
-    secrets = {}
     errors = PluginErrors()
     summary = 0
 
@@ -35,38 +50,50 @@ def get_secrets(scan, params):
         # If the scan was run with a diff set the diff_summary
         diff_summary = scan.diff_summary
 
+    filename_dict: FilenameDictType = {}
+
     plugin = _empty = object()
     for plugin in scan.pluginresult_set.filter(plugin_type=PluginType.SECRETS.value):
         if plugin.errors:
             errors.update(plugin)
 
-        for s in plugin.details:
+        for finding in plugin.details:
             if (
-                s.get("type") not in secret
-                or allowlisted_secret(s, allow_list)
-                or not diff_includes(s.get("filename"), s.get("line"), diff_summary)
+                finding.get("type") not in secret
+                or allowlisted_secret(finding, allow_list)
+                or not diff_includes(finding.get("filename"), finding.get("line"), diff_summary)
             ):
                 # Secret type is filtered out or whitelisted or line is not part of diff so skip it
                 continue
 
             success = False  # Reached a non-whitelisted, non-filtered secret
 
-            # Build the full secrets results
-            if s["filename"] not in secrets:
-                secrets[s["filename"]] = []
+            filename = finding["filename"]
+            if filename not in filename_dict:
+                filename_dict[filename] = {}
+            findings_dict = filename_dict[filename]
 
-            item = {
-                "type": s.get("type"),
-                "line": s.get("line"),
-                "commit": s.get("commit"),
-                "validity": s.get("validity"),
-            }
+            item = SecretFinding(
+                type=finding.get("type"),
+                line=finding.get("line"),
+                commit=finding.get("commit"),
+                validity=finding.get("validity"),
+            )
 
-            if item not in secrets[s["filename"]]:
-                secrets[s["filename"]].append(item)
+            key = get_finding_dict_key(item)
 
-            # Update the summary count
-            summary += 1
+            # Add the new finding if it doesn't exist
+            # If it already exists, take the higher validity
+            if key in findings_dict:
+                existing_finding = findings_dict[key]
+                highest_validity = get_highest_validity(existing_finding.validity, item.validity)
+
+                existing_finding.validity = highest_validity
+            else:
+                findings_dict[key] = item
+                summary += 1
+
+    secrets = get_secrets_from_filename_dict(filename_dict)
 
     if plugin is _empty:
         # Loop of secret plugins never ran so there were no secret plugin results. In this case the summary should be
@@ -82,3 +109,28 @@ def allowlisted_secret(item, allow_list):
         if dict_eq(al.value, item, ["filename", "line", "commit"]):
             return True
     return False
+
+
+def get_finding_dict_key(finding: SecretFinding) -> tuple[str, int, str]:
+    type = finding.type
+    line = finding.line
+    commit = finding.commit
+
+    return (type, line, commit)
+
+
+def get_highest_validity(one: str, two: str) -> str:
+    if one == "active" or two == "active":
+        return "active"
+    elif one == "inactive" or two == "inactive":
+        return "inactive"
+    else:
+        return "unknown"
+
+
+def get_secrets_from_filename_dict(filename_dict: FilenameDictType) -> dict[str, list[dict]]:
+    secrets = {}
+    for filename, findings_map in filename_dict.items():
+        secrets[filename] = list(finding.to_dict() for finding in findings_map.values())
+
+    return secrets

--- a/backend/lambdas/generators/json_report/json_report/results/secret.py
+++ b/backend/lambdas/generators/json_report/json_report/results/secret.py
@@ -77,7 +77,7 @@ def get_secrets(scan, params):
                 type=finding.get("type"),
                 line=finding.get("line"),
                 commit=finding.get("commit"),
-                validity=finding.get("validity"),
+                validity=finding.get("validity", "unknown"),
             )
 
             key = get_finding_dict_key(item)

--- a/backend/libs/artemisdb/artemisdb/artemisdb/consts.py
+++ b/backend/libs/artemisdb/artemisdb/artemisdb/consts.py
@@ -89,8 +89,3 @@ class ComponentType(Enum):
     GO = "go"
     PHP = "php"
     MAVEN = "maven"
-
-class SecretValidationType(Enum):
-    VALID = "valid"
-    INVALID = "invalid"
-    UNKNOWN = "unknown"

--- a/backend/libs/artemisdb/artemisdb/artemisdb/consts.py
+++ b/backend/libs/artemisdb/artemisdb/artemisdb/consts.py
@@ -89,3 +89,8 @@ class ComponentType(Enum):
     GO = "go"
     PHP = "php"
     MAVEN = "maven"
+
+class SecretValidationType(Enum):
+    VALID = "valid"
+    INVALID = "invalid"
+    UNKNOWN = "unknown"


### PR DESCRIPTION
Exposes secret validity in API

## Description
- Adds "validity" field to `gitsecrets`, `trufflehog` and `truffle_hog` results
  - `gitsecrets` and `truffle_hog` (legacy trufflehog) do not attempt to validate findings, so their results are always unknown
  - `trufflehog` (v3) will try to validate findings and will return either Active or Unknown
  - GHAS secrets already exposed the `validity` field
- Modifies the `json_report` generator to show validity
- Also fixes invalid types in files that are touched

## Motivation and Context
- GHAS secrets and Trufflehog v3 can attempt to validate that findings are legitimate. We want to surface this information to users

## How Has This Been Tested?
- Working in dev environment
- Tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Pic
![That's valid](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExOXAwM3F3bXZ4bWU5bWE0OXRxMnFhc25ieW9hdm83ZWUzbjR3aW8xbCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/eJk53qGy8m0WqfCLET/giphy.webp)