### PR TITLE
Fix edge-case for repo size with Github On-Prem

### DIFF
--- a/backend/lambdas/api/repo/repo/github_util/github_utils.py
+++ b/backend/lambdas/api/repo/repo/github_util/github_utils.py
@@ -229,6 +229,7 @@ def _get_authorization(org: str, github_secret: str) -> str:
     key = get_api_key(github_secret)
     return f"bearer {key}"
 
+
 def _get_repo_size(response_data: dict) -> int:
     # Addresses an edge-case in Github On-Prem where "diskUsage" in response_data is explicitly
     # None. This prevents us from doing a simple, `response_data.get("diskUsage", 0)`, as it would
@@ -237,4 +238,3 @@ def _get_repo_size(response_data: dict) -> int:
         return response_data["diskUsage"]
     else:
         return 0
-


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes an edge-case when retrieving repo size with Github On-Prem

## Description
<!--- Describe your changes in detail -->
There are cases when Github On-Prem will explicitly return `null` for `diskUsage`. These cases lead to the engine erroring out later down the line since it assumes `repo_size` is an int.

The fix is then to explicitly check that the `diskUsage` is an int when adding it, and set it to 0 otherwise.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- This edge-case was causing infrequent engine crashes

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Working locally and tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
