### PR TITLE
Support more NPM license conventions

### DIFF
--- a/backend/lambdas/maintenance/license_retriever/license_retriever/handlers.py
+++ b/backend/lambdas/maintenance/license_retriever/license_retriever/handlers.py
@@ -93,7 +93,7 @@ def license_lookup(license, spdx_licenses) -> Tuple[str, str]:
         return license, spdx_licenses[license]
     elif license in PYPI_LICENSE_MAP:
         return license, PYPI_LICENSE_MAP[license]
-    if re.match("^[a-zA-Z0-9_.-]+$", license):
+    if re.match("^[a-zA-Z0-9(): _.+-]+$", license):
         # License contains all valid characters
         return license, license
     LOG.info("Unexpected license ID: %s", license)

--- a/backend/lambdas/maintenance/license_retriever/license_retriever/retrievers/npm.py
+++ b/backend/lambdas/maintenance/license_retriever/license_retriever/retrievers/npm.py
@@ -22,12 +22,13 @@ def retrieve_npm_licenses(name: str, version: str) -> list:
 
     for item in license:
         item_type = type(item)
+
         if item_type is str:
             result.append(item.lower())
         elif item_type is dict and 'type' in item:
             result.append(item['type'].lower())
         else:
-            LOG.error(f'Unexpected license format for npm package, "{name}@{version}". Result was: {json.dumps(item)}')
+            LOG.error(f'Unexpected license format for npm package, "{name}@{version}". License item was: {json.dumps(item)}')
 
     return result
 

--- a/backend/lambdas/maintenance/license_retriever/license_retriever/retrievers/npm.py
+++ b/backend/lambdas/maintenance/license_retriever/license_retriever/retrievers/npm.py
@@ -27,8 +27,11 @@ def get_package_info(name: str, version: str) -> dict:
             retry = int(r.headers.get("Retry-After", 5))
             LOG.info("Rate limit reached, retrying after %s seconds", retry)
             sleep(retry)
+        elif r.status_code == 404:
+            LOG.warning('Unable to find package info for "%s@%s" on registry.npmjs.org', name, version)
+            return {}
         else:
-            LOG.error("Unable to find package info for %s: HTTP %s", name, r.status_code)
+            LOG.error('Unexpected error for "%s@%s": HTTP %s', name, version, r.status_code)
             return {}
 
 
@@ -58,7 +61,7 @@ def get_package_license(package_info: dict, package_name: str) -> list[str]:
     elif "licenses" in package_info:
         license = package_info["licenses"]
     else:
-        LOG.debug('No license information in package info for "%s"', package_name)
+        LOG.warning('No license information in package info for "%s"', package_name)
         return []
 
     if type(license) is list:

--- a/backend/lambdas/maintenance/license_retriever/license_retriever/retrievers/npm.py
+++ b/backend/lambdas/maintenance/license_retriever/license_retriever/retrievers/npm.py
@@ -39,7 +39,7 @@ def get_package_license(package_info: dict) -> list[str]:
     #
     # So, we should be able to parse all of these:
     # license: "GPL-3.0"
-    # license: "(GPL-3.0 OR MIT)" # SPDX expression. We will just return the expression whole as a string
+    # license: "(GPL-3.0 OR MIT)" # SPDX expression. We will return the expression whole as a string
     # license: [
     #     "GPL-3.0",
     #     "MIT"
@@ -49,14 +49,9 @@ def get_package_license(package_info: dict) -> list[str]:
     #     url: "..."
     # }
     # licenses: [
-    #     {
-    #         type: "GPL-3.0",
-    #         url: "..."
-    #     },
-    #     {
-    #         type: "MIT",
-    #         url: "..."
-    #     }
+    #     { type: "GPL-3.0", url: "..." },
+    #     { type: "MIT", url: "..." }
+    # ]
 
     if "license" in package_info:
         license = package_info["license"]

--- a/backend/lambdas/maintenance/license_retriever/license_retriever/retrievers/npm.py
+++ b/backend/lambdas/maintenance/license_retriever/license_retriever/retrievers/npm.py
@@ -1,5 +1,7 @@
 from time import sleep
+from typing import Optional, Union
 
+import json
 import requests
 
 from artemislib.logging import Logger
@@ -19,9 +21,15 @@ def retrieve_npm_licenses(name: str, version: str) -> list:
         return [license.lower()]
 
     for item in license:
-        result.append(item.lower())
+        item_type = type(item)
+        if item_type is str:
+            result.append(item.lower())
+        elif item_type is dict and 'type' in item:
+            result.append(item['type'].lower())
+        else:
+            LOG.error(f'Unexpected license format for npm package, "{name}@{version}". Result was: {json.dumps(item)}')
 
