### PR TITLE
Add runner field to PluginSettings

### DIFF
--- a/backend/engine/tests/data/util/plugins/invalid/settings.json
+++ b/backend/engine/tests/data/util/plugins/invalid/settings.json
@@ -1,5 +1,6 @@
 {
   "name": null,
   "type": 1234,
-  "image": ["$ECR/normal:latest"]
+  "image": ["$ECR/normal:latest"],
+  "runner": "unknown"
 }

--- a/backend/engine/tests/data/util/plugins/normal/settings.json
+++ b/backend/engine/tests/data/util/plugins/normal/settings.json
@@ -4,6 +4,7 @@
   "image": "$ECR/normal:latest",
   "feature": "unit-test",
   "build_images": true,
+  "runner": "core",
   "enabled": true,
   "timeout": 300
 }

--- a/backend/engine/tests/test_engine_utils.py
+++ b/backend/engine/tests/test_engine_utils.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import patch
 from pydantic import ValidationError
 
-from engine.utils.plugin import PluginSettings, get_plugin_settings, match_nonallowlisted_raw_secrets
+from engine.utils.plugin import PluginSettings, Runner, get_plugin_settings, match_nonallowlisted_raw_secrets
 from utils.services import _get_services_from_file
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -114,6 +114,7 @@ class TestEngineUtils(unittest.TestCase):
         self.assertEqual(actual.disabled, False)
         self.assertEqual(actual.plugin_type, "vulnerability")
         self.assertEqual(actual.build_images, True)
+        self.assertEqual(actual.runner, Runner.CORE)
         self.assertEqual(actual.feature, "unit-test")
         self.assertEqual(actual.timeout, 300)
 
@@ -128,6 +129,7 @@ class TestEngineUtils(unittest.TestCase):
         self.assertEqual(actual.disabled, False)
         self.assertEqual(actual.plugin_type, "misc")
         self.assertEqual(actual.build_images, False)
+        self.assertEqual(actual.runner, Runner.CORE)
         self.assertIsNone(actual.feature)
         self.assertIsNone(actual.timeout)
 
@@ -146,4 +148,4 @@ class TestEngineUtils(unittest.TestCase):
         """
         with self.assertRaises(ValidationError) as ex:
             get_plugin_settings("invalid")
-        self.assertEqual(ex.exception.error_count(), 3)
+        self.assertEqual(ex.exception.error_count(), 4)


### PR DESCRIPTION
## Description

Adds an optional field `runner` to plugin `settings.json`.

This is a placeholder field for now to enable experimentation with different plugin runners / architectures.

## Motivation and Context

We're starting on experiments on alternative methods for running plugins, so this sets the stage to select which runner each plugin will use.

## How Has This Been Tested?

Tested in nonprod environment.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
