### PR TITLE
Gitsecrets Plugin - Add additional types

### DIFF
--- a/backend/engine/plugins/gitsecrets/secret_regex.py
+++ b/backend/engine/plugins/gitsecrets/secret_regex.py
@@ -1,0 +1,7 @@
+from dataclasses import dataclass
+from re import Pattern
+
+@dataclass
+class SecretRegex:
+    finding_type: str
+    regex: Pattern

--- a/backend/engine/plugins/gitsecrets/secret_regex.py
+++ b/backend/engine/plugins/gitsecrets/secret_regex.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from re import Pattern
 
+
 @dataclass
 class SecretRegex:
     finding_type: str

--- a/backend/engine/plugins/gitsecrets/secrets_processor.py
+++ b/backend/engine/plugins/gitsecrets/secrets_processor.py
@@ -2,7 +2,9 @@
 import os
 import re
 from string import Template
+from typing import Optional
 
+from engine.plugins.gitsecrets.secret_regex import SecretRegex
 from engine.plugins.lib.utils import setup_logging
 
 log = setup_logging("gitsecrets")
@@ -10,48 +12,139 @@ log = setup_logging("gitsecrets")
 DEFAULT_SEPARATOR = ":"
 DEFAULT_SETTER_ERROR_MESSAGE = "property $property is read only"
 
