### PR TITLE
Adjust PluginSettings types and add unit tests

### DIFF
--- a/backend/engine/processor/processor.py
+++ b/backend/engine/processor/processor.py
@@ -25,7 +25,7 @@ from processor.vulns import process_vulns, resolve_vulns
 from utils.deploy_key import create_ssh_url, git_clone
 from utils.engine import get_key
 from utils.git import git_clean, git_pull, git_reset
-from utils.plugin import Result, is_plugin_disabled, run_plugin, process_event_info, queue_event
+from utils.plugin import Result, get_plugin_settings, run_plugin, process_event_info, queue_event
 
 logger = Logger(__name__)
 
@@ -238,10 +238,9 @@ class EngineProcessor:
         :return: True/False
         """
         for plugin in self.action_details.plugins:
-            with open(os.path.join(self.action_details.plugin_path, plugin, "settings.json")) as settings_file:
-                settings_dict = json.load(settings_file)
-                if settings_dict.get("build_images", False) and not is_plugin_disabled(settings_dict):
-                    return True
+            settings = get_plugin_settings(plugin)
+            if settings.build_images and not settings.disabled:
+                return True
         return False
 
     def _set_git_diff(self) -> None:

--- a/backend/engine/processor/scan_details.py
+++ b/backend/engine/processor/scan_details.py
@@ -28,10 +28,8 @@ class ScanDetails:
 def _get_plugins(plugin_path, requested_plugins):
     # get the list of total plugins from this directory, excluding files and
     # lib directory
-
     dirs = os.listdir(plugin_path)
-    plugins = [d for d in dirs if os.path.isdir(os.path.join(plugin_path, d))]
-    plugins.remove("lib")  # skip the lib directory which is not a plugin
+    plugins = [d for d in dirs if os.path.isdir(os.path.join(plugin_path, d)) and d != "lib"]
     plugins = set(plugins)
     # allow users to specify a list of specific plugins to include or (if
     # prepended with a '-') to exclude

--- a/backend/engine/tests/data/util/plugins/invalid/settings.json
+++ b/backend/engine/tests/data/util/plugins/invalid/settings.json
@@ -1,0 +1,5 @@
+{
+  "name": null,
+  "type": 1234,
+  "image": ["$ECR/normal:latest"]
+}

--- a/backend/engine/tests/data/util/plugins/minimal/settings.json
+++ b/backend/engine/tests/data/util/plugins/minimal/settings.json
@@ -1,0 +1,3 @@
+{
+  "name": "Test Minimal Plugin"
+}

--- a/backend/engine/tests/data/util/plugins/normal/settings.json
+++ b/backend/engine/tests/data/util/plugins/normal/settings.json
@@ -1,0 +1,9 @@
+{
+  "name": "Test Plugin",
+  "type": "vulnerability",
+  "image": "$ECR/normal:latest",
+  "feature": "unit-test",
+  "build_images": true,
+  "enabled": true,
+  "timeout": 300
+}

--- a/backend/engine/tests/test_engine_processor.py
+++ b/backend/engine/tests/test_engine_processor.py
@@ -18,6 +18,7 @@ from utils.services import _get_services_from_file
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 TEST_METADATA = os.path.join(TEST_DIR, "data/metadata.json")
+PLUGIN_TEST_BASE_DIR = os.path.join(TEST_DIR, "data", "util")
 
 SERVICES_FILE = os.path.join(TEST_DIR, "data", "services.json")
 
@@ -44,18 +45,21 @@ class TestEngineProcessor(unittest.TestCase):
         self.assertIsInstance(processor.details, Details)
         self.assertIsInstance(processor.action_details, ScanDetails)
 
-    def test_engine_processor_docker_image_required_true(self):
-        pytest.xfail("Trivy plugin is temporarily disabled due to unexpected vulns reporting.")
+    @patch("utils.plugin.ENGINE_DIR", PLUGIN_TEST_BASE_DIR)
+    @patch("processor.scan_details.ENGINE_DIR", PLUGIN_TEST_BASE_DIR)
+    def test_engine_processor_docker_images_required_true(self):
         details = deepcopy(TEST_DETAILS)
-        details["plugins"] = ["test", "tslint", "test", "trivy"]
+        details["plugins"] = ["minimal", "normal"]
         processor = engine_processor.EngineProcessor(TEST_SERVICES, "scan", details, {}, object)
         expected_result = True
         result = processor.docker_images_required()
         self.assertEqual(expected_result, result)
 
-    def test_engine_processor_docker_image_required_false(self):
+    @patch("utils.plugin.ENGINE_DIR", PLUGIN_TEST_BASE_DIR)
+    @patch("processor.scan_details.ENGINE_DIR", PLUGIN_TEST_BASE_DIR)
+    def test_engine_processor_docker_images_required_false(self):
         details = deepcopy(TEST_DETAILS)
-        details["plugins"] = ["test", "tslint"]
+        details["plugins"] = ["minimal"]
         processor = engine_processor.EngineProcessor(TEST_SERVICES, "scan", details, {}, object)
         expected_result = False
         result = processor.docker_images_required()

--- a/backend/engine/tests/test_engine_utils.py
+++ b/backend/engine/tests/test_engine_utils.py
@@ -1,11 +1,13 @@
 import os
 import unittest
+from unittest.mock import patch
 
-from engine.utils.plugin import is_plugin_disabled, match_nonallowlisted_raw_secrets
+from engine.utils.plugin import get_plugin_settings, is_plugin_disabled, match_nonallowlisted_raw_secrets
 from utils.services import _get_services_from_file
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 SERVICES_FILE = os.path.join(TEST_DIR, "data", "services.json")
+PLUGIN_TEST_BASE_DIR = os.path.join(TEST_DIR, "data", "util")
 
 EXPECTED_KEYS = [
     "allow_all",
@@ -82,3 +84,38 @@ class TestEngineUtils(unittest.TestCase):
             with self.subTest(test_case=test_case):
                 actual = match_nonallowlisted_raw_secrets(allowlist, test_case[0])
             self.assertEqual(actual, test_case[1])
+
+    @patch("engine.utils.plugin.ENGINE_DIR", PLUGIN_TEST_BASE_DIR)
+    @patch("engine.utils.plugin.ECR", "test.example.com")
+    def test_get_plugin_settings_normal(self):
+        """
+        Tests loading a fully-specified settings file.
+        """
+        actual = get_plugin_settings("normal")
+        self.assertEqual(actual.image, "test.example.com/normal:latest")
+        self.assertEqual(actual.disabled, False)
+        self.assertEqual(actual.name, "Test Plugin")
+        self.assertEqual(actual.plugin_type, "vulnerability")
+        self.assertEqual(actual.feature, "unit-test")
+        self.assertEqual(actual.timeout, 300)
+
+    @patch("engine.utils.plugin.ENGINE_DIR", PLUGIN_TEST_BASE_DIR)
+    def test_get_plugin_settings_minimal(self):
+        """
+        Tests default values when loading a minimal settings file.
+        """
+        actual = get_plugin_settings("minimal")
+        self.assertEqual(actual.image, "")
+        self.assertEqual(actual.disabled, False)
+        self.assertEqual(actual.name, "Test Minimal Plugin")
+        self.assertEqual(actual.plugin_type, "misc")
+        self.assertIsNone(actual.feature)
+        self.assertIsNone(actual.timeout)
+
+    @patch("engine.utils.plugin.ENGINE_DIR", PLUGIN_TEST_BASE_DIR)
+    def test_get_plugin_settings_nonexistent(self):
+        """
+        Tests an exception is raised when loading a nonexistent settings file.
+        """
+        with self.assertRaises(Exception):
+            get_plugin_settings("nonexistent")

--- a/backend/engine/tests/test_engine_utils.py
+++ b/backend/engine/tests/test_engine_utils.py
@@ -134,6 +134,7 @@ class TestEngineUtils(unittest.TestCase):
         self.assertEqual(actual.image, "test.example.com/normal:latest")
         self.assertEqual(actual.disabled, False)
         self.assertEqual(actual.plugin_type, "vulnerability")
+        self.assertEqual(actual.build_images, True)
         self.assertEqual(actual.feature, "unit-test")
         self.assertEqual(actual.timeout, 300)
 
@@ -147,6 +148,7 @@ class TestEngineUtils(unittest.TestCase):
         self.assertEqual(actual.image, "")
         self.assertEqual(actual.disabled, False)
         self.assertEqual(actual.plugin_type, "misc")
+        self.assertEqual(actual.build_images, False)
         self.assertIsNone(actual.feature)
         self.assertIsNone(actual.timeout)
 

--- a/backend/engine/tests/test_engine_utils.py
+++ b/backend/engine/tests/test_engine_utils.py
@@ -86,17 +86,17 @@ class TestEngineUtils(unittest.TestCase):
         os.environ["TEST_VAR_TRUE"] = "1"
         os.environ["TEST_VAR_FALSE"] = "0"
 
-        test_cases = [
+        test_cases: list[tuple[Any, bool]] = [
             # Test case format: (settings_dict, expected_bool)
-            ({"enabled": True}, False),
-            ({"enabled": False}, True),
-            ({"enabled": "$TEST_VAR_TRUE"}, False),
-            ({"enabled": "$TEST_VAR_FALSE"}, True),
-            ({"enabled": 1}, True),
-            ({"enabled": "string"}, True),
-            ({"enabled": "INVALID"}, True),
-            ({"enabled": "$TEST_VAR_NOT_SET"}, False),
-            ({}, False),
+            (True, False),
+            (False, True),
+            ("$TEST_VAR_TRUE", False),
+            ("$TEST_VAR_FALSE", True),
+            (1, True),
+            ("string", True),
+            ("INVALID", True),
+            ("$TEST_VAR_NOT_SET", False),
+            (None, False),
         ]
 
         for test_case in test_cases:

--- a/backend/engine/tests/test_engine_utils.py
+++ b/backend/engine/tests/test_engine_utils.py
@@ -129,9 +129,9 @@ class TestEngineUtils(unittest.TestCase):
         Tests loading a fully-specified settings file.
         """
         actual = get_plugin_settings("normal")
