### PR TITLE
Lowercase all secrets types

### DIFF
--- a/backend/engine/plugins/ghas_secrets/main.py
+++ b/backend/engine/plugins/ghas_secrets/main.py
@@ -95,7 +95,9 @@ def _normalize_secret_type(secret_type: str) -> str:
         return "ssh"
     elif secret_type in ["slack_incoming_webhook_url", "slack_workflow_webhook_url"]:
         return "slack"
-    return secret_type  # Keep the original type as a fallthrough
+    # Keep the original type as a fallthrough
+    # Type must be lowercase
+    return secret_type.lower()
 
 
 def _get_alerts(gh: GitHubAPI) -> list[dict]:

--- a/backend/engine/plugins/gitsecrets/secrets_processor.py
+++ b/backend/engine/plugins/gitsecrets/secrets_processor.py
@@ -18,7 +18,7 @@ URL_REGEX = r"://[^/\s:@]{3,64}:[^/\s:@]{3,64}@[a-zA-Z0-9\.-]+(:[0-9]{1,5}){0,1}
 # This regex needs to match the git-secrets regexes in Dockerfiles/data/secret-patterns
 REGEXES = [
     SecretRegex(
-        finding_type="Amazon MWS",
+        finding_type="amazon mws",
         regex=re.compile(str(r"(amzn\.mws\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})")),
     ),
     SecretRegex(
@@ -50,11 +50,11 @@ REGEXES = [
         regex=re.compile(str(r"([f|F][a|A][c|C][e|E][b|B][o|O][o|O][k|K](.){1,64}['|\"][0-9a-f]{32}['|\"])")),
     ),
     SecretRegex(
-        finding_type="Generic API Key",
+        finding_type="generic api key",
         regex=re.compile(str(r"([a|A][p|P][i|I][_]?[k|K][e|E][y|Y](.){1,64}['|\"][0-9a-zA-Z]{32,45}['|\"])")),
     ),
     SecretRegex(
-        finding_type="Generic Secret",
+        finding_type="generic secret",
         regex=re.compile(str(r"([s|S][e|E][c|C][r|R][e|E][t|T](.){1,64}['|\"][0-9a-zA-Z]{32,45}['|\"])")),
     ),
     SecretRegex(
@@ -78,7 +78,7 @@ REGEXES = [
         regex=re.compile(str(r"((ftp|ftps|http|https)" + URL_REGEX)),
     ),
     SecretRegex(
-        finding_type="Heroku API Key",
+        finding_type="heroku api key",
         regex=re.compile(
             str(
                 r"([h|H][e|E][r|R][o|O][k|K][u|U](.){1,64}[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12})"
@@ -86,19 +86,19 @@ REGEXES = [
         ),
     ),
     SecretRegex(
-        finding_type="MailChimp API Key",
+        finding_type="mailchimp api key",
         regex=re.compile(str(r"([0-9a-f]{32}-us[0-9]{1,2})")),
     ),
     SecretRegex(
-        finding_type="Mailgun API Key",
+        finding_type="mailgun api key",
         regex=re.compile(str(r"(key-[0-9a-zA-Z]{32})")),
     ),
     SecretRegex(
-        finding_type="PayPal Braintree Access Token",
+        finding_type="paypal braintree access token",
         regex=re.compile(str(r"(access_token\$production\$[0-9a-z]{16}\$[0-9a-f]{32})")),
     ),
     SecretRegex(
-        finding_type="Picatic API Key",
+        finding_type="picatic api key",
         regex=re.compile(str(r"(sk_live_[0-9a-z]{32})")),
     ),
     SecretRegex(
@@ -106,28 +106,28 @@ REGEXES = [
         regex=re.compile(str(r"(xox[p|b|o|a]-[0-9]{12}-[0-9]{12}-[0-9]{12}-[a-z0-9]{32})")),
     ),
     SecretRegex(
-        finding_type="Stripe API Key",
+        finding_type="stripe api key",
         regex=re.compile(str(r"(sk_live_[0-9a-zA-Z]{24})")),
     ),
     SecretRegex(
-        finding_type="Stripe Restricted API Key",
+        finding_type="stripe restricted api key",
         regex=re.compile(str(r"(rk_live_[0-9a-zA-Z]{24})")),
     ),
     SecretRegex(
-        finding_type="Square Access Token",
+        finding_type="square access token",
         regex=re.compile(str(r"(sq0atp-[0-9A-Za-z\-_]{22})")),
     ),
     SecretRegex(
-        finding_type="Square OAuth Secret",
+        finding_type="square oauth secret",
         regex=re.compile(str(r"(sq0csp-[0-9A-Za-z\-_]{43})")),
     ),
-    SecretRegex(finding_type="Twilio API Key", regex=re.compile(str(r"(SK[0-9a-fA-F]{32})"))),
+    SecretRegex(finding_type="twilio api key", regex=re.compile(str(r"(SK[0-9a-fA-F]{32})"))),
     SecretRegex(
-        finding_type="Twitter Access Token",
+        finding_type="twitter access token",
         regex=re.compile(str(r"([t|T][w|W][i|I][t|T][t|T][e|E][r|R](.){1,64}[1-9][0-9]+-[0-9a-zA-Z]{40})")),
     ),
     SecretRegex(
-        finding_type="Twitter Oauth",
+        finding_type="twitter oauth",
         regex=re.compile(str(r"([t|T][w|W][i|I][t|T][t|T][e|E][r|R](.){1,64}['|\"][0-9a-zA-Z]{35,44}['|\"])")),
     ),
     SecretRegex(

--- a/backend/engine/plugins/truffle_hog/main.py
+++ b/backend/engine/plugins/truffle_hog/main.py
@@ -60,7 +60,8 @@ def secret_type(reason: str) -> str:
     elif reason.startswith("Slack "):
         return "slack"
     else:
-        return reason
+        # Types must be all lowercase
+        return reason.lower()
 
 
 def commit_author(scan_path: str, commit: str) -> tuple:

--- a/backend/engine/plugins/trufflehog/type_normalization.py
+++ b/backend/engine/plugins/trufflehog/type_normalization.py
@@ -41,4 +41,5 @@ def normalize_type(finding_type: str) -> str:
     if finding_type in _TYPE_NORMALIZATION_TABLE:
         return _TYPE_NORMALIZATION_TABLE[finding_type]
     else:
-        return finding_type
+        # Types must be all lowercase
+        return finding_type.lower()

--- a/backend/engine/tests/test_plugin_trufflehog.py
+++ b/backend/engine/tests/test_plugin_trufflehog.py
@@ -121,7 +121,7 @@ EXAMPLE_VENDOR_FINDING = {
     "SourceType": 7,
     "SourceName": "trufflehog - git",
     "DetectorType": 17,
-    "tetectorName": "pytest",
+    "DetectorName": "pytest",
     "DecoderName": "PLAIN",
     "Verified": False,
     "VerificationError": "i/o timeout",

--- a/backend/engine/tests/test_plugin_trufflehog.py
+++ b/backend/engine/tests/test_plugin_trufflehog.py
@@ -121,7 +121,7 @@ EXAMPLE_VENDOR_FINDING = {
     "SourceType": 7,
     "SourceName": "trufflehog - git",
     "DetectorType": 17,
-    "DetectorName": "pytest",
+    "tetectorName": "pytest",
     "DecoderName": "PLAIN",
     "Verified": False,
     "VerificationError": "i/o timeout",
@@ -177,7 +177,7 @@ class TestPluginTrufflehog(unittest.TestCase):
         test = [EXAMPLE_LEGIT_FINDING, EXAMPLE_LOCKFILE_FINDING, EXAMPLE_VENDOR_FINDING]
         actual = trufflehog.scrub_results(test, errors_dict)
 
-        expected_type = EXAMPLE_LEGIT_FINDING.get("DetectorName")
+        expected_type = EXAMPLE_LEGIT_FINDING.get("DetectorName", "").lower()
         expected1 = {
             "id": actual["results"][0]["id"],
             "filename": "The Pacific Crest Trail",


### PR DESCRIPTION
Lowercases the secret types in all secrets plugins

## Description
- Secret types with capital letters were not showing up in results, so we lowercase them all

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- When writing the list of secret types, we [lowercase them all](https://github.com/WarnerMedia/artemis/blob/main/backend/engine/utils/plugin.py#L699). This creates an implicit requirement for secret types to be all lowercase, since we later [pull down this list](https://github.com/WarnerMedia/artemis/blob/main/backend/lambdas/generators/json_report/json_report/results/secret.py#L49) and [check that a given finding's type is in it](https://github.com/WarnerMedia/artemis/blob/main/backend/lambdas/generators/json_report/json_report/results/secret.py#L79)
- We also considered lowercasing in the `json_report` lambda before comparing with the list of types, but ran into issues with casing affecting deduplication

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Working in dev environment and locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.