### PR TITLE
Disable legacy trufflehog

### DIFF
--- a/backend/lambdas/api/repo/repo/util/const.py
+++ b/backend/lambdas/api/repo/repo/util/const.py
@@ -31,7 +31,6 @@ PLUGIN_LIST_BY_CATEGORY = {
     },
     "secret": {
         "gitsecrets": None,
-        "truffle_hog": None,
         "trufflehog": None,
     },
     "static_analysis": {

--- a/backend/lambdas/api/repo/tests/test_parse_event.py
+++ b/backend/lambdas/api/repo/tests/test_parse_event.py
@@ -226,7 +226,6 @@ EXPECTED_EVENT_RESULT_1 = {
         "-owasp_dependency_check",
         "-base_images",
         "-node_dependencies",
-        "-truffle_hog",
         "-trufflehog",
         "-bundler_audit",
         "-php_sensio_security_checker",

--- a/ui/src/api/__tests__/client.test.ts
+++ b/ui/src/api/__tests__/client.test.ts
@@ -290,7 +290,7 @@ describe("api client", () => {
 				expect.objectContaining({
 					data: expect.objectContaining({
 						categories: categories,
-						plugins: ["-ghas_secrets", "-truffle_hog", "-trufflehog"],
+						plugins: ["-ghas_secrets", "-trufflehog"],
 					}),
 					url: `${data.vcsOrg}/${data.repo}`,
 				})

--- a/ui/src/app/scanPlugins.ts
+++ b/ui/src/app/scanPlugins.ts
@@ -216,7 +216,9 @@ export const nonDefaultPlugins: string[] = [];
 // any enabled plugins that should be excluded (not run) by default
 export const excludePlugins: string[] = ["nodejsscan"];
 
-export const pluginsDisabled: { [name: string]: boolean } = {};
+export const pluginsDisabled: { [name: string]: boolean } = {
+	truffle_hog: true,
+};
 
 if (!APP_AQUA_ENABLED) {
 	pluginsDisabled["aqua_cli_scanner"] = true;


### PR DESCRIPTION
Disables Legacy Trufflehog

## Description (and Motivation and Context)
<!--- Describe your changes in detail -->
- Git Secrets should have parity with legacy Trufflehog findings for secrets in the HEAD
- Trufflehog v3 should have coverage of git history with lower-noise detectors
- With all that in mind, we deprecate Legacy Trufflehog as it is poorly supported
  - We'll remove the plugin entirely after a few days with it disabled

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Working in dev environment
- Tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Pic
![byebye](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExazFxNHhvcW1mNXBia3V5NTZnMjlueHVhbTN4ZHcwNWRpejd1YnhkciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ac7MA7r5IMYda/giphy.webp)