### PR TITLE
Unit tests for artemis-scan.sh

### DIFF
--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -36,6 +36,7 @@ moto = {extras = ["awslambda", "ec2", "s3", "secretsmanager", "sqs"], version = 
 pylint = "~=3.0"
 pytest = "~=8.2"
 pytest-cov = "~=5.0"
+pytest-httpserver = "~=1.1"
 pytest-subtests = "~=0.12"
 python-dotenv = "~=1.0"
 responses = "~=0.25.0"

--- a/backend/Pipfile.lock
+++ b/backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1e6aaaaa7aa57c95c3d560a2629d655c97a0f6ddf49f2e548adcb53388c4f658"
+            "sha256": "33fbf9dd7b5901bb0003afa857013753cccae048fbbda45ae3af8c66b4aca4ce"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -2429,6 +2429,15 @@
             "markers": "python_version >= '3.8'",
             "version": "==5.0.0"
         },
+        "pytest-httpserver": {
+            "hashes": [
+                "sha256:6b1cb0199e2ed551b1b94d43f096863bbf6ae5bcd7c75c2c06845e5ce2dc8701",
+                "sha256:7ef88be8ed3354b6784daa3daa75a422370327c634053cefb124903fa8d73a41"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==1.1.0"
+        },
         "pytest-subtests": {
             "hashes": [
                 "sha256:989e38f0f1c01bc7c6b2e04db7d9fd859db35d77c2c1a430c831a70cbf3fde2d",
@@ -2815,11 +2824,11 @@
         },
         "werkzeug": {
             "hashes": [
-                "sha256:097e5bfda9f0aba8da6b8545146def481d06aa7d3266e7448e2cccf67dd8bd18",
-                "sha256:fc9645dc43e03e4d630d23143a04a7f947a9a3b5727cd535fdfe155a17cc48c8"
+                "sha256:02c9eb92b7d6c06f31a782811505d2157837cea66aaede3e217c7c27c039476c",
+                "sha256:34f2371506b250df4d4f84bfe7b0921e4762525762bbd936614909fe25cd7306"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==3.0.3"
+            "version": "==3.0.4"
         },
         "xmltodict": {
             "hashes": [

--- a/backend/ci-tools/shell/artemis-scan.sh
+++ b/backend/ci-tools/shell/artemis-scan.sh
@@ -90,6 +90,7 @@ fi
 ARTEMIS="https://${ARTEMIS_FQDN:-}"  # This either uses the ARTEMIS_FQDN env var or is set to a static value during the build
 ARTEMIS_API="${ARTEMIS_API:-$ARTEMIS/api/v1}"  # Allow Artemis API prefix to be directly specified (e.g. for testing)
 ARTEMIS_RESULTS="$ARTEMIS/results"
+ARTEMIS_STATUS_INTERVAL="${ARTEMIS_STATUS_INTERVAL:-10}"  # Time in seconds between status checks.
 SERVICE=$1
 RESOURCE=$2
 BRANCH=$3
@@ -217,7 +218,7 @@ log "Scan started ($SCAN)"
 # Wait for the scan to end
 STATUS="queued"
 while [ "$STATUS" != "completed" ] && [ "$STATUS" != "failed" ] && [ "$STATUS" != "error" ] && [ "$STATUS" != "terminated" ]; do
-  sleep 10
+  sleep "$ARTEMIS_STATUS_INTERVAL"
   RESP=$(curl --silent --write-out "\n%{http_code}" \
     --request GET \
     --url "$ARTEMIS_API/$SERVICE/$SCAN?format=summary&results=vulnerabilities&${SEVERITY_ARGS}results=secrets&results=static_analysis" \

--- a/backend/ci-tools/shell/artemis-scan.sh
+++ b/backend/ci-tools/shell/artemis-scan.sh
@@ -88,7 +88,7 @@ fi
 
 # Scan parameters
 ARTEMIS="https://${ARTEMIS_FQDN:-}"  # This either uses the ARTEMIS_FQDN env var or is set to a static value during the build
-ARTEMIS_API="$ARTEMIS/api/v1"
+ARTEMIS_API="${ARTEMIS_API:-$ARTEMIS/api/v1}"  # Allow Artemis API prefix to be directly specified (e.g. for testing)
 ARTEMIS_RESULTS="$ARTEMIS/results"
 SERVICE=$1
 RESOURCE=$2

--- a/backend/ci-tools/tests/test_artemis_scan_sh.py
+++ b/backend/ci-tools/tests/test_artemis_scan_sh.py
@@ -1,0 +1,232 @@
+import logging
+import pytest
+import subprocess
+from pytest_httpserver import HTTPServer, RequestHandler
+from typing import Tuple
+from werkzeug.datastructures import MultiDict
+
+LOGGER = logging.getLogger(__name__)
+
+API_KEY = "test-key"
+DEFAULT_ARGS = ["service", "repo", "main", "critical,high"]
+SCAN_ID = "a909dc2b-59f9-4483-99e9-1de2e5d41459"
+
+# Example analysis report to return from the status check request.
+BASIC_ANALYSIS_REPORT = {
+    "repo": "repo",
+    "scan_id": SCAN_ID,
+    "branch": "main",
+    "initiated_by": "system",
+}
+
+
+def _run_script(
+    httpserver: HTTPServer, args: list[str] = DEFAULT_ARGS, env: dict[str, str] = {}
+) -> Tuple[str, str, int]:
+    """
+    Runs the artemis-scan.sh script with the test HTTP server.
+
+    Returns the captured stdout, stderr, and exit code.
+    """
+    merged_env = {
+        "ARTEMIS_API": httpserver.url_for("/api/v1"),
+        "ARTEMIS_API_KEY": API_KEY,
+        "ARTEMIS_STATUS_INTERVAL": "0",  # Don't wait between status checks.
+    } | env
+    LOGGER.info(merged_env)
+    proc = subprocess.run(args=["ci-tools/shell/artemis-scan.sh", *args], env=merged_env, capture_output=True)
+    return (proc.stdout.decode("utf-8"), proc.stderr.decode("utf-8"), proc.returncode)
+
+
+def _expect_scan_req(httpserver: HTTPServer) -> RequestHandler:
+    """
+    Registers an expected scan request.
+
+    Returns the request handler.
+    """
+    return httpserver.expect_ordered_request(method="POST", uri="/api/v1/service/repo", headers={"x-api-key": API_KEY})
+
+
+def _expect_status_req(httpserver: HTTPServer) -> RequestHandler:
+    """
+    Registers an expected status request.
+
+    Returns the request handler.
+    """
+    return httpserver.expect_ordered_request(
+        method="GET",
+        uri=f"/api/v1/service/{SCAN_ID}",
+        headers={"x-api-key": API_KEY},
+        query_string=MultiDict(
+            [
+                ("format", "summary"),
+                ("results", "vulnerabilities"),
+                ("results", "secrets"),
+                ("results", "static_analysis"),
+                ("severity", "critical"),
+                ("severity", "high"),
+            ]
+        ),
+    )
+
+
+def test_missing_opts(httpserver: HTTPServer):
+    """
+    Test when no arguments are passed, the usage is printed.
+    """
+    (out, err, ret) = _run_script(httpserver, args=[])
+    assert err == ""
+    assert out.find("Positional arguments:") >= 0
+    assert ret != 0
+
+
+def test_missing_api_key(httpserver: HTTPServer):
+    """
+    Test when ARTEMIS_API_KEY is not set.
+    """
+    (out, err, ret) = _run_script(httpserver, env={"ARTEMIS_API_KEY": ""})
+    assert err == ""
+    assert out.find("environment variable is not set") >= 0
+    assert ret != 0
+
+
+def test_unauthorized(httpserver: HTTPServer):
+    """
+    Test when API key is rejected.
+    """
+    _expect_scan_req(httpserver).respond_with_json(status=403, response_json={"message": "unauthorized"})
+
+    (out, err, ret) = _run_script(httpserver)
+    assert err == ""
+    assert out.find("Scan failed to start")
+    assert ret != 0
+
+
+@pytest.mark.parametrize("fail_closed,retcode", [(False, 0), (True, 1)])
+def test_maintenance_mode(httpserver: HTTPServer, fail_closed: bool, retcode: int):
+    """
+    Test when maintenance mode is enabled on the server.
+    """
+    args = ["-c"] if fail_closed else []
+    args += DEFAULT_ARGS
+
+    _expect_scan_req(httpserver).respond_with_json(
+        status=503, response_json={"maintenance": True, "message": "upgrading"}
+    )
+
+    (out, err, ret) = _run_script(httpserver, args=args)
+    assert err == ""
+    assert out.find("Artemis is in maintenance mode") >= 0
+    assert ret == retcode
+
+
+def test_queue_failed(httpserver: HTTPServer):
+    """
+    Test when the scan fails to be added to the queue.
+    """
+    _expect_scan_req(httpserver).respond_with_json(
+        {"queued": [], "failed": [{"repo": "repo", "error": "error message"}]}
+    )
+
+    (out, err, ret) = _run_script(httpserver)
+    assert err == ""
+    assert out.find("Scan failed to start") >= 0
+    assert ret != 0
+
+
+@pytest.mark.parametrize("fail_closed,retcode", [(False, 0), (True, 1)])
+def test_scan_maintenance_mode(httpserver: HTTPServer, fail_closed: bool, retcode: int):
+    """
+    Test when maintenance mode is activated during a scan.
+    """
+    args = ["-c"] if fail_closed else []
+    args += DEFAULT_ARGS
+
+    _expect_scan_req(httpserver).respond_with_json({"queued": [SCAN_ID], "failed": []})
+    _expect_status_req(httpserver).respond_with_json(
+        status=503, response_json={"maintenance": True, "message": "upgrading"}
+    )
+
+    (out, err, ret) = _run_script(httpserver, args=args)
+    assert err == ""
+    assert out.find("Artemis is in maintenance mode") >= 0
+    assert ret == retcode
+
+
+@pytest.mark.xfail(reason="Scan details are not valid JSON")
+def test_scan_error(httpserver: HTTPServer):
+    """
+    Test a scan that was aborted due to an error.
+    """
+    _expect_scan_req(httpserver).respond_with_json({"queued": [SCAN_ID], "failed": []})
+    _expect_status_req(httpserver).respond_with_json(
+        BASIC_ANALYSIS_REPORT | {"status": "error"},
+    )
+
+    (out, err, ret) = _run_script(httpserver)
+    assert err == ""
+    assert out.find("Scan failed") >= 0
+    assert ret != 0
+
+
+def test_scan_completed_success(httpserver: HTTPServer):
+    """
+    Test a normal successful scan.
+    """
+    _expect_scan_req(httpserver).respond_with_json({"queued": [SCAN_ID], "failed": []})
+    _expect_status_req(httpserver).respond_with_json(
+        BASIC_ANALYSIS_REPORT | {"status": "queued"},
+    )
+    _expect_status_req(httpserver).respond_with_json(
+        BASIC_ANALYSIS_REPORT
+        | {
+            "status": "completed",
+            "success": True,
+        },
+    )
+
+    (out, err, ret) = _run_script(httpserver)
+    assert err == ""
+    assert out.find("Scan status: completed") >= 0
+    assert out.find("Analysis result: pass") >= 0
+    assert ret == 0
+
+
+def test_scan_completed_failed(httpserver: HTTPServer):
+    """
+    Test a normal scan with findings.
+    """
+    _expect_scan_req(httpserver).respond_with_json({"queued": [SCAN_ID], "failed": []})
+    _expect_status_req(httpserver).respond_with_json(
+        BASIC_ANALYSIS_REPORT | {"status": "queued"},
+    )
+    _expect_status_req(httpserver).respond_with_json(
+        BASIC_ANALYSIS_REPORT
+        | {
+            "status": "completed",
+            "success": False,
+            "results_summary": {
+                "vulnerabilities": {
+                    "critical": 5,
+                    "high": 4,
+                    "medium": 3,
+                    "low": 2,
+                    "negligible": 1,
+                },
+                "secrets": 123,
+                "static_analysis": {
+                    "critical": 5,
+                    "high": 4,
+                    "medium": 3,
+                    "low": 2,
+                    "negligible": 1,
+                },
+            },
+        },
+    )
+
+    (out, err, ret) = _run_script(httpserver)
+    assert err == ""
+    assert out.find("Scan status: completed") >= 0
+    assert out.find("Analysis result: fail") >= 0
+    assert ret != 0

--- a/backend/ci-tools/tests/test_artemis_scan_sh.py
+++ b/backend/ci-tools/tests/test_artemis_scan_sh.py
@@ -2,7 +2,6 @@ import logging
 import pytest
 import subprocess
 from pytest_httpserver import HTTPServer, RequestHandler
-from typing import Tuple
 from werkzeug.datastructures import MultiDict
 
 LOGGER = logging.getLogger(__name__)
@@ -22,7 +21,7 @@ BASIC_ANALYSIS_REPORT = {
 
 def _run_script(
     httpserver: HTTPServer, args: list[str] = DEFAULT_ARGS, env: dict[str, str] = {}
-) -> Tuple[str, str, int]:
+) -> tuple[str, str, int]:
     """
     Runs the artemis-scan.sh script with the test HTTP server.
 

--- a/backend/ci-tools/tests/test_artemis_scan_sh.py
+++ b/backend/ci-tools/tests/test_artemis_scan_sh.py
@@ -1,10 +1,7 @@
-import logging
 import pytest
 import subprocess
 from pytest_httpserver import HTTPServer, RequestHandler
 from werkzeug.datastructures import MultiDict
-
-LOGGER = logging.getLogger(__name__)
 
 API_KEY = "test-key"
 DEFAULT_ARGS = ["service", "repo", "main", "critical,high"]
@@ -32,7 +29,6 @@ def _run_script(
         "ARTEMIS_API_KEY": API_KEY,
         "ARTEMIS_STATUS_INTERVAL": "0",  # Don't wait between status checks.
     } | env
-    LOGGER.info(merged_env)
     proc = subprocess.run(args=["ci-tools/shell/artemis-scan.sh", *args], env=merged_env, capture_output=True)
     return (proc.stdout.decode("utf-8"), proc.stderr.decode("utf-8"), proc.returncode)
 

--- a/backend/ci-tools/tests/test_artemis_scan_sh.py
+++ b/backend/ci-tools/tests/test_artemis_scan_sh.py
@@ -75,7 +75,7 @@ def test_missing_opts(httpserver: HTTPServer):
     """
     (out, err, ret) = _run_script(httpserver, args=[])
     assert err == ""
-    assert out.find("Positional arguments:") >= 0
+    assert "Positional arguments:" in out
     assert ret != 0
 
 
@@ -85,7 +85,7 @@ def test_missing_api_key(httpserver: HTTPServer):
     """
     (out, err, ret) = _run_script(httpserver, env={"ARTEMIS_API_KEY": ""})
     assert err == ""
-    assert out.find("environment variable is not set") >= 0
+    assert "environment variable is not set" in out
     assert ret != 0
 
 
@@ -97,7 +97,7 @@ def test_unauthorized(httpserver: HTTPServer):
 
     (out, err, ret) = _run_script(httpserver)
     assert err == ""
-    assert out.find("Scan failed to start")
+    assert "Scan failed to start" in out
     assert ret != 0
 
 
@@ -115,7 +115,7 @@ def test_maintenance_mode(httpserver: HTTPServer, fail_closed: bool, retcode: in
 
     (out, err, ret) = _run_script(httpserver, args=args)
     assert err == ""
-    assert out.find("Artemis is in maintenance mode") >= 0
+    assert "Artemis is in maintenance mode" in out
     assert ret == retcode
 
 
@@ -129,7 +129,7 @@ def test_queue_failed(httpserver: HTTPServer):
 
     (out, err, ret) = _run_script(httpserver)
     assert err == ""
-    assert out.find("Scan failed to start") >= 0
+    assert "Scan failed to start" in out
     assert ret != 0
 
 
@@ -148,7 +148,7 @@ def test_scan_maintenance_mode(httpserver: HTTPServer, fail_closed: bool, retcod
 
     (out, err, ret) = _run_script(httpserver, args=args)
     assert err == ""
-    assert out.find("Artemis is in maintenance mode") >= 0
+    assert "Artemis is in maintenance mode" in out
     assert ret == retcode
 
 
@@ -164,7 +164,7 @@ def test_scan_error(httpserver: HTTPServer):
 
     (out, err, ret) = _run_script(httpserver)
     assert err == ""
-    assert out.find("Scan failed") >= 0
+    assert "Scan failed" in out
     assert ret != 0
 
 
@@ -186,8 +186,8 @@ def test_scan_completed_success(httpserver: HTTPServer):
 
     (out, err, ret) = _run_script(httpserver)
     assert err == ""
-    assert out.find("Scan status: completed") >= 0
-    assert out.find("Analysis result: pass") >= 0
+    assert "Scan status: completed" in out
+    assert "Analysis result: pass" in out
     assert ret == 0
 
 
@@ -226,6 +226,6 @@ def test_scan_completed_failed(httpserver: HTTPServer):
 
     (out, err, ret) = _run_script(httpserver)
     assert err == ""
-    assert out.find("Scan status: completed") >= 0
-    assert out.find("Analysis result: fail") >= 0
+    assert "Scan status: completed" in out
+    assert "Analysis result: fail" in out
     assert ret != 0


### PR DESCRIPTION
## Description

This adds unit tests for artemis-scan.sh, the script we publish for integrating Artemis scans into CI pipelines.

We mock the API calls via [pytest-httpserver](https://pytest-httpserver.readthedocs.io/en/latest/) which creates a local HTTP server for the script to call (via Curl).  This plugin was designed to be used with Pytest-style unit tests, which is why this test suite is in Pytest style rather than "classic" unittest style.

To make testing easier, artemis-scan.sh has two new scan options.  We only document these options in the source code since they're only used internally for the unit tests:

* `ARTEMIS_API` is now overridable so we can point it at the local server.
* `ARTEMIS_STATUS_INTERVAL` adjusts the time to wait between status checks of the in-progress scan, so the unit test doesn't spend time waiting.

These tests are not exhaustive; this initial version aims to cover a range of scenarios which can be built upon in later updates.

## Motivation and Context

We've encountered at least one corner which which is not handled well by artemis-scan.sh. By adding unit tests, we can write tests for the issues we fix and reduce the chance of regressions.

Note: A unit test for one of the error cases which was identified is included in this PR, but is marked as XFAIL.

## How Has This Been Tested?

Tests run locally and in CI.

Ran artemis-scan.sh manually against nonprod environment.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
