### PR TITLE
Upgrade Ruby image and tools (Debian)

### DIFF
--- a/backend/Dockerfiles/Dockerfile.ruby
+++ b/backend/Dockerfiles/Dockerfile.ruby
@@ -10,13 +10,15 @@ ARG BUNDLER_VER=0.9.2
 # Run all additional config in a single RUN to reduce the layers:
 # - Install brakeman and bundler-audit
 # - Install git as a dependency of bundler-audit.
-# - Remove bundler-audit rspec Gemfiles to avoid false-positives in scans.
+# - Remove unused packages and bundler-audit rspec Gemfiles to avoid
+#   false-positives in scans.
 # hadolint ignore=DL3008
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends git && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
     gem install brakeman --version ${BRAKEMAN_VER} && \
     gem install bundler-audit --version ${BUNDLER_VER} && \
-    rm -rf /usr/local/bundle/gems/bundler-audit-${BUNDLER_VER}/spec/
+    rm -rf /usr/local/bundle/gems/bundler-audit-${BUNDLER_VER}/spec/ && \
+    apt-get remove -y linux-libc-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*

--- a/backend/Dockerfiles/Dockerfile.ruby
+++ b/backend/Dockerfiles/Dockerfile.ruby
@@ -1,11 +1,11 @@
-ARG RUBY_VER=3.0-slim-bullseye
+ARG RUBY_VER=3.3-slim-bookworm
 FROM ruby:${RUBY_VER}
 
 ARG MAINTAINER
 LABEL maintainer=$MAINTAINER
 
-ARG BRAKEMAN_VER=5.0.0
-ARG BUNDLER_VER=0.8.0
+ARG BRAKEMAN_VER=6.2.2
+ARG BUNDLER_VER=0.9.2
 
 # Run all additional config in a single RUN to reduce the layers:
 # - Install brakeman and bundler-audit
@@ -13,9 +13,7 @@ ARG BUNDLER_VER=0.8.0
 # - Remove bundler-audit rspec Gemfiles to avoid false-positives in scans.
 # hadolint ignore=DL3008
 RUN apt-get update && \
-    grep security /etc/apt/sources.list > /etc/apt/security.sources.list && \
     apt-get upgrade -y && \
-    apt-get upgrade -y -o Dir::Etc::Sourcelist=/etc/apt/security.sources.list && \
     apt-get install -y --no-install-recommends git && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -530,7 +530,7 @@ dist/docker/ruby: Dockerfiles/Dockerfile.ruby
 	$(DOCKER) build . --pull -t ${RUBY_TAG} -f Dockerfiles/Dockerfile.ruby \
 		--no-cache --force-rm \
 		--build-arg MAINTAINER=${MAINTAINER} \
-		--build-arg RUBY_VER=3.0-slim-bullseye
+		--build-arg RUBY_VER=3.3-slim-bookworm
 	mkdir -p ${DIST_DIR}/docker
 	${DOCKER} tag ${RUBY_TAG} ${ECR_URL}${RUBY_TAG}
 	${DOCKER} tag ${RUBY_TAG} ${ECR_URL}${RUBY_TAG}-stage-${LATEST_COMMIT}


### PR DESCRIPTION
## Description

This upgrades the Ruby base image to use Ruby 3.3.  To support this version of Ruby, the tools have been upgraded as well:

* Brakeman upgraded to 6.2.2
* Bundler-Audit upgraded to 0.9.2

Additionally:

* Removed the separate step to upgrade security updates, which is unnecessary since we upgrade all packages anyway.
* The `linux-libc-dev` package and dependencies are removed as they are not needed in the final image, and they result in hundreds of false-positives in container scanning.

> [!NOTE]
> This is the *Debian* version of this solution.
> The Debian base image has more detected vulnerabilities than the [Chainguard version](https://github.com/WarnerMedia/artemis/pull/342), but lets us select the specific Ruby version version which should result in fewer surprises from incompatibilities.

## Motivation and Context

Upgrades the base image to resolve detected vulnerabilities.

## How Has This Been Tested?

Tested in non-prod environment.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