+        self.assertEqual(actual.name, "Test Plugin")
         self.assertEqual(actual.image, "test.example.com/normal:latest")
         self.assertEqual(actual.disabled, False)
-        self.assertEqual(actual.name, "Test Plugin")
         self.assertEqual(actual.plugin_type, "vulnerability")
         self.assertEqual(actual.feature, "unit-test")
         self.assertEqual(actual.timeout, 300)
@@ -142,9 +142,9 @@ class TestEngineUtils(unittest.TestCase):
         Tests default values when loading a minimal settings file.
         """
         actual = get_plugin_settings("minimal")
+        self.assertEqual(actual.name, "Test Minimal Plugin")
         self.assertEqual(actual.image, "")
         self.assertEqual(actual.disabled, False)
-        self.assertEqual(actual.name, "Test Minimal Plugin")
         self.assertEqual(actual.plugin_type, "misc")
         self.assertIsNone(actual.feature)
         self.assertIsNone(actual.timeout)

--- a/backend/engine/tests/test_engine_utils.py
+++ b/backend/engine/tests/test_engine_utils.py
@@ -2,6 +2,7 @@ import os
 from typing import Any
 import unittest
 from unittest.mock import patch
+from pydantic import ValidationError
 
 from engine.utils.plugin import (
     PluginSettings,
@@ -154,5 +155,14 @@ class TestEngineUtils(unittest.TestCase):
         """
         Tests an exception is raised when loading a nonexistent settings file.
         """
-        with self.assertRaises(Exception):
+        with self.assertRaises(FileNotFoundError):
             get_plugin_settings("nonexistent")
+
+    @patch("engine.utils.plugin.ENGINE_DIR", PLUGIN_TEST_BASE_DIR)
+    def test_get_plugin_settings_invalid(self):
+        """
+        Tests an exception is raised when loading a malformed settings file.
+        """
+        with self.assertRaises(ValidationError) as ex:
+            get_plugin_settings("invalid")
+        self.assertEqual(ex.exception.error_count(), 3)

--- a/backend/engine/utils/plugin.py
+++ b/backend/engine/utils/plugin.py
@@ -56,9 +56,15 @@ class Result:
 
 
 class PluginSettings(BaseModel):
+    """
+    Plugin description, loaded from the settings.json of the plugin.
+
+    Only the "name" field is required, all other fields are optional.
+    """
+
+    name: str
     image: str = ""
     disabled: bool = Field(alias="enabled", default=False)
-    name: str
     plugin_type: str = Field(alias="type", default="misc")
     feature: Optional[str] = None
     timeout: Optional[int] = None

--- a/backend/engine/utils/plugin.py
+++ b/backend/engine/utils/plugin.py
@@ -60,8 +60,8 @@ class PluginSettings:
     disabled: bool
     name: str
     plugin_type: str
-    feature: str
-    timeout: int
+    feature: Optional[str]
+    timeout: Optional[int]
 
 
 def get_engine_vars(scan: Scan, depth: Optional[str] = None, include_dev=False, services=None):

--- a/backend/engine/utils/plugin.py
+++ b/backend/engine/utils/plugin.py
@@ -83,7 +83,7 @@ class PluginSettings(BaseModel):
     @field_validator("disabled", mode="before")
     @classmethod
     def _parse_disabled(cls, orig: Union[str, bool]) -> bool:
-        return is_plugin_disabled({"enabled": orig})
+        return is_plugin_disabled(orig)
 
 
 def get_engine_vars(scan: Scan, depth: Optional[str] = None, include_dev=False, services=None):
@@ -215,7 +215,7 @@ def _get_plugin_config(plugin: str, full_repo: str) -> dict:
     return {}
 
 
-def is_plugin_disabled(settings: dict) -> bool:
+def is_plugin_disabled(enabled: Union[str, bool, None]) -> bool:
     """Determines whether the plugin is disabled
 
     The "enabled" key in the plugin's settings.json can be either a boolean value or the name of an environment
