### PR TITLE
Fix bug in trivy_sbom

### DIFF
--- a/backend/engine/plugins/trivy_sbom/parser.py
+++ b/backend/engine/plugins/trivy_sbom/parser.py
@@ -19,6 +19,9 @@ def clean_output_application_sbom(output: list) -> list:
         if item["type"] == "operating-system":
             continue
         bom_ref = item["bom-ref"]
+        if "name" not in item:
+            logger.error("Unable to parse trivy component: %s", item)
+            continue
         if "group" in item:
             name = f'{item["group"]}/{item["name"]}'
         else:

--- a/backend/engine/plugins/trivy_sbom/parser.py
+++ b/backend/engine/plugins/trivy_sbom/parser.py
@@ -19,7 +19,10 @@ def clean_output_application_sbom(output: list) -> list:
         if item["type"] == "operating-system":
             continue
         bom_ref = item["bom-ref"]
-        name = item.get("group", "") + item["name"]
+        if "group" in item:
+            name = f'{item["group"]}/{item["name"]}'
+        else:
+            name = item["name"]
         version = item["version"]
         licenses = []
         licenses_list = item.get("licenses", [])

--- a/backend/engine/tests/test_trivy_sbom.py
+++ b/backend/engine/tests/test_trivy_sbom.py
@@ -72,6 +72,16 @@ TEST_CHECK_OUTPUT_SBOM_FILE_PARSED = [
     {"bom-ref": "pkg", "name": "test", "version": "0.16.2", "licenses": [{"id": "MIT", "name": "MIT"}], "type": "npm"}
 ]
 
+TEST_CHECK_OUTPUT_SBOM_FILE_PARSED_WITH_GROUP = [
+    {
+        "bom-ref": "pkg",
+        "name": "@test-group/test",
+        "version": "0.16.2",
+        "licenses": [{"id": "MIT", "name": "MIT"}],
+        "type": "npm",
+    }
+]
+
 TEST_BUILD_SCAN_PARSE_RESULT_DICT = {
     "component": "libcrypto1.1-1.1.1g-r0",
     "source": "/image/test_file_for_docker",
@@ -107,7 +117,13 @@ class TestTrivy(unittest.TestCase):
 
     def test_parser(self):
         check_parsed_output = Trivy.clean_output_application_sbom(TEST_CHECK_OUTPUT_SBOM_FILE)
-        assert check_parsed_output == TEST_CHECK_OUTPUT_SBOM_FILE_PARSED
+        self.assertEqual(check_parsed_output, TEST_CHECK_OUTPUT_SBOM_FILE_PARSED)
+
+    def test_parser_with_group_field(self):
+        cyclone_dx_json = TEST_CHECK_OUTPUT_SBOM_FILE.copy()
+        cyclone_dx_json["components"][0]["group"] = "@test-group"
+        parsed_json = Trivy.clean_output_application_sbom(cyclone_dx_json)
+        self.assertEqual(parsed_json, cyclone_dx_json)
 
 
 @pytest.mark.integtest

--- a/backend/engine/tests/test_trivy_sbom.py
+++ b/backend/engine/tests/test_trivy_sbom.py
@@ -123,7 +123,7 @@ class TestTrivy(unittest.TestCase):
         cyclone_dx_json = TEST_CHECK_OUTPUT_SBOM_FILE.copy()
         cyclone_dx_json["components"][0]["group"] = "@test-group"
         parsed_json = Trivy.clean_output_application_sbom(cyclone_dx_json)
-        self.assertEqual(parsed_json, cyclone_dx_json)
+        self.assertEqual(parsed_json, TEST_CHECK_OUTPUT_SBOM_FILE_PARSED_WITH_GROUP)
 
 
 @pytest.mark.integtest


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The package names stored for trivy_sbom results are not correct. For example, packages with a group field are stored as: `@balenadockerignore` and not `@balena/dockerignore`

#### This PR:
Adds a divider between the component group and the component name for a detected package.

Example Cyclone DX component for https://www.npmjs.com/package/@balena/dockerignore
```
{
      "bom-ref": "pkg:npm/%40balena/dockerignore@1.0.2",
      "type": "library",
      "group": "@balena",
      "name": "dockerignore",
      "version": "1.0.2",
      "purl": "pkg:npm/%40balena/dockerignore@1.0.2",
      "properties": [
        {
          "name": "aquasecurity:trivy:PkgID",
          "value": "@balena/dockerignore@1.0.2"
        },
        {
          "name": "aquasecurity:trivy:PkgType",
          "value": "yarn"
        }
      ]
    }
```

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This affects the `artemis-license-retriever` Lambda because it uses the package name to build URLs to query different package registries

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Pic
![Embed something funny here](https://giphy.com/trending-gifs)