### PR TITLE
Fix Makefile "help" target

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -235,7 +235,7 @@ help:  ## Print this help text
 	@echo " make <target>"
 	@echo
 	@echo "${YELLOW}Targets:${CNone}"
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(firstword $(MAKEFILE_LIST)) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
 
 ###############################################################################

--- a/orchestrator/Makefile
+++ b/orchestrator/Makefile
@@ -71,7 +71,7 @@ help:
 	@echo " make <target>"
 	@echo
 	@echo "${YELLOW}Targets:${CNone}"
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(firstword $(MAKEFILE_LIST)) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
 
 define run-pytest


### PR DESCRIPTION
## Description

Fixes the "make help" listing of available targets.

Before, each target was being listed as `Makefile`, e.g.

```text
Targets:
Makefile                       Do everything (test, build, upload, deploy)
Makefile                       Build all
...
```

Fixed:

```
Targets:
all                            Do everything (test, build, upload, deploy)
build                          Build all
...
```

The issue is `MAKEFILE_LIST` expands to the *list* of processed Makefiles, including any includes.

This change makes sure we only check the first item in the list (i.e., this Makefile) and prevents grep from prepending the filename to the output.

## How Has This Been Tested?

N/A

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
