### PR TITLE
plugin-runner: Handle missing .env file and allow writable target

### DIFF
--- a/backend/utilities/plugin_runner/README.md
+++ b/backend/utilities/plugin_runner/README.md
@@ -50,6 +50,14 @@ Run the "gosec" plugin and start a debug shell in the container:
 bash-5.0#
 ```
 
+By default, the target directory is mounted as read-only to avoid unexpected changes that would change the results from run-to-run.
+This is fine for most plugins, but some plugins expect the target directory to be writable.
+For those plugins, use `run-writable` instead of `run`:
+
+```bash
+./plugin.sh run-writable gosec ~/git/my-repo
+```
+
 Stop all containers and release resources:
 
 ```bash

--- a/backend/utilities/plugin_runner/plugin.sh
+++ b/backend/utilities/plugin_runner/plugin.sh
@@ -107,7 +107,9 @@ EOD
   fi
 
   # Install optional config files.
-  [[ -f "$BASEDIR/.env" ]] && cp -L "$BASEDIR/.env" "$TEMPDIR/.env" || return 1
+  if [[ -f "$BASEDIR/.env" ]]; then
+    cp -L "$BASEDIR/.env" "$TEMPDIR/.env" || return 1
+  fi
   install_plugin_arg_file engine-vars.json "$plugindir" || return 1
   install_plugin_arg_file images.json "$plugindir" || return 1
   install_plugin_arg_file config.json "$plugindir" || return 1

--- a/backend/utilities/plugin_runner/plugin.sh
+++ b/backend/utilities/plugin_runner/plugin.sh
@@ -7,6 +7,8 @@ readonly BASEDIR
 readonly TEMPDIR="$BASEDIR/tmp"
 readonly COMPOSEFILE="$TEMPDIR/docker-compose.yml"
 
+workdir_readonly=true
+
 # Print usage info to stderr.
 function usage {
   cat <<EOD >&2
@@ -14,6 +16,7 @@ Usage: $0 (subcommand)
 
 Available subcommands:
     run - Run a core plugin in local containers.
+    run-writable - Same as "run", but mounts target directory as read-write.
     clean - Stop and clean up all containers.
 EOD
 }
@@ -142,7 +145,7 @@ services:
       - type: bind
         source: "$target"
         target: /work/base
-        read_only: true
+        read_only: $workdir_readonly
 EOD
 }
 
@@ -212,6 +215,10 @@ fi
 
 case "$cmd" in
   run)
+    do_run "$@" || exit 1
+    ;;
+  run-writable)
+    workdir_readonly=false
     do_run "$@" || exit 1
     ;;
   clean)


### PR DESCRIPTION
## Description

* Properly handle the case where no `.env` file exists. Before, this would cause the script to exit immediately.
* Add a new `run-writable` subcommand to support plugins that expect the target directory to be writable.

## Motivation and Context

Fixes & features from feedback.

## How Has This Been Tested?

Tested locally.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