+URL_REGEX = r"://[^/\s:@]{3,64}:[^/\s:@]{3,64}@[a-zA-Z0-9\.-]+(:[0-9]{1,5}){0,1})"
+
 # !!! IMPORTANT
 # This regex needs to match the git-secrets regexes in Dockerfiles/data/secret-patterns
 REGEXES = [
-    re.compile(str(r"(amzn\.mws\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})")),
-    re.compile(str(r"(AIza[0-9A-Za-z_-]{35})")),
-    re.compile(str(r"(https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24})")),
-    re.compile(str(r"(AKIA[A-Z0-9]{16})")),
-    re.compile(str(r"(ASIA[A-Z0-9]{16})")),
-    re.compile(str(r"(ACCA[A-Z0-9]{16})")),
-    re.compile(str(r"(EAACEdEose0cBA[0-9A-Za-z]{16,255})")),
-    re.compile(str(r"([f|F][a|A][c|C][e|E][b|B][o|O][o|O][k|K](.){1,64}['|\"][0-9a-f]{32}['|\"])")),
-    re.compile(str(r"([a|A][p|P][i|I][_]?[k|K][e|E][y|Y](.){1,64}['|\"][0-9a-zA-Z]{32,45}['|\"])")),
-    re.compile(str(r"([s|S][e|E][c|C][r|R][e|E][t|T](.){1,64}['|\"][0-9a-zA-Z]{32,45}['|\"])")),
-    re.compile(str(r"([0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com)")),
-    re.compile(str(r"(ya29\.[0-9A-Za-z\-_]{55})")),
-    re.compile(
-        str(
-            (
-                r"((ftp|ftps|http|https|mongodb|mongodb\+srv|postgres)"
-                r"://[^/\s:@]{3,64}:[^/\s:@]{3,64}@[a-zA-Z0-9\.-]+(:[0-9]{1,5}){0,1})"
-            )
-        )
+    SecretRegex(
+        finding_type="Amazon MWS",
+        regex=re.compile(str(r"(amzn\.mws\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})")),
     ),
-    re.compile(
-        str(r"([h|H][e|E][r|R][o|O][k|K][u|U](.){1,64}[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})")
+    SecretRegex(
+        finding_type="google",
+        regex=re.compile(str(r"(AIza[0-9A-Za-z_-]{35})")),
     ),
-    re.compile(str(r"([0-9a-f]{32}-us[0-9]{1,2})")),
-    re.compile(str(r"(key-[0-9a-zA-Z]{32})")),
-    re.compile(str(r"(access_token\$production\$[0-9a-z]{16}\$[0-9a-f]{32})")),
-    re.compile(str(r"(sk_live_[0-9a-z]{32})")),
-    re.compile(str(r"(xox[p|b|o|a]-[0-9]{12}-[0-9]{12}-[0-9]{12}-[a-z0-9]{32})")),
-    re.compile(str(r"(sk_live_[0-9a-zA-Z]{24})")),
-    re.compile(str(r"(rk_live_[0-9a-zA-Z]{24})")),
-    re.compile(str(r"(sq0atp-[0-9A-Za-z\-_]{22})")),
-    re.compile(str(r"(sq0csp-[0-9A-Za-z\-_]{43})")),
-    re.compile(str(r"(SK[0-9a-fA-F]{32})")),
-    re.compile(str(r"([t|T][w|W][i|I][t|T][t|T][e|E][r|R](.){1,64}[1-9][0-9]+-[0-9a-zA-Z]{40})")),
-    re.compile(str(r"([t|T][w|W][i|I][t|T][t|T][e|E][r|R](.){1,64}['|\"][0-9a-zA-Z]{35,44}['|\"])")),
-    re.compile(str(r"((A3T[A-Z0-9]|AKIA|ASIA|ACCA)[A-Z0-9]{16})")),
-    re.compile(str(r"([-]{5}BEGIN\s((RSA|DSA|EC|PGP|OPENSSH)\s)?PRIVATE\s(KEY|KEY\sBLOCK)[-]{5})")),
-    re.compile(str(r"(gh[pousr]_[A-Za-z0-9_]{36,255})")),
-    re.compile(str(r"(github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59})")),
+    SecretRegex(
+        finding_type="slack",
+        regex=re.compile(str(r"(https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24})")),
+    ),
+    SecretRegex(
+        finding_type="aws",
+        regex=re.compile(str(r"(AKIA[A-Z0-9]{16})")),
+    ),
+    SecretRegex(
+        finding_type="aws",
+        regex=re.compile(str(r"(ASIA[A-Z0-9]{16})")),
+    ),
+    SecretRegex(
+        finding_type="aws",
+        regex=re.compile(str(r"(ACCA[A-Z0-9]{16})")),
+    ),
+    SecretRegex(
+        finding_type="facebook",
+        regex=re.compile(str(r"(EAACEdEose0cBA[0-9A-Za-z]{16,255})")),
+    ),
+    SecretRegex(
+        finding_type="facebook",
+        regex=re.compile(str(r"([f|F][a|A][c|C][e|E][b|B][o|O][o|O][k|K](.){1,64}['|\"][0-9a-f]{32}['|\"])")),
+    ),
+    SecretRegex(
+        finding_type="Generic API Key",
+        regex=re.compile(str(r"([a|A][p|P][i|I][_]?[k|K][e|E][y|Y](.){1,64}['|\"][0-9a-zA-Z]{32,45}['|\"])")),
+    ),
+    SecretRegex(
+        finding_type="Generic Secret",
+        regex=re.compile(str(r"([s|S][e|E][c|C][r|R][e|E][t|T](.){1,64}['|\"][0-9a-zA-Z]{32,45}['|\"])")),
+    ),
+    SecretRegex(
+        finding_type="google",
+        regex=re.compile(str(r"([0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com)")),
+    ),
+    SecretRegex(
+        finding_type="google",
+        regex=re.compile(str(r"(ya29\.[0-9A-Za-z\-_]{55})")),
+    ),
+    SecretRegex(
+        finding_type="mongo",
+        regex=re.compile(str(r"((mongodb|mongodb\+srv)" + URL_REGEX)),
+    ),
+    SecretRegex(
+        finding_type="postgres",
+        regex=re.compile(str(r"((postgres)" + URL_REGEX)),
+    ),
+    SecretRegex(
+        finding_type="urlauth",
+        regex=re.compile(str(r"((ftp|ftps|http|https)" + URL_REGEX)),
+    ),
+    SecretRegex(
+        finding_type="Heroku API Key",
+        regex=re.compile(str(r"([h|H][e|E][r|R][o|O][k|K][u|U](.){1,64}[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})")),
+    ),
+    SecretRegex(
+        finding_type="MailChimp API Key",
+        regex=re.compile(str(r"([0-9a-f]{32}-us[0-9]{1,2})")),
+    ),
+    SecretRegex(
+        finding_type="Mailgun API Key",
+        regex=re.compile(str(r"(key-[0-9a-zA-Z]{32})")),
+    ),
+    SecretRegex(
+        finding_type="PayPal Braintree Access Token",
+        regex=re.compile(str(r"(access_token\$production\$[0-9a-z]{16}\$[0-9a-f]{32})")),
+    ),
+    SecretRegex(
+        finding_type="Picatic API Key",
+        regex=re.compile(str(r"(sk_live_[0-9a-z]{32})")),
+    ),
+    SecretRegex(
+        finding_type="slack",
+        regex=re.compile(str(r"(xox[p|b|o|a]-[0-9]{12}-[0-9]{12}-[0-9]{12}-[a-z0-9]{32})")),
+    ),
+    SecretRegex(
+        finding_type="Stripe API Key",
+        regex=re.compile(str(r"(sk_live_[0-9a-zA-Z]{24})")),
+    ),
+    SecretRegex(
+        finding_type="Stripe Restricted API Key",
+        regex=re.compile(str(r"(rk_live_[0-9a-zA-Z]{24})")),
+    ),
+    SecretRegex(
+        finding_type="Square Access Token",
+        regex=re.compile(str(r"(sq0atp-[0-9A-Za-z\-_]{22})")),
+    ),
+    SecretRegex(
+        finding_type="Square OAuth Secret",
+        regex=re.compile(str(r"(sq0csp-[0-9A-Za-z\-_]{43})")),
+    ),
+    SecretRegex(
+        finding_type="Twilio API Key",
+        regex=re.compile(str(r"(SK[0-9a-fA-F]{32})"))
+    ),
+    SecretRegex(
+        finding_type="Twitter Access Token",
+        regex=re.compile(str(r"([t|T][w|W][i|I][t|T][t|T][e|E][r|R](.){1,64}[1-9][0-9]+-[0-9a-zA-Z]{40})")),
+    ),
+    SecretRegex(
+        finding_type="Twitter Oauth",
+        regex=re.compile(str(r"([t|T][w|W][i|I][t|T][t|T][e|E][r|R](.){1,64}['|\"][0-9a-zA-Z]{35,44}['|\"])")),
+    ),
+    SecretRegex(
+        finding_type="aws",
+        regex=re.compile(str(r"((A3T[A-Z0-9]|AKIA|ASIA|ACCA)[A-Z0-9]{16})")),
+    ),
+    SecretRegex(
+        finding_type="ssh",
+        regex=re.compile(str(r"([-]{5}BEGIN\s((RSA|DSA|EC|PGP|OPENSSH)\s)?PRIVATE\s(KEY|KEY\sBLOCK)[-]{5})")),
+    ),
+    SecretRegex(
+        finding_type="github",
+        regex=re.compile(str(r"(gh[pousr]_[A-Za-z0-9_]{36,255})")),
+    ),
+    SecretRegex(
+        finding_type="github",
+        regex=re.compile(str(r"(github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59})")),
+    ),
 ]
 
 
@@ -80,7 +173,6 @@ class SecretProcessor:
             return False
         if not self._process_secret():
             return False
-        self._process_secret_type()
         return True
 
     def _process_filename(self) -> bool:
@@ -114,35 +206,7 @@ class SecretProcessor:
         except ValueError:
             return False
 
-    def _process_secret_type(self) -> None:
-        """
-        Determines secret type based on _secret variable content.
-        Sets _secret_type
-        """
-        stype = "other"
-        if self.secret.startswith("-----"):
-            stype = "ssh"
-        elif "mongodb://" in self.secret:
-            stype = "mongo"
-        elif "mongodb+srv://" in self.secret:
-            stype = "mongo"
-        elif "postgres://" in self.secret:
-            stype = "postgres"
-        elif "hooks.slack.com" in self.secret:
-            stype = "slack"
-        elif ("http" in self.secret or "https" in self.secret) and ":6379" in self.secret:
-            stype = "redis"
-        elif "http" in self.secret or "https" in self.secret or "ftp" in self.secret or "ftps" in self.secret:
-            stype = "urlauth"
-        elif "AIza" in self.secret:
-            stype = "google"
-        else:
-            for prefix in ("AKIA", "ASIA", "ACCA"):
-                if prefix in self.secret:
-                    stype = "aws"
-        self.secret_type = stype
-
-    def _extract_match(self, secret: str) -> str:
+    def _extract_match(self, secret: str) -> tuple[str, str]:
         """
         Cuts down the secret variable to the important piece necessary to identify the secret type
         If a match is found, return the matched portion
@@ -150,11 +214,15 @@ class SecretProcessor:
         """
         # git-secrets returns the entire line that was matched. We only want to
         # return the specific match.
-        for regex in REGEXES:
+        for secret_regex in REGEXES:
+            finding_type = secret_regex.finding_type
+            regex = secret_regex.regex
+
             match = regex.search(secret)
             if match:
-                return match.group(0)
-        return secret
+                return (match.group(0), finding_type) 
+
+        return (secret, "other")
 
     def _process_secret(self) -> bool:
         """
@@ -162,14 +230,18 @@ class SecretProcessor:
         If extract_match somehow returns None, return False.
         """
         secret = f"{self.separator}".join(self.split).strip()
-        secret = self._extract_match(secret)
+        secret, secret_type = self._extract_match(secret)
+
         if not secret:
             return False
+
         self.secret = secret
+        self.secret_type = secret_type
+
         return True
 
     @property
-    def filename(self) -> str:
+    def filename(self) -> Optional[str]:
         return self._filename
 
     @filename.setter
@@ -188,7 +260,7 @@ class SecretProcessor:
             raise ValueError(Template(DEFAULT_SETTER_ERROR_MESSAGE).substitute(property="filename"))
 
     @property
-    def line_number(self) -> int:
+    def line_number(self) -> Optional[int]:
         return self._line_number
 
     @line_number.setter
@@ -199,7 +271,7 @@ class SecretProcessor:
             raise ValueError(Template(DEFAULT_SETTER_ERROR_MESSAGE).substitute(property="line_number"))
 
     @property
-    def secret(self) -> str:
+    def secret(self) -> Optional[str]:
         return self._secret
 
     @secret.setter
@@ -210,7 +282,7 @@ class SecretProcessor:
             raise ValueError(Template(DEFAULT_SETTER_ERROR_MESSAGE).substitute(property="secret"))
 
     @property
-    def secret_type(self) -> str:
+    def secret_type(self) -> Optional[str]:
         return self._secret_type
 
     @secret_type.setter

--- a/backend/engine/plugins/gitsecrets/secrets_processor.py
+++ b/backend/engine/plugins/gitsecrets/secrets_processor.py
@@ -79,7 +79,11 @@ REGEXES = [
     ),
     SecretRegex(
         finding_type="Heroku API Key",
-        regex=re.compile(str(r"([h|H][e|E][r|R][o|O][k|K][u|U](.){1,64}[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})")),
+        regex=re.compile(
+            str(
+                r"([h|H][e|E][r|R][o|O][k|K][u|U](.){1,64}[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})"
+            )
+        ),
     ),
     SecretRegex(
         finding_type="MailChimp API Key",
@@ -117,10 +121,7 @@ REGEXES = [
         finding_type="Square OAuth Secret",
         regex=re.compile(str(r"(sq0csp-[0-9A-Za-z\-_]{43})")),
     ),
-    SecretRegex(
-        finding_type="Twilio API Key",
-        regex=re.compile(str(r"(SK[0-9a-fA-F]{32})"))
-    ),
+    SecretRegex(finding_type="Twilio API Key", regex=re.compile(str(r"(SK[0-9a-fA-F]{32})"))),
     SecretRegex(
         finding_type="Twitter Access Token",
         regex=re.compile(str(r"([t|T][w|W][i|I][t|T][t|T][e|E][r|R](.){1,64}[1-9][0-9]+-[0-9a-zA-Z]{40})")),
@@ -220,7 +221,7 @@ class SecretProcessor:
 
             match = regex.search(secret)
             if match:
-                return (match.group(0), finding_type) 
+                return (match.group(0), finding_type)
 
         return (secret, "other")
 

--- a/backend/engine/tests/test_plugin_gitsecrets.py
+++ b/backend/engine/tests/test_plugin_gitsecrets.py
@@ -86,29 +86,29 @@ class TestGitSecrets(unittest.TestCase):
 
     def test_process_secret_type_ssh(self):
         processor = SecretProcessor(base_path=TEST_DIR)
+        secret = "-----BEGIN RSA PRIVATE KEY-----"
 
-        processor._secret = "------"
+        processor.split = [secret]
 
-        processor._process_secret_type()
-
+        self.assertTrue(processor._process_secret())
         self.assertEqual("ssh", processor.secret_type)
 
     def test_process_secret_type_mongo(self):
         processor = SecretProcessor(base_path=TEST_DIR)
+        secret = "mongodb://fakeuser:fakepass@example-db"
 
-        processor._secret = "mongodb://fakeuser:fakepass@example-db"
+        processor.split = [secret]
 
-        processor._process_secret_type()
-
+        self.assertTrue(processor._process_secret())
         self.assertEqual("mongo", processor.secret_type)
 
     def test_process_secret_type_aws(self):
         processor = SecretProcessor(base_path=TEST_DIR)
+        secret = "AKIATHISISNOTREALKEY"
 
-        processor._secret = "AKIATHISISNOTREALKEY"
+        processor.split = [secret]
 
-        processor._process_secret_type()
-
+        self.assertTrue(processor._process_secret())
         self.assertEqual("aws", processor.secret_type)
 
     def test_process_secret_pass(self):
@@ -124,16 +124,17 @@ class TestGitSecrets(unittest.TestCase):
         webhook = "https://hooks.slack.com/services/T01234567/B09876543/thisisnotarealwebhook123"
 
         processor = SecretProcessor(base_path=TEST_DIR)
-        actual = processor._extract_match(webhook)
+        actual_secret, _ = processor._extract_match(webhook)
 
-        self.assertEqual(webhook, actual)
+        self.assertEqual(webhook, actual_secret)
 
     def test_secret_type_slack(self):
         processor = SecretProcessor(base_path=TEST_DIR)
-        processor._secret = "https://hooks.slack.com/services/T01234567/B09876543/thisisnotarealwebhook123"
+        secret = "https://hooks.slack.com/services/T01234567/B09876543/thisisnotarealwebhook123"
 
-        processor._process_secret_type()
+        processor.split = [secret]
 
+        self.assertTrue(processor._process_secret())
         self.assertEqual("slack", processor.secret_type)
 
     def test_property_filename_read_only(self):
@@ -214,5 +215,5 @@ class TestGitSecrets(unittest.TestCase):
         for test_case in test_cases:
             with self.subTest(test_case=test_case):
                 # Test that the regex correctly extracts the secret from surrounding text
-                actual = processor._extract_match(f'{extra}\n{extra}"{test_case}"{extra}\n{extra}')
+                actual, _ = processor._extract_match(f'{extra}\n{extra}"{test_case}"{extra}\n{extra}')
                 self.assertEqual(test_case, actual)


### PR DESCRIPTION
Add types to Gitsecrets results, instead of returning "other" for many different finding types

## Description
- Gitsecrets will now more often return a secret type, rather than binning things into an "other" bin
- We were using [old Trufflehog regexes](https://github.com/dxa4481/truffleHogRegexes/blob/9257f45e66e31ad3fefd9d6e2b2e09dfb83043d6/truffleHogRegexes/regexes.json), so this PR adds the types from those trufflehog regexes back in (except where an existing bin makes more sense)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
With
https://github.com/WarnerMedia/artemis/pull/252 merged, type is not factored into de-duplication so the other type is just hiding useful information from the user. This PR removes that from gitsecrets

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Working in dev environment and tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
