### PR TITLE
Add Pyright configuration

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -35,3 +35,45 @@ known_first_party = [
     "scale_down",
     "json_report"
 ]
+
+[tool.pyright]
+pythonVersion = "3.9"
+typeCheckingMode = "standard"
+include = [
+    "engine",
+    "lambdas",
+    "libs",
+    "utilities",
+]
+exclude = [
+    "**/.eggs",
+    "**/build",
+    "**/dist",
+]
+extraPaths = [
+    "engine",
+    "lambdas/api/authorizer",
+    "lambdas/api/groups",
+    "lambdas/api/groups_keys",
+    "lambdas/api/groups_members",
+    "lambdas/api/repo",
+    "lambdas/api/system_services",
+    "lambdas/api/users",
+    "lambdas/api/users_keys",
+    "lambdas/api/users_services",
+    "lambdas/events/event_dispatch",
+    "lambdas/events/splunk_handler",
+    "lambdas/generators/json_report",
+    "lambdas/generators/sbom_report",
+    "lambdas/scheduled/scan_scheduler",
+    "libs/artemisapi",
+    "libs/artemisdb",
+    "libs/artemislib",
+]
+ignore = [
+    # Type checking for Django models is currently problematic.
+    "libs/artemisdb/artemisdb/artemisdb/models.py",
+]
+executionEnvironments = [
+    { root = "utilities/api_runner", extraPaths = ["lambdas/api"] },
+]

--- a/orchestrator/pyproject.toml
+++ b/orchestrator/pyproject.toml
@@ -16,3 +16,20 @@ known_first_party = [
     "repo_scan_loop",
     "lambdas"
 ]
+
+[tool.pyright]
+pythonVersion = "3.9"
+typeCheckingMode = "standard"
+include = [
+    "lambdas",
+]
+exclude = [
+    "**/.eggs",
+    "**/build",
+    "**/dist",
+]
+extraPaths = [
+    "lambdas/layers/heimdall_orgs",
+    "lambdas/layers/heimdall_repos",
+    "lambdas/layers/heimdall_utils",
+]


### PR DESCRIPTION
## Description

Adds a config section for Pyright to the `pyproject.toml` in engine and orchestrator.

## Motivation and Context

Enables Pyright to be run from the command-line (i.e., instead of via an editor extension).

This will allow us to roughly gauge our progress in fixing issues over time.

## How Has This Been Tested?

```bash
pip install pyright
cd backend ; pyright
cd orchestrator ; pyright
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
