### PR TITLE
Remove CI-specific logic for swagger-codegen

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -64,11 +64,7 @@ ifndef ANALYZER_DJANGO_SECRET_KEY
 	export ANALYZER_DB_PORT=5433
 endif
 
-ifeq ($(shell whoami),circleci)
-	SWAGGER_CODEGEN := java -jar swagger-codegen-cli-3.0.11.jar
-else
-	SWAGGER_CODEGEN := swagger-codegen
-endif
+SWAGGER_CODEGEN := swagger-codegen
 
 # Lambdas
 REPO_LAMBDA := ${PREFIX}-repo-handler


### PR DESCRIPTION
## Description

Removes the CI-specific logic in backend/Makefile to set `SWAGGER_CODEGEN`.

If `SWAGGER_CODEGEN` needs to be changed from the default, it should be defined via `make`, e.g.:

```bash
make dist/api/index.html SWAGGER_CODEGEN='java -jar /opt/swagger-codegen-3.0.63'
```

## Motivation and Context

Simplifies the Makefile by removing unnecessary code.

## How Has This Been Tested?

Tested running `make dist/api/index.html` locally.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
