### PR TITLE
Upgrade Ruby image and tools (Chainguard)

### DIFF
--- a/backend/Dockerfiles/Dockerfile.ruby
+++ b/backend/Dockerfiles/Dockerfile.ruby
@@ -1,24 +1,20 @@
-ARG RUBY_VER=3.0-slim-bullseye
-FROM ruby:${RUBY_VER}
+FROM cgr.dev/chainguard/ruby:latest-dev
 
 ARG MAINTAINER
 LABEL maintainer=$MAINTAINER
 
-ARG BRAKEMAN_VER=5.0.0
-ARG BUNDLER_VER=0.8.0
+ARG BRAKEMAN_VER=6.2.2
+ARG BUNDLER_VER=0.9.2
+
+USER root
 
 # Run all additional config in a single RUN to reduce the layers:
 # - Install brakeman and bundler-audit
-# - Install git as a dependency of bundler-audit.
 # - Remove bundler-audit rspec Gemfiles to avoid false-positives in scans.
 # hadolint ignore=DL3008
-RUN apt-get update && \
-    grep security /etc/apt/sources.list > /etc/apt/security.sources.list && \
-    apt-get upgrade -y && \
-    apt-get upgrade -y -o Dir::Etc::Sourcelist=/etc/apt/security.sources.list && \
-    apt-get install -y --no-install-recommends git && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    gem install brakeman --version ${BRAKEMAN_VER} && \
+RUN gem install brakeman --version ${BRAKEMAN_VER} && \
     gem install bundler-audit --version ${BUNDLER_VER} && \
-    rm -rf /usr/local/bundle/gems/bundler-audit-${BUNDLER_VER}/spec/
+    rm -rf /usr/lib/ruby/gems/3.3.0/gems/bundler-audit-${BUNDLER_VER}/spec/
+
+USER nonroot
+ENTRYPOINT ["/bin/sh"]

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -529,8 +529,7 @@ dist/docker/ruby: Dockerfiles/Dockerfile.ruby
 	@echo "${INFO}Building $@"
 	$(DOCKER) build . --pull -t ${RUBY_TAG} -f Dockerfiles/Dockerfile.ruby \
 		--no-cache --force-rm \
-		--build-arg MAINTAINER=${MAINTAINER} \
-		--build-arg RUBY_VER=3.0-slim-bullseye
+		--build-arg MAINTAINER=${MAINTAINER}
 	mkdir -p ${DIST_DIR}/docker
 	${DOCKER} tag ${RUBY_TAG} ${ECR_URL}${RUBY_TAG}
 	${DOCKER} tag ${RUBY_TAG} ${ECR_URL}${RUBY_TAG}-stage-${LATEST_COMMIT}


### PR DESCRIPTION
## Description

This upgrades the Ruby base image to use Ruby 3.3.  To support this version of Ruby, the tools have been upgraded as well:

* Brakeman upgraded to 6.2.2
* Bundler-Audit upgraded to 0.9.2

> [!NOTE]
> This is the *Chainguard* version of this solution.
> The Chainguard base image has zero vulnerabilities (compare to the [Debian version](https://github.com/WarnerMedia/artemis/pull/343)), but does not let us choose the Ruby version.

## Motivation and Context

Upgrades the base image to resolve detected vulnerabilities.

## How Has This Been Tested?

TODO

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