@@ -223,8 +223,9 @@ def is_plugin_disabled(settings: dict) -> bool:
     is not set or the ENV VAR is not set the plugin is not disabled. If "enabled" or the ENV VAR is present but set to
     an invalid value the plugin is disabled.
     """
-    # Get the enabled setting, with the plugin enabled by default if not set
-    enabled = settings.get("enabled", True)
+    # Plugin enabled by default if not set
+    if enabled is None:
+        return False
 
     # If already a boolean, return the inverse (enabled -> disabled)
     if isinstance(enabled, bool):

--- a/backend/engine/utils/plugin.py
+++ b/backend/engine/utils/plugin.py
@@ -66,6 +66,7 @@ class PluginSettings(BaseModel):
     image: str = ""
     disabled: bool = Field(alias="enabled", default=False)
     plugin_type: str = Field(alias="type", default="misc")
+    build_images: bool = False
     feature: Optional[str] = None
     timeout: Optional[int] = None
 


### PR DESCRIPTION
## Description

Applies various fixes and refactorings surrounding the `PluginSettings` type:

* Strictly validate the types when loading `settings.json` (via Pydantic).
* Field parsers for `image` and `disabled` have been moved into `PluginSettings`.
* Mark the `feature` and `timeout` fields as `Optional` since they can be `None`.
* Adds `PluginSettings.build_images` which is used in `EngineProcessor.docker_images_required()`, so we consolidate the loading of `settings.json` into one place.
* Adds test `settings.json` files so the unit tests don't depend on the actual plugins which could change.  This also fixes a longstanding xfail'd test.
* Fixes a potential `ValueError` in `ScanDetails` if the plugin directory doesn't have a `lib` directory (such as in unit tests).

Additional unit tests have been added or modified to cover the above.

## Motivation and Context

Cleanups and fixes before making additional changes.

## How Has This Been Tested?

Tested in nonprod environment.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
