### PR TITLE
Return failed Lambda messages to SQS

### DIFF
--- a/backend/build_scripts/update_lambda_layers.py
+++ b/backend/build_scripts/update_lambda_layers.py
@@ -8,7 +8,9 @@ import boto3
 def main():
     parser = argparse.ArgumentParser(description=f"Lambda Layer Update")
 
-    parser.add_argument("--function-name", required=True, type=str, help="Name of the Lambda to update")
+    parser.add_argument(
+        "--function-name", required=True, type=str, help="Name of the Lambda to update"
+    )
     parser.add_argument("--region", required=True, type=str, help="AWS region name")
     args = parser.parse_args()
 
@@ -18,7 +20,9 @@ def main():
     config = client.get_function_configuration(FunctionName=args.function_name)
     layers = get_layers(config)
     latest = get_latest_layer_versions(layers, client)
-    response = client.update_function_configuration(FunctionName=args.function_name, Layers=latest)
+    response = client.update_function_configuration(
+        FunctionName=args.function_name, Layers=latest
+    )
 
     print(f'Update status: {response["LastUpdateStatus"]}')
 
@@ -29,6 +33,9 @@ def get_layers(config: dict) -> list:
     for layer in config.get("Layers", []):
         print(layer["Arn"])
         arn = layer["Arn"].rsplit(":", maxsplit=1)[0]
+        if "Datadog-Extension" in arn or "Datadog-Python" in arn:
+            # Skip Datadog layers
+            continue
         layers.append(arn)
     return layers
 

--- a/backend/build_scripts/update_lambda_layers.py
+++ b/backend/build_scripts/update_lambda_layers.py
@@ -29,9 +29,6 @@ def get_layers(config: dict) -> list:
     for layer in config.get("Layers", []):
         print(layer["Arn"])
         arn = layer["Arn"].rsplit(":", maxsplit=1)[0]
-        if "Datadog-Extension" in arn or "Datadog-Python" in arn:
-            # Skip Datadog layers
-            continue
         layers.append(arn)
     return layers
 

--- a/backend/build_scripts/update_lambda_layers.py
+++ b/backend/build_scripts/update_lambda_layers.py
@@ -8,9 +8,7 @@ import boto3
 def main():
     parser = argparse.ArgumentParser(description=f"Lambda Layer Update")
 
-    parser.add_argument(
-        "--function-name", required=True, type=str, help="Name of the Lambda to update"
-    )
+    parser.add_argument("--function-name", required=True, type=str, help="Name of the Lambda to update")
     parser.add_argument("--region", required=True, type=str, help="AWS region name")
     args = parser.parse_args()
 
@@ -20,9 +18,7 @@ def main():
     config = client.get_function_configuration(FunctionName=args.function_name)
     layers = get_layers(config)
     latest = get_latest_layer_versions(layers, client)
-    response = client.update_function_configuration(
-        FunctionName=args.function_name, Layers=latest
-    )
+    response = client.update_function_configuration(FunctionName=args.function_name, Layers=latest)
 
     print(f'Update status: {response["LastUpdateStatus"]}')
 

--- a/orchestrator/lambdas/repo_queue/repo_queue/repo_queue.py
+++ b/orchestrator/lambdas/repo_queue/repo_queue/repo_queue.py
@@ -59,7 +59,7 @@ def run(event: dict[str, Any] = None, context: LambdaContext = None, services_fi
 
         if i != 0:
             log.debug(f"{i} queued")
-    return {"batchItemFailures" : batch_item_failures}
+    return {"batchItemFailures": batch_item_failures}
 
 
 def group(iterable, n, fillvalue=None):

--- a/orchestrator/lambdas/repo_queue/repo_queue/repo_queue.py
+++ b/orchestrator/lambdas/repo_queue/repo_queue/repo_queue.py
@@ -20,7 +20,7 @@ log = Logger(service=APPLICATION, name="repo_queue")
 
 
 @log.inject_lambda_context
-def run(event: dict[str, Any] = None, context: LambdaContext = None, services_file: str = None) -> list:
+def run(event: dict[str, Any] = None, context: LambdaContext = None, services_file: str = None) -> dict:
     batch_item_failures = []
     full_services_dict = get_services_dict(services_file)
     services = full_services_dict.get("services")
@@ -59,7 +59,7 @@ def run(event: dict[str, Any] = None, context: LambdaContext = None, services_fi
 
         if i != 0:
             log.debug(f"{i} queued")
-    return batch_item_failures
+    return {"batchItemFailures" : batch_item_failures}
 
 
 def group(iterable, n, fillvalue=None):

--- a/orchestrator/lambdas/repo_queue/repo_queue/repo_queue_env.py
+++ b/orchestrator/lambdas/repo_queue/repo_queue/repo_queue_env.py
@@ -11,7 +11,6 @@ from heimdall_repos.gitlab_utils import ProcessGitlabRepos
 ORG_QUEUE = os.environ.get("ORG_QUEUE")
 REPO_QUEUE = os.environ.get("REPO_QUEUE")
 REGION = os.environ.get("REGION", "us-east-1")
-ORG_DLQ = os.environ.get("ORG_DEAD_LETTER_QUEUE")
 
 SERVICE_PROCESSORS = {
     "github": ProcessGithubRepos,

--- a/orchestrator/terraform/modules/heimdall/lambdas.tf
+++ b/orchestrator/terraform/modules/heimdall/lambdas.tf
@@ -102,7 +102,6 @@ resource "aws_lambda_function" "repo-queue" {
       ARTEMIS_S3_BUCKET                 = data.aws_s3_bucket.artemis_s3_bucket.bucket
       REPO_QUEUE                        = aws_sqs_queue.repo-queue.id
       ORG_QUEUE                         = aws_sqs_queue.org-queue.id
-      ORG_DEAD_LETTER_QUEUE             = aws_sqs_queue.org-deadletter-queue.id
       DEFAULT_API_TIMEOUT               = var.third_party_api_timeout
       HEIMDALL_GITHUB_APP_ID            = var.github_app_id
       HEIMDALL_GITHUB_PRIVATE_KEY       = var.github_private_key
@@ -498,4 +497,6 @@ resource "aws_lambda_event_source_mapping" "org-queue" {
   event_source_arn = aws_sqs_queue.org-queue.arn
   function_name    = aws_lambda_function.repo-queue.arn
   batch_size       = 1
+
+  function_response_types = ["ReportBatchItemFailures"]
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR: 
1. Updates the `repo-queue-lambda` to send failed tasks back to SQS. This is the recommended way for handling failed tasks in Lambdas: https://docs.aws.amazon.com/lambda/latest/dg/services-sqs-errorhandling.html. 
Currently, these messages are manually sent to the Deadletter Queue 

2. Deprecates the `ORG_DEADLETTER_QUEUE` environment variable 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested in a dev environment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Pic
![Embed something funny here](https://giphy.com/trending-gifs)