-    return []
+    return result
 
 
 def get_package_info(name: str, version: str) -> dict:

--- a/backend/lambdas/maintenance/license_retriever/tests/test_retriever_npm.py
+++ b/backend/lambdas/maintenance/license_retriever/tests/test_retriever_npm.py
@@ -1,0 +1,70 @@
+import unittest
+import pytest
+
+from unittest.mock import patch
+from license_retriever.retrievers import npm
+
+GPL = "GPL-3.0"
+MIT = "MIT"
+
+GPL_OR_MIT_SPDX = f"({GPL} OR {MIT})"
+
+
+@pytest.mark.parametrize(
+    "npm_response,expected_result",
+    [
+        pytest.param({}, [], id="should return empty array if no license"),
+        pytest.param({"license": {"name": GPL}}, [], id="should return empty array if unexpected license format"),
+        pytest.param(
+            {"license": GPL},
+            [GPL.lower()],
+            id="should return a single license if license is a single license in a string",
+        ),
+        pytest.param(
+            {"license": {"type": GPL}},
+            [GPL.lower()],
+            id="should return a single license if license is a single license in 'type' property of an object",
+        ),
+        pytest.param(
+            {"license": GPL_OR_MIT_SPDX},
+            [GPL_OR_MIT_SPDX.lower()],
+            id="should return whole expression if license is a SPDX expression in a string",
+        ),
+        pytest.param(
+            {"license": [GPL, MIT]},
+            [GPL.lower(), MIT.lower()],
+            id="should return each license if license is an array of string",
+        ),
+        pytest.param(
+            {"licenses": [GPL, MIT]},
+            [GPL.lower(), MIT.lower()],
+            id="should return each license if license is an array of string in 'licenses' property",
+        ),
+        pytest.param(
+            {
+                "license": [
+                    {"type": GPL},
+                    {"type": MIT},
+                ]
+            },
+            [GPL.lower(), MIT.lower()],
+            id="should return each license if license is an array of objects with 'type' property",
+        ),
+    ],
+)
+@patch("requests.get")
+def test_retrieve_npm_licenses(mock_get, npm_response, expected_result):
+    mock_get.return_value = FakeGetResponse(npm_response)
+
+    result = npm.retrieve_npm_licenses("name", "version")
+
+    assert result == expected_result
+
+
+class FakeGetResponse:
+    def __init__(self, response: dict):
+        self.response = response
+        self.status_code = 200
+
+    def json(self) -> dict:
+        return self.response

--- a/backend/lambdas/maintenance/license_retriever/tests/test_retriever_npm.py
+++ b/backend/lambdas/maintenance/license_retriever/tests/test_retriever_npm.py
@@ -49,6 +49,16 @@ GPL_OR_MIT_SPDX = f"({GPL} OR {MIT})"
             [GPL.lower(), MIT.lower()],
             id="should return each license if license is an array of objects with 'type' property",
         ),
+        pytest.param(
+            {
+                "licenses": [
+                    {"type": GPL},
+                    {"type": MIT},
+                ]
+            },
+            [GPL.lower(), MIT.lower()],
+            id="should return each license if license is in 'licenses' property with an array of objects with 'type' property",
+        ),
     ],
 )
 @patch("requests.get")

--- a/backend/lambdas/maintenance/license_retriever/tests/test_retriever_npm.py
+++ b/backend/lambdas/maintenance/license_retriever/tests/test_retriever_npm.py
@@ -1,4 +1,3 @@
-import unittest
 import pytest
 
 from unittest.mock import patch

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -23,6 +23,7 @@ pythonpath =
     lambdas/api/users_services
     lambdas/events/event_dispatch
     lambdas/generators/json_report
+    lambdas/maintenance/license_retriever
     lambdas/scheduled/scan_scheduler
     libs/artemisapi
     libs/artemisdb


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
- Extends the NPM license retriever to cover more cases

## Description
<!--- Describe your changes in detail -->
- Can now handle SPDX license expressions
  - Which is the currently-supported way to have multiple licenses: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#license
  - We opted not to lose the AND/OR/WITH logic in this pull request by extracting all the mentioned license versions. SPDX expressions should be preserved as-is
    - Another option is to parse the expression and return all licenses mentioned, but then we'd lose the AND/OR/WITH relationship. (We are not doing this)
- Also handles more "deprecated" license cases
  - Like `license: { type: str }`
  - Like `licenses: [ { type: str } ]`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
There were common license patterns that we were not reading

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests pass and working in dev environment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
