### PR TITLE
Trufflehog Plugin - Fix error when finding is allowlisted

### DIFF
--- a/backend/engine/plugins/trufflehog/main.py
+++ b/backend/engine/plugins/trufflehog/main.py
@@ -96,7 +96,7 @@ def scrub_results(scan_results: list, error_dict: dict) -> dict:
 
             if allowlist.ignore_secret(path, finding_raw):
                 # No matches remaining so skip the finding altogether
-                log.info("Skipping secret that matched system allowlist in file '%s'", record["path"])
+                log.info("Skipping secret that matched system allowlist in file '%s'", path)
                 continue
 
             record_json = {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes an error when the finding is allowlisted

## Description
<!--- Describe your changes in detail -->
- Copy & paste error from Legacy Trufflehog. We didn't change how we access the path with the breaking change in output format between Trufflehog v2 and v3.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Trufflehog v3 is failing when there is a finding that is also on the system allowlist

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
