### PR TITLE
Fix git-secrets plugin regular expressions

### DIFF
--- a/backend/Dockerfiles/Dockerfile.python3
+++ b/backend/Dockerfiles/Dockerfile.python3
@@ -33,17 +33,14 @@ RUN wget -q https://github.com/awslabs/git-secrets/archive/$GIT_SECRETS_VER.tar.
     tar xzf $GIT_SECRETS_VER.tar.gz && \
     cd git-secrets-$GIT_SECRETS_VER && \
     make install && \
-    git secrets --register-aws --global && \
     cd .. && \
     rm -rf git-secrets-$GIT_SECRETS_VER $GIT_SECRETS_VER.tar.gz
 
 # Copy git secret patterns file
 COPY Dockerfiles/data/secret-patterns /app/secret-patterns
 
-# Target the search to just AWS key IDs and secret key banners
 # This assumes that the repo you are testing git secrets is in the /app directory
-RUN git config --unset-all --global secrets.patterns && \
-    git secrets --add-provider --global -- cat secret-patterns
+RUN git secrets --add-provider --global -- cat secret-patterns
 
 # Alpine uses musl instead of glibc at runtime.
 RUN apk -q del gcc

--- a/backend/Dockerfiles/data/secret-patterns
+++ b/backend/Dockerfiles/data/secret-patterns
@@ -10,7 +10,7 @@ EAACEdEose0cBA[0-9A-Za-z]{16,255}
 [s|S][e|E][c|C][r|R][e|E][t|T](.){1,64}['|"][0-9a-zA-Z]{32,45}['|"]
 [0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com
 ya29\.[0-9A-Za-z\-_]{55}
-(ftp|ftps|http|https|mongodb|mongodb\+srv|postgres):\/\/[^\/\s:@]{3,64}:[^\/\s:@]{3,64}@[a-zA-Z0-9\.-]+(:[0-9]{1,5}){0,1}
+(ftp|ftps|http|https|mongodb|mongodb\+srv|postgres):\/\/[^/:@ \t\n]{3,64}:[^/:@ \t\n]{3,64}@[a-zA-Z0-9\.-]+(:[0-9]{1,5}){0,1}
 [h|H][e|E][r|R][o|O][k|K][u|U][.]{1,64}[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}
 [0-9a-f]{32}-us[0-9]{1,2}
 key-[0-9a-zA-Z]{32}

--- a/backend/Dockerfiles/data/secret-patterns
+++ b/backend/Dockerfiles/data/secret-patterns
@@ -10,7 +10,7 @@ EAACEdEose0cBA[0-9A-Za-z]{16,255}
 [s|S][e|E][c|C][r|R][e|E][t|T](.){1,64}['|"][0-9a-zA-Z]{32,45}['|"]
 [0-9]+-[0-9A-Za-z_]{32}\.apps\.googleusercontent\.com
 ya29\.[0-9A-Za-z\-_]{55}
-(ftp|ftps|http|https|mongodb|mongodb\+srv|postgres):\/\/[^/:@ \t\n]{3,64}:[^/:@ \t\n]{3,64}@[a-zA-Z0-9\.-]+(:[0-9]{1,5}){0,1}
+(ftp|ftps|http|https|mongodb|mongodb\+srv|postgres):\/\/[^/:@[:space:]]{3,64}:[^/:@[:space:]]{3,64}@[a-zA-Z0-9\.-]+(:[0-9]{1,5}){0,1}
 [h|H][e|E][r|R][o|O][k|K][u|U][.]{1,64}[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}
 [0-9a-f]{32}-us[0-9]{1,2}
 key-[0-9a-zA-Z]{32}
@@ -25,6 +25,6 @@ SK[0-9a-fA-F]{32}
 [t|T][w|W][i|I][t|T][t|T][e|E][r|R](.){1,64}[1-9][0-9]+-[0-9a-zA-Z]{40}
 [t|T][w|W][i|I][t|T][t|T][e|E][r|R](.){1.64}['|"][0-9a-zA-Z]{35,44}['|"]
 (A3T[A-Z0-9]|AKIA|ASIA|ACCA)[A-Z0-9]{16}
-[-]{5}BEGIN[ \t\n]((RSA|DSA|EC|PGP|OPENSSH)[ \t\n])?PRIVATE[ \t\n](KEY|KEY[ \t\n]BLOCK)[-]{5}
+[-]{5}BEGIN[:space:]((RSA|DSA|EC|PGP|OPENSSH)[:space:])?PRIVATE[:space:](KEY|KEY[:space:]BLOCK)[-]{5}
 gh[pousr]_[A-Za-z0-9_]{36,255}
 github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}

--- a/backend/Dockerfiles/data/secret-patterns
+++ b/backend/Dockerfiles/data/secret-patterns
@@ -25,6 +25,6 @@ SK[0-9a-fA-F]{32}
 [t|T][w|W][i|I][t|T][t|T][e|E][r|R](.){1,64}[1-9][0-9]+-[0-9a-zA-Z]{40}
 [t|T][w|W][i|I][t|T][t|T][e|E][r|R](.){1.64}['|"][0-9a-zA-Z]{35,44}['|"]
 (A3T[A-Z0-9]|AKIA|ASIA|ACCA)[A-Z0-9]{16}
-[-]{5}BEGIN\s((RSA|DSA|EC|PGP|OPENSSH)\s)?PRIVATE\s(KEY|KEY\sBLOCK)[-]{5}
+[-]{5}BEGIN[ \t\n]((RSA|DSA|EC|PGP|OPENSSH)[ \t\n])?PRIVATE[ \t\n](KEY|KEY[ \t\n]BLOCK)[-]{5}
 gh[pousr]_[A-Za-z0-9_]{36,255}
 github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes the git-secrets plugin regular expressions

## Description
<!--- Describe your changes in detail -->
- The version of grep used by git-secrets does not support `\s`, so we replace it with `[:space:]` (as per [the table here](https://www.regular-expressions.info/posixbrackets.html) that converts from shorthand to POSIX)). This should give git-secrets parity with Trufflehog, provided the full word is a match  
  - `git-secrets` runs `grep -w` under the hood, which cares about words. Trufflehog does not care about words. So, with `AKIA12345678901234567` as an example (AKIA + 17 characters. A normal AWS Key ID has 16 characters), git-secrets will not find it while Trufflehog Legacy will.
  - This fixes the urlauth gitsecrets rules, which drive `mongo`, `postgres`, `ftp`, `http`, and more
- Removed `--register-aws` from dockerfile, as it was allowlisting some values that we want to search for
  - This is likely inconsequential as they are example API key IDs and Secret Access Keys, but it was undocumented behavior that differed from Trufflehog Legacy

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Some git-secrets regexes have been broken for years. This fixes them :) 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Working in dev
- Working locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
