### PR TITLE
Switch Ruby plugins to use the boxed runner

### DIFF
--- a/backend/Dockerfiles/Dockerfile.ruby
+++ b/backend/Dockerfiles/Dockerfile.ruby
@@ -9,7 +9,8 @@ ARG BUNDLER_VER=0.8.0
 
 # Run all additional config in a single RUN to reduce the layers:
 # - Install brakeman and bundler-audit
-# - Remove bundler-audit rspec Gemfiles so that Aqua doesn't generate F+ from them when scanned
+# - Install git as a dependency of bundler-audit.
+# - Remove bundler-audit rspec Gemfiles to avoid false-positives in scans.
 # hadolint ignore=DL3008
 RUN apt-get update && \
     grep security /etc/apt/sources.list > /etc/apt/security.sources.list && \

--- a/backend/Dockerfiles/Dockerfile.ruby
+++ b/backend/Dockerfiles/Dockerfile.ruby
@@ -4,7 +4,7 @@ FROM ruby:${RUBY_VER}
 ARG MAINTAINER
 LABEL maintainer=$MAINTAINER
 
-# Set the version for bundler audit
+ARG BRAKEMAN_VER=5.0.0
 ARG BUNDLER_VER=0.8.0
 
 # Run all additional config in a single RUN to reduce the layers:
@@ -18,6 +18,6 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends git && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    gem install brakeman --version 5.0.0 && \
+    gem install brakeman --version ${BRAKEMAN_VER} && \
     gem install bundler-audit --version ${BUNDLER_VER} && \
     rm -rf /usr/local/bundle/gems/bundler-audit-${BUNDLER_VER}/spec/

--- a/backend/Dockerfiles/Dockerfile.ruby
+++ b/backend/Dockerfiles/Dockerfile.ruby
@@ -1,4 +1,4 @@
-ARG RUBY_VER=3.0-alpine
+ARG RUBY_VER=3.0-slim-bullseye
 FROM ruby:${RUBY_VER}
 
 ARG MAINTAINER
@@ -8,20 +8,16 @@ LABEL maintainer=$MAINTAINER
 ARG BUNDLER_VER=0.8.0
 
 # Run all additional config in a single RUN to reduce the layers:
-# - Apply security updates
-# - Base apk requirements to execute script
-# - Upgrade pip and install boto3 for plugin utils
-# - Symlink python3 to python for Analyzer Engine benefit
 # - Install brakeman and bundler-audit
-# - Update webrick to resolve CVE-2020-25613. We can't actually uninstall webrick:1.6.0 because it's a default gem so
-#   we'll still have to create an exception for this CVE. But with webrick:1.6.1 installed as a default gem it should
-#   prevent it from being accidentally used (especially because webrick isn't used at all by Artemis plugins).
 # - Remove bundler-audit rspec Gemfiles so that Aqua doesn't generate F+ from them when scanned
-RUN apk update && \
-    apk upgrade libcrypto1.1 libssl1.1 libretls && \
-    apk add git unzip python3 py3-pip jq py3-boto3 && \
-    ln -sf /usr/bin/python3 /usr/bin/python && \
-    pip install --upgrade setuptools && \
+# hadolint ignore=DL3008
+RUN apt-get update && \
+    grep security /etc/apt/sources.list > /etc/apt/security.sources.list && \
+    apt-get upgrade -y && \
+    apt-get upgrade -y -o Dir::Etc::Sourcelist=/etc/apt/security.sources.list && \
+    apt-get install -y --no-install-recommends git && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
     gem install brakeman --version 5.0.0 && \
     gem install bundler-audit --version ${BUNDLER_VER} && \
     rm -rf /usr/local/bundle/gems/bundler-audit-${BUNDLER_VER}/spec/

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -534,7 +534,7 @@ dist/docker/ruby: Dockerfiles/Dockerfile.ruby
 	$(DOCKER) build . --pull -t ${RUBY_TAG} -f Dockerfiles/Dockerfile.ruby \
 		--no-cache --force-rm \
 		--build-arg MAINTAINER=${MAINTAINER} \
-		--build-arg RUBY_VER=3.0-alpine
+		--build-arg RUBY_VER=3.0-slim-bullseye
 	mkdir -p ${DIST_DIR}/docker
 	${DOCKER} tag ${RUBY_TAG} ${ECR_URL}${RUBY_TAG}
 	${DOCKER} tag ${RUBY_TAG} ${ECR_URL}${RUBY_TAG}-stage-${LATEST_COMMIT}

--- a/backend/engine/plugins/brakeman/settings.json
+++ b/backend/engine/plugins/brakeman/settings.json
@@ -1,5 +1,6 @@
 {
     "name": "Brakeman Scanner",
     "type": "static_analysis",
-    "image": "$ECR/artemis/ruby:latest"
+    "image": "$ECR/artemis/ruby:latest",
+    "runner": "boxed"
 }

--- a/backend/engine/plugins/bundler_audit/settings.json
+++ b/backend/engine/plugins/bundler_audit/settings.json
@@ -1,5 +1,6 @@
 {
     "name": "Bundler Audit Scanner",
     "type": "vulnerability",
-    "image": "$ECR/artemis/ruby:latest"
+    "image": "$ECR/artemis/ruby:latest",
+    "runner": "boxed"
 }


### PR DESCRIPTION
## Description

Switched the Ruby plugins (Brakeman and Bundler-Audit) to use the boxed plugin runner.

Additionally, included some minor cleanups of the Dockerfile.

## Motivation and Context

Simplify maintenance of `Dockerfile.ruby`.

## How Has This Been Tested?

Tested in non-prod environment.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
