### PR TITLE
Fix CI build by restricting setuptools to pre-v74

### DIFF
--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -22,8 +22,10 @@ jobs:
           key: backend-unit-test-tools-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('backend/Makefile') }}
           path: backend/.temp
       - name: Install Test Dependencies
+        # Setuptools v74 is incompatible with our version of packaging, so we restrict it
+        # as well as virtualenv which bundles setuptools in new environments.
         run: |
-          pip install --upgrade pipenv wheel
+          pip install --upgrade pipenv wheel 'setuptools<74' 'virtualenv==20.26.3'
       - name: Run code style tests
         run: make -C backend style-test ENV=example
       - name: Run backend tests

--- a/.github/workflows/test_orchestrator.yml
+++ b/.github/workflows/test_orchestrator.yml
@@ -19,8 +19,10 @@ jobs:
           cache-dependency-path: orchestrator/Pipfile.lock
       - uses: hashicorp/setup-terraform@651471c36a6092792c552e8b1bef71e592b462d8 # hashicorp/setup-terraform@v3.1.1
       - name: Install Test Dependencies
+        # Setuptools v74 is incompatible with our version of packaging, so we restrict it
+        # as well as virtualenv which bundles setuptools in new environments.
         run: |
-          pip install --upgrade pipenv wheel
+          pip install --upgrade pipenv wheel 'setuptools<74' 'virtualenv==20.26.3'
       - name: Run code style tests
         run: make -C orchestrator style-test ENV=example
       - name: Run orchestrator tests


### PR DESCRIPTION
## Description

setuptools v74 is causing a crash when pip installs dependencies with the error:

```
TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'
```

The workaround is to constrain setuptools to v73 or earlier. We must also pin virtulenv since 20.26.4 is hard-coded to install setuptools v74 into new virtual environments.

We can likely remove this restriction when we can upgrade to packaging v24.

## Motivation and Context

Resolve issues with CI build in `pipenv sync` step.

## How Has This Been Tested?

Included in other pending branches.  Splitting the fix out into a separate PR to fix other in-progress branches.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
