### PR TITLE
Propagate errors in the heimdall_orgs layer

### DIFF
--- a/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_bitbucket.py
+++ b/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_bitbucket.py
@@ -74,11 +74,9 @@ class BitbucketOrgs:
                 url=f"{self.api_url}/projects?limit=100&start={start}", headers=headers, timeout=TIMEOUT
             )
         except requests.exceptions.Timeout:
-            log.error("Request timed out after %ss retrieving orgs for %s", TIMEOUT, self.service)
-            return None
+            raise HeimdallException(f"Request timed out after {TIMEOUT}s retrieving orgs for {self.service}")
         except requests.ConnectionError as e:
-            log.error("Error connecting to %s: %s", self.service, str(e))
-            return None
+            raise HeimdallException(f"Error connecting to {self.service,}: {e}")
 
         if response.status_code != 200:
             log.info("Error retrieving orgs for %s: %s", self.service, response.text)

--- a/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_bitbucket.py
+++ b/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_bitbucket.py
@@ -79,7 +79,7 @@ class BitbucketOrgs:
             raise HeimdallException(f"Error connecting to {self.service,}: {e}")
 
         if response.status_code != 200:
-            log.info("Error retrieving orgs for %s: %s", self.service, response.text)
+            log.warning("Error retrieving orgs for %s: %s", self.service, response.text)
             return None
         return response
 

--- a/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_bitbucket.py
+++ b/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_bitbucket.py
@@ -76,7 +76,7 @@ class BitbucketOrgs:
         except requests.exceptions.Timeout:
             raise HeimdallException(f"Request timed out after {TIMEOUT}s retrieving orgs for {self.service}")
         except requests.ConnectionError as e:
-            raise HeimdallException(f"Error connecting to {self.service,}: {e}")
+            raise HeimdallException(f"Error connecting to {self.service}: {e}")
 
         if response.status_code != 200:
             log.warning("Error retrieving orgs for %s: %s", self.service, response.text)

--- a/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_bitbucket.py
+++ b/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_bitbucket.py
@@ -6,6 +6,7 @@ import requests
 from aws_lambda_powertools import Logger
 
 from heimdall_orgs.const import TIMEOUT
+from heimdall_utils.utils import HeimdallException
 from heimdall_utils.aws_utils import GetProxySecret
 from heimdall_utils.env import APPLICATION
 from heimdall_utils.variables import REV_PROXY_DOMAIN_SUBSTRING, REV_PROXY_SECRET_HEADER
@@ -33,8 +34,7 @@ class BitbucketOrgs:
     def get_all_orgs(cls, service: str, api_url: str, api_key: str):
         bitbucket_orgs = cls(service, api_url, api_key)
         if not bitbucket_orgs.get_org_set():
-            log.error("Unexpected error occurred getting %s orgs", bitbucket_orgs.service)
-            return None
+            raise HeimdallException(f"Unexpected error occurred getting {bitbucket_orgs.service}")
         while not bitbucket_orgs.is_last_page:
             bitbucket_orgs.get_org_set()
 
@@ -55,7 +55,7 @@ class BitbucketOrgs:
         self.next_page_start = response_dict.get("nextPageStart")
         return True
 
