### PR TITLE
Fix Trivy SBOM error when no version is provided

### DIFF
--- a/backend/engine/plugins/trivy_sbom/parser.py
+++ b/backend/engine/plugins/trivy_sbom/parser.py
@@ -26,7 +26,7 @@ def clean_output_application_sbom(output: list) -> list:
             name = f'{item["group"]}/{item["name"]}'
         else:
             name = item["name"]
-        version = item["version"]
+        version = item.get("version", "none")
         licenses = []
         licenses_list = item.get("licenses", [])
         for lic in licenses_list:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a Trivy SBOM error when no version is provided

## Description
<!--- Describe your changes in detail -->
- Trivy SBOM was erroing with KeyError when no version was provided. This uses `dict.get` instead
- Uses the string "none" as the default value if it's not provided
  - This is as opposed to None, since these values get thrown into a database and it's unclear what behavior passing None would lead to.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Fixes an error

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Working locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
