### PR TITLE
Fix error in Trivy SBOM plugin when returned output is None

### DIFF
--- a/backend/engine/plugins/lib/utils.py
+++ b/backend/engine/plugins/lib/utils.py
@@ -9,6 +9,7 @@ import sys
 import boto3
 from botocore.exceptions import ClientError, NoCredentialsError
 from types import TracebackType
+from typing import Optional
 
 CODE_DIRECTORY = "/work/base"
 CVE_API_URL = "https://services.nvd.nist.gov/rest/json/cve/1.0"
@@ -152,7 +153,7 @@ def get_object_from_json_dict(json_object: dict, traversal_list: list, logger):
     return cur_object
 
 
-def convert_string_to_json(output_str: str, log):
+def convert_string_to_json(output_str: Optional[str], log):
     if not output_str:
         return None
     try:

--- a/backend/engine/plugins/trivy_sbom/main.py
+++ b/backend/engine/plugins/trivy_sbom/main.py
@@ -111,13 +111,13 @@ def main():
     errors.extend(go_mod_errors)
 
     # Scan local lock files
-    trivy_sbom_result_raw = execute_trivy_application_sbom(args.path, include_dev)
-    trivy_sbom_result = convert_string_to_json(trivy_sbom_result_raw, logger)
+    sbom_result_raw = execute_trivy_application_sbom(args.path, include_dev)
+    sbom_result = convert_string_to_json(sbom_result_raw, logger)
 
-    if not trivy_sbom_result:
+    if not sbom_result:
         logger.warning("Application SBOM output is None. Continuing.")
     else:
-        application_sbom_output = edit_application_sbom_path(repo, trivy_sbom_result)
+        application_sbom_output = edit_application_sbom_path(repo, sbom_result)
         application_sbom_output_parsed = clean_output_application_sbom(application_sbom_output)
         logger.debug(application_sbom_output)
 

--- a/backend/engine/plugins/trivy_sbom/main.py
+++ b/backend/engine/plugins/trivy_sbom/main.py
@@ -115,7 +115,7 @@ def main():
     trivy_sbom_result = convert_string_to_json(trivy_sbom_result_raw, logger)
 
     if not trivy_sbom_result:
-        logger.warning("Trivy SBOM output is None. Continuing.")
+        logger.warning("Application SBOM output is None. Continuing.")
     else:
         application_sbom_output = edit_application_sbom_path(repo, trivy_sbom_result)
         application_sbom_output_parsed = clean_output_application_sbom(application_sbom_output)

--- a/backend/engine/plugins/trivy_sbom/main.py
+++ b/backend/engine/plugins/trivy_sbom/main.py
@@ -111,14 +111,16 @@ def main():
     errors.extend(go_mod_errors)
 
     # Scan local lock files
-    application_sbom_output = edit_application_sbom_path(
-        repo, convert_string_to_json(execute_trivy_application_sbom(args.path, include_dev), logger)
-    )
-    application_sbom_output_parsed = clean_output_application_sbom(application_sbom_output)
-    logger.debug(application_sbom_output)
-    if not application_sbom_output:
-        logger.warning("Application SBOM output is None. Continuing.")
+    trivy_sbom_result_raw = execute_trivy_application_sbom(args.path, include_dev)
+    trivy_sbom_result = convert_string_to_json(trivy_sbom_result_raw, logger)
+
+    if not trivy_sbom_result:
+        logger.warning("Trivy SBOM output is None. Continuing.")
     else:
+        application_sbom_output = edit_application_sbom_path(repo, trivy_sbom_result)
+        application_sbom_output_parsed = clean_output_application_sbom(application_sbom_output)
+        logger.debug(application_sbom_output)
+
         logger.info("Application Level SBOM generated. Success: %s", bool(application_sbom_output))
         results.append(application_sbom_output)
         parsed.extend(application_sbom_output_parsed)

--- a/backend/engine/plugins/trivy_sbom/parser.py
+++ b/backend/engine/plugins/trivy_sbom/parser.py
@@ -5,11 +5,13 @@ trivy output parser
 from engine.plugins.lib.utils import setup_logging
 from engine.plugins.lib.trivy_common.parsing_util import convert_type
 
+from typing import Optional
+
 logger = setup_logging("trivy_sbom")
 
 
 # Gets the scan and formats it to work with the processor
-def clean_output_application_sbom(output: list) -> list:
+def clean_output_application_sbom(output: dict) -> list:
     results = []
     type = None
     for item in output["components"]:
@@ -44,7 +46,7 @@ def clean_output_application_sbom(output: list) -> list:
 
 
 # Updates the path to be relative to the repo instead of relative to artemis
-def edit_application_sbom_path(repo: str, application_sbom_output: dict):
-    if application_sbom_output and application_sbom_output.get("metadata").get("component").get("name"):
+def edit_application_sbom_path(repo: str, application_sbom_output: dict) -> dict:
+    if application_sbom_output.get("metadata", {}).get("component", {}).get("name"):
         application_sbom_output["metadata"]["component"]["name"] = repo
     return application_sbom_output


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes an error in the Trivy SBOM plugin

## Description
<!--- Describe your changes in detail -->
- Trivy SBOM was erroring out when `output` passed to `clean_output_application_sbom` is `None`. This PR adds a check that the value is truthy to prevent this
- This PR also updates relevant types to prevent such errors in the future

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Fixes an error that occurs in Trivy SBOM

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Working in dev environment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
