### PR TITLE
Fix Pytest deprecation warning about LogCaptureFixture

### DIFF
--- a/backend/libs/artemislib/tests/test_logger.py
+++ b/backend/libs/artemislib/tests/test_logger.py
@@ -2,7 +2,6 @@ import json
 import pytest
 import logging
 from artemislib.logging import Logger, JSONFormatter
-from _pytest.logging import LogCaptureFixture
 
 LOG_MESSAGE1 = {"level": "INFO", "message": "Scanning Repository", "repo": "Warnermedia/artemis", "scan_id": "1234"}
 LOG_MESSAGE2 = {"level": "CRITICAL", "message": "Unable To process task", "scan_id": "1234"}
@@ -22,19 +21,17 @@ LAMBDA_LOG_MESSAGE = {
 
 
 @pytest.fixture(scope="function")
-def custom_caplog(request):
+def custom_caplog(caplog):
     logger = logging.getLogger()
     original_factory = logging.getLogRecordFactory()
 
-    # Create a new LogCaptureHandler with the custom formatter
-    handler = LogCaptureFixture(request.node)
-    handler.handler.setFormatter(JSONFormatter())
-    logger.addHandler(handler.handler)
+    # Use our custom formatter with the capture log handler.
+    caplog.handler.setFormatter(JSONFormatter())
+    logger.addHandler(caplog.handler)
 
-    yield handler
+    yield caplog
 
-    # Clean up
-    logger.removeHandler(handler.handler)
+    logger.removeHandler(caplog.handler)
     logging.setLogRecordFactory(original_factory)
     Logger.reset_fields()
 


### PR DESCRIPTION
## Description

This fixes the `PytestDeprecationWarning` in the backend unit tests:

```
PytestDeprecationWarning: A private pytest class or function was used.
    handler = LogCaptureFixture(request.node)
```

We avoid this warning by extending the built-in [caplog](https://docs.pytest.org/en/stable/reference/reference.html#pytest.logging.caplog) fixture (which essentially just creates a new LogCaptureFixture) instead of re-implementing it.

## Motivation and Context

Fixes unit test warnings.

## How Has This Been Tested?

Tested via unit-tests locally and in CI.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
