### PR TITLE
Overhaul handling of errors from bundler-audit

### DIFF
--- a/backend/engine/plugins/bundler_audit/main.py
+++ b/backend/engine/plugins/bundler_audit/main.py
@@ -68,7 +68,6 @@ def parse_results(returncode: int, out: str, err: str) -> tuple[Results, list[st
         # stdout instead of stderr.
         # This may or may not be accompanied by a git error, which *is*
         # written to stderr, so we try to capture that as well.
-        LOG.warning(f"bundler-audit error log: {err}")
         return (Results(), parse_stderr(err) + [lastline])
     else:
         output = parse_output(out)

--- a/backend/engine/plugins/bundler_audit/main.py
+++ b/backend/engine/plugins/bundler_audit/main.py
@@ -63,6 +63,13 @@ def parse_results(returncode: int, out: str, err: str) -> tuple[Results, list[st
     if returncode == 0:
         # No findings, no errors.
         return (Results(), [])
+    elif (lastline := out.splitlines()[-1].strip()).startswith("failed to download "):
+        # Special case: The "failed to download" error is written to
+        # stdout instead of stderr.
+        # This may or may not be accompanied by a git error, which *is*
+        # written to stderr, so we try to capture that as well.
+        LOG.warning(f"bundler-audit error log: {err}")
+        return (Results(), parse_stderr(err) + [lastline])
     else:
         output = parse_output(out)
         if not output.empty():

--- a/backend/engine/plugins/bundler_audit/main.py
+++ b/backend/engine/plugins/bundler_audit/main.py
@@ -93,12 +93,21 @@ def parse_stderr(data: str) -> list[str]:
     # To keep things simple, we no longer attempt to trim the first line
     # of the stack trace.
 
-    return [
+    errs = [
         s.strip()
         for s in data.splitlines()
         # Remove Ruby stacktrace lines.
         if not s.startswith("\tfrom")
     ]
+    if len(errs) > 0:
+        # bundler-audit runs git which outputs status messages to stderr, which
+        # adds a lot of noise when reporting to the user.
+        # We assume that the last line of stderr (after filtering above) is the
+        # actual error, if any.
+        errs = errs[-1:]
+        # Log the full unfiltered output so we can debug.
+        LOG.warning(f"bundler-audit error log: {data}")
+    return errs
 
 
 def parse_output(data: str) -> Results:

--- a/backend/engine/plugins/bundler_audit/main.py
+++ b/backend/engine/plugins/bundler_audit/main.py
@@ -103,7 +103,10 @@ def parse_stderr(data: str) -> list[str]:
     errs = [
         s.strip()
         for s in data.splitlines()
-        # Remove Ruby stacktrace lines.
+        # Remove Ruby backtrace lines.
+        # This assumes that the backtrace is in pre-Ruby 2.5 format, which
+        # should always be the case since the output is not attached to
+        # a TTY.
         if not s.startswith("\tfrom")
     ]
     if len(errs) > 0:

--- a/backend/engine/tests/test_bundler_audit.py
+++ b/backend/engine/tests/test_bundler_audit.py
@@ -59,6 +59,40 @@ class TestBundlerAudit(unittest.TestCase):
         self.assertTrue(results.empty())
         self.assertEqual(errors, ["Failed updating ruby-advisory-db!"])
 
+    def test_parse_results_download_error(self):
+        """
+        Tests parse_results for the "Failed to download" case.
+        """
+        # This is a special case since bundler-audit writes this error to
+        # *stdout* not stderr.
+        out = 'Download ruby-advisory-db ...\nfailed to download https://github.com/rubysec/ruby-advisory-db.git to "/root/.local/share/ruby-advisory-db"\n'
+        err = ""
+        (results, errors) = bundler.parse_results(1, out, err)
+        self.assertTrue(results.empty())
+        self.assertEqual(
+            errors,
+            [
+                'failed to download https://github.com/rubysec/ruby-advisory-db.git to "/root/.local/share/ruby-advisory-db"'
+            ],
+        )
+
+    def test_parse_results_download_error_with_git(self):
+        """
+        Tests parse_results for the "Failed to download" case with an
+        additional error from git.
+        """
+        out = 'Download ruby-advisory-db ...\nfailed to download https://github.com/rubysec/ruby-advisory-db.git to "/root/.local/share/ruby-advisory-db"\n'
+        err = "fatal: destination path '/root/.local/share/ruby-advisory-db' already exists and is not an empty directory."
+        (results, errors) = bundler.parse_results(1, out, err)
+        self.assertTrue(results.empty())
+        self.assertEqual(
+            errors,
+            [
+                "fatal: destination path '/root/.local/share/ruby-advisory-db' already exists and is not an empty directory.",
+                'failed to download https://github.com/rubysec/ruby-advisory-db.git to "/root/.local/share/ruby-advisory-db"',
+            ],
+        )
+
     def test_parse_results_output(self):
         """
         Tests parse_results handles findings.

--- a/backend/engine/tests/test_bundler_audit.py
+++ b/backend/engine/tests/test_bundler_audit.py
@@ -366,7 +366,7 @@ class TestBundlerAudit(unittest.TestCase):
             ">= 4.1.14.2, ~> 4.1.14\n\n"
         )
         actual = bundler.parse_output(test)
-        self.assertEqual(actual, bundler.Results(details=[{}]))
+        self.assertEqual(actual, bundler.Results())
 
 
 if __name__ == "__main__":

--- a/backend/engine/tests/test_bundler_audit.py
+++ b/backend/engine/tests/test_bundler_audit.py
@@ -57,13 +57,7 @@ class TestBundlerAudit(unittest.TestCase):
         err = "Cloning into '/root/.local/share/ruby-advisory-db'...\nFailed updating ruby-advisory-db!\n"
         (results, errors) = bundler.parse_results(1, out, err)
         self.assertTrue(results.empty())
-        self.assertEqual(
-            errors,
-            [
-                "Cloning into '/root/.local/share/ruby-advisory-db'...",
-                "Failed updating ruby-advisory-db!",
-            ],
-        )
+        self.assertEqual(errors, ["Failed updating ruby-advisory-db!"])
 
     def test_parse_results_output(self):
         """
@@ -141,7 +135,6 @@ class TestBundlerAudit(unittest.TestCase):
             + 'failed to download https://github.com/rubysec/ruby-advisory-db.git to "/root/.local/share/ruby-advisory-db"\n'
         )
         expected = [
-            "Git is not installed!",
             'failed to download https://github.com/rubysec/ruby-advisory-db.git to "/root/.local/share/ruby-advisory-db"',
         ]
         actual = bundler.parse_stderr(data)

--- a/backend/engine/tests/test_bundler_audit.py
+++ b/backend/engine/tests/test_bundler_audit.py
@@ -7,8 +7,108 @@ import unittest
 
 from engine.plugins.bundler_audit import main as bundler
 
+# Common output from bundler-audit to stdout (when downloading a new database).
+STDOUT_PREAMBLE_DOWNLOAD = textwrap.dedent("""\
+    Download ruby-advisory-db ...
+    ruby-advisory-db:
+      advisories:   945 advisories
+      last updated: 2024-10-29 09:29:46 -0700
+    """)
+
+# Common output from bundler-audit to stdout (when updating existing database).
+STDOUT_PREAMBLE_UPDATE = textwrap.dedent("""\
+    Updating ruby-advisory-db ...
+    Already up to date.
+    Updated ruby-advisory-db
+    ruby-advisory-db:
+      advisories:   945 advisories
+      last updated: 2024-10-29 09:29:46 -0700
+    """)
+
+# Common output from bundler-audit to stderr.
+STDERR_PREAMBLE = textwrap.dedent("""\
+    Download ruby-advisory-db ...
+    Cloning into '/root/.local/share/ruby-advisory-db'...
+    remote: Enumerating objects: 12197, done.
+    remote: Counting objects: 100% (1945/1945), done.
+    remote: Compressing objects: 100% (563/563), done.
+    remote: Total 12197 (delta 1479), reused 1508 (delta 1372), pack-reused 10252 (from 1)
+    Receiving objects: 100% (12197/12197), 1.99 MiB | 16.45 MiB/s, done.
+    Resolving deltas: 100% (6920/6920), done.
+    """)
+
 
 class TestBundlerAudit(unittest.TestCase):
+    def test_parse_results_empty(self):
+        """
+        Tests parse_results handles no findings and no errors.
+        """
+        out = STDOUT_PREAMBLE_DOWNLOAD + "\n\nNo vulnerabilities found"
+        err = STDERR_PREAMBLE
+        (results, errors) = bundler.parse_results(0, out, err)
+        self.assertTrue(results.empty())
+        self.assertEqual(errors, [])
+
+    def test_parse_results_error(self):
+        """
+        Tests parse_results handles errors and no findings.
+        """
+        out = STDOUT_PREAMBLE_DOWNLOAD + "\n\nNo vulnerabilities found"
+        err = "Cloning into '/root/.local/share/ruby-advisory-db'...\nFailed updating ruby-advisory-db!\n"
+        (results, errors) = bundler.parse_results(1, out, err)
+        self.assertTrue(results.empty())
+        self.assertEqual(
+            errors,
+            [
+                "Cloning into '/root/.local/share/ruby-advisory-db'...",
+                "Failed updating ruby-advisory-db!",
+            ],
+        )
+
+    def test_parse_results_output(self):
+        """
+        Tests parse_results handles findings.
+        """
+        out = (
+            STDOUT_PREAMBLE_DOWNLOAD
+            + "Name: nokogiri\n"
+            + "Version: 1.10.8\n"
+            + "CVE: CVE-2022-23437\n"
+            + "GHSA: GHSA-xxx9-3xcr-gjj3\n"
+            + "Criticality: Medium\n"
+            + "URL: https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-xxx9-3xcr-gjj3\n"
+            + "Title: XML Injection in Xerces Java affects Nokogiri\n"
+            + "Solution: upgrade to >= 1.13.4\n\n"
+            + "Vulnerabilities found!\n"
+        )
+        err = STDERR_PREAMBLE
+        (results, errors) = bundler.parse_results(1, out, err)
+        self.assertEqual(
+            results,
+            bundler.Results(
+                details=[
+                    {
+                        "component": "nokogiri-1.10.8",
+                        "source": "Gemfile.lock",
+                        "id": "CVE-2022-23437",
+                        "description": "XML Injection in Xerces Java affects Nokogiri",
+                        "severity": "medium",
+                        "remediation": "upgrade to >= 1.13.4",
+                        "inventory": {
+                            "component": {"name": "nokogiri", "version": "1.10.8", "type": "gem"},
+                            "advisory_ids": [
+                                "CVE-2022-23437",
+                                "GHSA-xxx9-3xcr-gjj3",
+                                "https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-xxx9-3xcr-gjj3",
+                            ],
+                        },
+                    }
+                ],
+                truncated=False,
+            ),
+        )
+        self.assertEqual(errors, [])
+
     def test_parse_stderr_stacktrace(self):
         """
         Tests parse_stderr extracts the error message from a stacktrace.
@@ -56,8 +156,7 @@ class TestBundlerAudit(unittest.TestCase):
         """
         test = ""
         actual = bundler.parse_output(test)
-        expected = {}
-        self.assertEqual(actual, expected)
+        self.assertEqual(actual, bundler.Results())
 
     def test_build_dict1(self):
         """
@@ -80,8 +179,8 @@ class TestBundlerAudit(unittest.TestCase):
             "Vulnerablities Found!"
         )
         actual = bundler.parse_output(test)
-        expected = {
-            "details": [
+        expected = bundler.Results(
+            details=[
                 {
                     "component": "actionpack-4.2.0",
                     "source": "Gemfile.lock",
@@ -98,8 +197,8 @@ class TestBundlerAudit(unittest.TestCase):
                     },
                 }
             ],
-            "truncated": False,
-        }
+            truncated=False,
+        )
         self.assertEqual(actual, expected)
 
     def test_build_dict2(self):
@@ -133,8 +232,8 @@ class TestBundlerAudit(unittest.TestCase):
             "Vulnerablities Found!"
         )
         actual = bundler.parse_output(test)
-        expected = {
-            "details": [
+        expected = bundler.Results(
+            details=[
                 {
                     "component": "actionpack-4.2.0",
                     "source": "Gemfile.lock",
@@ -168,10 +267,9 @@ class TestBundlerAudit(unittest.TestCase):
                     },
                 },
             ],
-            "truncated": False,
-        }
+            truncated=False,
+        )
         self.assertEqual(actual, expected)
-        self.assertEqual(len(actual), 2)
 
     def test_build_dict3(self):
         """
@@ -215,8 +313,8 @@ class TestBundlerAudit(unittest.TestCase):
         # ">= 6.0.3.1\n\n"
 
         actual = bundler.parse_output(test)
-        expected = {
-            "details": [
+        expected = bundler.Results(
+            details=[
                 {
                     "component": "actionpack-4.2.0",
                     "source": "Gemfile.lock",
@@ -247,10 +345,9 @@ class TestBundlerAudit(unittest.TestCase):
                     },
                 },
             ],
-            "truncated": False,
-        }
+            truncated=False,
+        )
         self.assertEqual(actual, expected)
-        self.assertEqual(len(actual), 2)
 
     def test_build_dict4(self):
         """
@@ -269,8 +366,7 @@ class TestBundlerAudit(unittest.TestCase):
             ">= 4.1.14.2, ~> 4.1.14\n\n"
         )
         actual = bundler.parse_output(test)
-        expected = {"details": [{}], "truncated": False}
-        self.assertEqual(actual, expected)
+        self.assertEqual(actual, bundler.Results(details=[{}]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

Parsing of stdout and stderr from running bundler-audit is now more consistent, with better detection of error conditions.

A [previous fix](https://github.com/WarnerMedia/artemis/pull/323) adjusted the stderr parsing so that it no longer ignores/mangles error messages, but this exposed the issue that git (which is called by bundler-audit) writes its progress messages to stderr, which was being captured as errors.  Additionally, in one case the tool emits a fatal error message to stdout instead of stderr.

We now check the exit code of the tool as well as if any findings are present in order to determine if the errors should be reported.

A number of test cases were added based on actual test runs of bundler-audit so that the tests better reflect reality.

## Motivation and Context

Fix error messages mistakenly being reported for bundler-audit runs.

## How Has This Been Tested?

Tested in non-prod environment.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
