### PR TITLE
Trufflehog Plugin - Classify some findings as "Inactive"

### DIFF
--- a/backend/engine/plugins/trufflehog/detectors.py
+++ b/backend/engine/plugins/trufflehog/detectors.py
@@ -103,12 +103,10 @@ verified_detectors_allowlist = [
 
 # Some detectors make a best effort to verify, but are not exhaustive. We never want to mark their
 # results as "inactive"
-_never_inactive_detectors = set(
-    [
-        "PrivateKey",
-    ]
-)
+_never_inactive_detectors = [
+    "PrivateKey",
+]
 
 inactiveable_detectors = [
-    detector for detector in verified_detectors_allowlist if detector not in _never_inactive_detectors
+    detector for detector in verified_detectors_allowlist if detector not in set(_never_inactive_detectors)
 ]

--- a/backend/engine/plugins/trufflehog/detectors.py
+++ b/backend/engine/plugins/trufflehog/detectors.py
@@ -49,7 +49,6 @@ verified_detectors_allowlist = [
     "Flickr",
     "FTP",
     "GCP",
-    "Generic",
     "Github",
     "GitHubApp",
     "GitHubOauth2",
@@ -100,4 +99,16 @@ verified_detectors_allowlist = [
     "Wiz",
     "Workday",
     "WpEngine",
+]
+
+# Some detectors make a best effort to verify, but are not exhaustive. We never want to mark their
+# results as "inactive"
+_never_inactive_detectors = set(
+    [
+        "PrivateKey",
+    ]
+)
+
+inactiveable_detectors = [
+    detector for detector in verified_detectors_allowlist if detector not in _never_inactive_detectors
 ]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Extends the Trufflehog plugin to classify some findings as `inactive`

## Description
<!--- Describe your changes in detail -->
- The Trufflehog plugin now tries to classify as `inactive` if it can
  - In the case that `verified` is False and there is no `VerificationError`
  - Also checks that it's one of the detectors we try to verify (there will never be a `VerificationError` if we run with `--no-verification`)
  - And that it's not one we deliberately stop from reporting as `inactive` (like the `ssh`/"PrivateKey" detector, which makes a best-effort attempt to verify with popular PrivateKey usecases, but is not exhaustive, so it can successfully check that the key isn't used with its 3 services while the key is still valid someplace else)
- Removes "Generic" detector from list of verified detectors (it doesn't do any verification, so there's no reason for it to be in that list)
  - It being in that list was an oversight in the first place, but it would always return "Inactive" otherwise

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [This PR](https://github.com/trufflesecurity/trufflehog/pull/2335) added similar functionality to Trufflehog itself, which was then removed in [this PR](https://github.com/trufflesecurity/trufflehog/pull/2730) due to what seemed like UX concerns. We have a different UX, so it makes more sense for us
  - Despite this, there are still some detectors which cannot reliably be marked as "Inactive" with this criteria. We force these detectors to always be either `Active` or `Unknown`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tests added for `get_validity` changes
- Working in dev
  - Will monitor results for next few weeks and add any problematic detectors to `_never_inactive_detectors` 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.