### PR TITLE
Modify CI Script to exclude Trufflehog v3

### DIFF
--- a/backend/ci-tools/shell/artemis-scan.sh
+++ b/backend/ci-tools/shell/artemis-scan.sh
@@ -11,7 +11,7 @@ FAIL_CLOSED=0
 
 # Defaults
 DEFAULT_CATEGORIES="[\"vulnerability\", \"secret\"]"
-DEFAULT_PLUGINS="[\"-truffle_hog\", \"-aqua_cli_scanner\"]"
+DEFAULT_PLUGINS="[\"-trufflehog\", \"-aqua_cli_scanner\"]"
 
 usage() {
   echo "artemis-scan.sh [-h] [-b] [-c] [-P...] [-C...] [-i...] [-e...] <SERVICE> <REPO> <BRANCH> <SEVERITY>"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
With Legacy Trufflehog deprecated, the CI Script should exclude Trufflehog v3 rather than Legacy Trufflehog

## Description
<!--- Describe your changes in detail -->
- Excludes Trufflehog v3 rather than Legacy Trufflehog

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Trufflehog by default scans commit history and that can take too long for CI, so we don't want it to run there.



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