-    def request_orgs(self, start: int = 0) -> Union[dict, None]:
+    def request_orgs(self, start: int = 0) -> Union[requests.Response, None]:
         if not self.api_url:
             log.info(
                 "Service %s url was not found and therefore deemed unsupported",
@@ -88,7 +88,7 @@ class BitbucketOrgs:
 
 def _process_orgs(org_dict: dict) -> set:
     org_output_set = set()
-    org_list = org_dict.get("values")
+    org_list = org_dict["values"]
 
     for org in org_list:
         org_output_set.add(org.get("key"))

--- a/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_gitlab.py
+++ b/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_gitlab.py
@@ -7,6 +7,7 @@ from aws_lambda_powertools import Logger
 from heimdall_orgs.const import TIMEOUT
 from heimdall_utils.aws_utils import GetProxySecret
 from heimdall_utils.env import APPLICATION
+from heimdall_utils.utils import HeimdallException
 from heimdall_utils.variables import REV_PROXY_DOMAIN_SUBSTRING, REV_PROXY_SECRET_HEADER
 
 log = Logger(service=APPLICATION, name=__name__, child=True)
@@ -112,12 +113,10 @@ class GitlabOrgs:
 
         try:
             response = requests.get(url=url, headers=headers, timeout=TIMEOUT)
-        except requests.Timeout:
-            log.error("Request timed out after %ss retrieving orgs for %s", TIMEOUT, self.service)
-            return None
+        except requests.exceptions.Timeout:
+            raise HeimdallException(f"Request timed out after {TIMEOUT}s retrieving orgs for {self.service}")
         except requests.ConnectionError as e:
-            log.error("Error connecting to %s: %s", self.service, str(e))
-            return None
+            raise HeimdallException(f"Error connecting to {self.service,}: {e}")
 
         if response.status_code != 200:
             log.warning("Error retrieving query: %s", response.text)

--- a/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_gitlab.py
+++ b/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_gitlab.py
@@ -116,7 +116,7 @@ class GitlabOrgs:
         except requests.exceptions.Timeout:
             raise HeimdallException(f"Request timed out after {TIMEOUT}s retrieving orgs for {self.service}")
         except requests.ConnectionError as e:
-            raise HeimdallException(f"Error connecting to {self.service,}: {e}")
+            raise HeimdallException(f"Error connecting to {self.service}: {e}")
 
         if response.status_code != 200:
             log.warning("Error retrieving query: %s", response.text)

--- a/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_gitlab.py
+++ b/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_gitlab.py
@@ -81,13 +81,13 @@ class GitlabOrgs:
             for page in range(2, total_pages + 1):
                 page_url = f"{url}&page={page}"
                 page_response = self._query_gitlab_api(page_url)
-                if response:
+                if page_response:
                     page_response = page_response.json()
                     subgroups.extend(page_response)
 
         return subgroups
 
-    def _request_orgs(self, page: int = 1) -> Union[dict, None]:
+    def _request_orgs(self, page: int = 1) -> Union[requests.Response, None]:
         """
         Gets all groups from the service, using the service API.
         NOTE: Current logic only supports private gitlab services.
@@ -104,7 +104,7 @@ class GitlabOrgs:
             return None
         return response
 
-    def _query_gitlab_api(self, url: str):
+    def _query_gitlab_api(self, url: str) -> Union[requests.Response, None]:
         log.debug("GitLab API request: %s", url)
         headers = {"Authorization": "bearer %s" % self.api_key, "Content-Type": "application/json"}
         if REV_PROXY_DOMAIN_SUBSTRING and REV_PROXY_DOMAIN_SUBSTRING in url:

--- a/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_private_github.py
+++ b/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_private_github.py
@@ -107,7 +107,7 @@ class GithubOrgs:
         except requests.exceptions.Timeout:
             raise HeimdallException(f"Request timed out after {TIMEOUT}s retrieving orgs for {self.service}")
         except requests.ConnectionError as e:
-            raise HeimdallException(f"Error connecting to {self.service,}: {e}")
+            raise HeimdallException(f"Error connecting to {self.service}: {e}")
 
         if response.status_code != 200 or response is None:
             log.info("Error retrieving orgs for %s: %s", self.service, response.text)

--- a/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_private_github.py
+++ b/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_private_github.py
@@ -7,7 +7,7 @@ from aws_lambda_powertools import Logger
 from heimdall_orgs.const import TIMEOUT
 from heimdall_utils.aws_utils import GetProxySecret
 from heimdall_utils.env import APPLICATION
-from heimdall_utils.utils import JSONUtils
+from heimdall_utils.utils import JSONUtils, HeimdallException
 from heimdall_utils.variables import REV_PROXY_DOMAIN_SUBSTRING, REV_PROXY_SECRET_HEADER
 
 log = Logger(service=APPLICATION, name=__name__, child=True)
@@ -42,8 +42,7 @@ class GithubOrgs:
         """
         github_orgs = cls(service, api_url, api_key)
         if not github_orgs.get_org_set():
-            log.error("Unexpected error occurred getting %s orgs", service)
-            return None
+            raise HeimdallException(f"Unexpected error occurred getting {service}")
 
         while github_orgs.has_next_page:
             github_orgs.get_org_set()
@@ -112,7 +111,7 @@ class GithubOrgs:
             log.error("Error connecting to %s: %s", self.service, str(e))
             return None
 
-        if response.status_code != 200 or response == None:
+        if response.status_code != 200 or response is None:
             log.info("Error retrieving orgs for %s: %s", self.service, response.text)
             return None
 

--- a/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_private_github.py
+++ b/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_private_github.py
@@ -105,11 +105,9 @@ class GithubOrgs:
                 timeout=TIMEOUT,
             )
         except requests.exceptions.Timeout:
