### PR TITLE
Add type hints to Engine plugin.py

### DIFF
--- a/backend/engine/utils/plugin.py
+++ b/backend/engine/utils/plugin.py
@@ -469,7 +469,10 @@ def queue_event(repo: str, plugin_type, payload):
 
 def get_secret_raw_wl(scan):
     # Note: scan type is unspecified until we enable typechecking Django models.
-    # Get the non-expired secret_raw whitelist for the repo and convert it into a list of the whitelisted strings
+    """
+    Get the non-expired secret_raw whitelist for the repo and convert it into
+    a list of the whitelisted strings.
+    """
     from artemisdb.artemisdb.consts import (
         AllowListType,  # pylint: disable=import-outside-toplevel
     )
@@ -485,7 +488,9 @@ def get_secret_raw_wl(scan):
 
 def get_secret_al(scan):
     # Note: scan type is unspecified until we enable typechecking Django models.
-    # Get the non-expired secret whitelist for the repo and convert it into a list
+    """
+    Get the non-expired secret whitelist for the repo and convert it into a list.
+    """
     from artemisdb.artemisdb.consts import (
         AllowListType,  # pylint: disable=import-outside-toplevel
     )
@@ -497,7 +502,9 @@ def get_secret_al(scan):
 
 
 def filter_raw_secrets(scan: Scan, plugin_output):
-    # Get the raw secrets whitelists for this repo as a list of strings
+    """
+    Get the raw secrets whitelists for this repo as a list of strings.
+    """
     secret_al = get_secret_raw_wl(scan)
 
     details = plugin_output.get("details", [])
@@ -530,7 +537,9 @@ def filter_raw_secrets(scan: Scan, plugin_output):
 
 
 def filter_secrets(scan: Scan, plugin_output):
-    # Get the secrets whitelists for this repo
+    """
+    Get the secrets whitelists for this repo.
+    """
     secret_al = get_secret_al(scan)
 
     details = plugin_output.get("details", [])

--- a/backend/engine/utils/plugin.py
+++ b/backend/engine/utils/plugin.py
@@ -4,7 +4,7 @@ import subprocess
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from fnmatch import fnmatch
-from typing import Optional
+from typing import Optional, Union
 from urllib.parse import quote_plus
 
 import boto3
@@ -564,7 +564,7 @@ def filter_secrets(scan: Scan, plugin_output: dict):
     return {"details": filtered_details, "event_info": event_info}
 
 
-def match_nonallowlisted_raw_secrets(allowlist: list, matches: tuple[str, list]) -> list:
+def match_nonallowlisted_raw_secrets(allowlist: list, matches: Union[str, list]) -> list:
     if not isinstance(matches, list):
         matches = [matches]
 


### PR DESCRIPTION
## Description

Type hint updates for backend/engine/utils/plugin.py before making further changes.

* Add and fix type hints.
* Reformat docstrings previously written as comments.

No changes to the code itself, only type hints and docstrings.

## Motivation and Context

Separating out the simple type hint and docstring fixes from a (future) PR.

## How Has This Been Tested?

No code changes, only updates to type hints and docstrings.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
