### PR TITLE
Migrate to OpenAPI 3.1.0

### DIFF
--- a/backend/lambdas/api/spec.yaml
+++ b/backend/lambdas/api/spec.yaml
@@ -1,7 +1,10 @@
-openapi: 3.0.2
+openapi: 3.1.0
 info:
   title: Artemis REST API
   version: 1.1.0
+  license:
+    name: MIT License
+    identifier: MIT
   contact:
     email: "cso_appsec@warnermedia.com"
 tags:
@@ -21,6 +24,12 @@ tags:
     description: User actions
   - name: whitelist
     description: Whitelist actions
+servers:
+  - url: https://{host}/api/v1
+    variables:
+      host:
+        default: localhost
+        description: API host
 paths:
   "/{service}":
     parameters:
@@ -2122,8 +2131,9 @@ components:
           default: false
         diff_base:
           description: Commit hash or branch name to use for diff-based reporting
-          type: string
-          nullable: true
+          type:
+            - string
+            - "null"
           minLength: 1
           maxLength: 256
         batch_id:
@@ -3227,8 +3237,9 @@ components:
           type: string
         error:
           description: Error encountered when testing connection from Artemis to service
-          type: string
-          nullable: true
+          type:
+            - string
+            - "null"
 
     SystemServiceStats:
       type: object


### PR DESCRIPTION
## Description

Migrates the API spec to OpenAPI 3.1.0.  This resolves the bulk of lint warnings from Redocly.

## Motivation and Context

Preparation for switching from swagger-codegen to Redocly for documentation generation.

## How Has This Been Tested?

Passes `redocly lint` (with a config file which will be added in a follow-up PR).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.