-            log.error("Request timed out after %ss retrieving orgs for %s", TIMEOUT, self.service)
-            return None
+            raise HeimdallException(f"Request timed out after {TIMEOUT}s retrieving orgs for {self.service}")
         except requests.ConnectionError as e:
-            log.error("Error connecting to %s: %s", self.service, str(e))
-            return None
+            raise HeimdallException(f"Error connecting to {self.service,}: {e}")
 
         if response.status_code != 200 or response is None:
             log.info("Error retrieving orgs for %s: %s", self.service, response.text)

--- a/orchestrator/lambdas/layers/heimdall_utils/heimdall_utils/utils.py
+++ b/orchestrator/lambdas/layers/heimdall_utils/heimdall_utils/utils.py
@@ -29,6 +29,10 @@ MAX_HEIMDALL_SCAN_AGE = 83
 log = Logger(service=APPLICATION, name=__name__, child=True)
 
 
+class HeimdallException(Exception):
+    pass
+
+
 class ServiceInfo:
     # pylint: disable=too-many-instance-attributes
     def __init__(self, service, service_dict, org, api_key, repo_cursor=None, branch_cursor=None):

--- a/orchestrator/lambdas/org_queue/org_queue/org_queue.py
+++ b/orchestrator/lambdas/org_queue/org_queue/org_queue.py
@@ -62,7 +62,7 @@ def run(event: dict = None, context: LambdaContext = None, services_file: str = 
     batch_id = generate_batch_id(batch_label)
 
     log.append_keys(batch_id=batch_id)
-    log.info(f"Queueing the following organizations:\n{orgs}")
+    log.info(f"Queuing the following organizations:\n{orgs}")
 
     for org in orgs:
         split = org.split("/", maxsplit=1)
@@ -77,7 +77,7 @@ def run(event: dict = None, context: LambdaContext = None, services_file: str = 
         org_list = get_org_list(services, service, org_name)
         if not org_list:
             continue
-        log.info("Queuing %d service orgs for service %s", len(org_list), service, version_control_service=service)
+        log.debug("Queuing %d service orgs for service %s", len(org_list), service, version_control_service=service)
         for org_name_str in org_list:
             org_result_str = f"{service}/{org_name_str}"
             if not fnmatch(org_name_str, org_name):

--- a/orchestrator/lambdas/tests/test_org_queue_github.py
+++ b/orchestrator/lambdas/tests/test_org_queue_github.py
@@ -6,6 +6,7 @@ from copy import deepcopy
 from unittest.mock import patch
 
 from heimdall_orgs.org_queue_private_github import GithubOrgs
+from heimdall_utils.utils import HeimdallException
 
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 GITHUB_ORG_GRAPHQL_ERROR_RESPONSE = os.path.abspath(os.path.join(TEST_DIR, "data", "github_org_error_response.json"))
@@ -76,8 +77,9 @@ class TestOrgQueueGithub(unittest.TestCase):
         self.assertEqual(GithubOrgs._query_service, mock_request)
         mock_request.return_value = self.error_response
 
-        org_set = GithubOrgs.get_all_orgs(None, None, None)
-        self.assertEqual(None, org_set)
+        with self.assertRaises(HeimdallException):
+            org_set = GithubOrgs.get_all_orgs(None, None, None)
+            self.assertIsNone(org_set)
 
 
 def get_json_from_file(file_path):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The main execution block in the `heimdall_org_queue` Lambda does not detect errors in the `heimdall_org` layer.
This means that some failed organizations are not caught in the main handler.



This PR updates the retrievers in the `heimdall_org` layer ([`org_queue_bitbucket`](https://github.com/WarnerMedia/artemis/blob/main/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_bitbucket.py), [`org_queue_gitlab`](https://github.com/WarnerMedia/artemis/blob/main/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_gitlab.py), [`org_queue_private_github`](https://github.com/WarnerMedia/artemis/blob/main/orchestrator/lambdas/layers/heimdall_orgs/heimdall_orgs/org_queue_private_github.py))  to raise a `HeimdallException` when they detect http errors

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Pic
![Embed something funny here](https://giphy.com/trending-gifs)