### PR TITLE
Tiny lint cleanups in license-retriever

### DIFF
--- a/backend/lambdas/maintenance/license_retriever/license_retriever/retrievers/go.py
+++ b/backend/lambdas/maintenance/license_retriever/license_retriever/retrievers/go.py
@@ -16,7 +16,7 @@ def retrieve_go_licenses(name: str, _version: str) -> list:
     return extract_licenses(package_info)
 
 
-def get_package_info(name: str) -> dict:
+def get_package_info(name: str) -> str:
     url = f"https://pkg.go.dev/{name}?tab=licenses"
 
     while True:

--- a/backend/lambdas/maintenance/license_retriever/license_retriever/retrievers/pypi.py
+++ b/backend/lambdas/maintenance/license_retriever/license_retriever/retrievers/pypi.py
@@ -152,7 +152,6 @@ PYPI_LICENSE_MAP = {
     "aal": "Attribution Assurance License",
     "bsd": "BSD License",
     "common": "Common Public License",
-    "efl": "Eiffel Forum License",
     "gfdl": "GNU Free Documentation License",
     "gpl": "GNU General Public License",
     "lgpl": "GNU Library or Lesser General Public License",


### PR DESCRIPTION
## Description

Two tiny fixups in the license-retriever lambda that appear to be copy-paste typos:

* Remove duplicate "efl" key in PYPI_LICENSE_MAP.
* Fixed the return type of `get_package_info()` in the Go retriever.

## Motivation and Context

Discovered while examining the license retriever code.

## How Has This Been Tested?

N/A -- changes don't effect the logic, just the type hint and duplicated key.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
