### PR TITLE
Downgrade @types/redux-logger to 3.0.9 to fix dev mode

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -16,7 +16,7 @@
         "@lingui/react": "^4.13.0",
         "@mui/icons-material": "^5.16.7",
         "@mui/lab": "5.0.0-alpha.132",
-        "@mui/material": "^5.14.11",
+        "@mui/material": "5.14.11",
         "@mui/x-date-pickers": "^5.0.20",
         "@reduxjs/toolkit": "^1.9.7",
         "@types/node": "^20.16.13",
@@ -59,7 +59,7 @@
         "@types/luxon": "^3.4.2",
         "@types/react-copy-to-clipboard": "^5.0.7",
         "@types/react-syntax-highlighter": "^15.5.13",
-        "@types/redux-logger": "^3.0.13",
+        "@types/redux-logger": "3.0.9",
         "@types/webpack-env": "^1.18.5",
         "env-cmd": "^10.1.0",
         "jest-html-reporter": "^3.10.2",
@@ -5789,19 +5789,13 @@
       }
     },
     "node_modules/@types/redux-logger": {
-      "version": "3.0.13",
-      "resolved": "https://registry.npmjs.org/@types/redux-logger/-/redux-logger-3.0.13.tgz",
-      "integrity": "sha512-jylqZXQfMxahkuPcO8J12AKSSCQngdEWQrw7UiLUJzMBcv1r4Qg77P6mjGLjM27e5gFQDPD8vwUMJ9AyVxFSsg==",
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/redux-logger/-/redux-logger-3.0.9.tgz",
+      "integrity": "sha512-cwYhVbYNgH01aepeMwhd0ABX6fhVB2rcQ9m80u8Fl50ZODhsZ8RhQArnLTkE7/Zrfq4Sz/taNoF7DQy9pCZSKg==",
       "dev": true,
       "dependencies": {
-        "redux": "^5.0.0"
+        "redux": "^4.0.0"
       }
-    },
-    "node_modules/@types/redux-logger/node_modules/redux": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
-      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "dev": true
     },
     "node_modules/@types/resolve": {
       "version": "1.17.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -63,7 +63,7 @@
     "@types/luxon": "^3.4.2",
     "@types/react-copy-to-clipboard": "^5.0.7",
     "@types/react-syntax-highlighter": "^15.5.13",
-    "@types/redux-logger": "^3.0.13",
+    "@types/redux-logger": "3.0.9",
     "@types/webpack-env": "^1.18.5",
     "env-cmd": "^10.1.0",
     "jest-html-reporter": "^3.10.2",


### PR DESCRIPTION
## Description

Downgrades `@types/redux-logger` to 3.0.9.

## Motivation and Context

Fixes the UI in dev mode.  Newer versions are incompatible.

## How Has This Been Tested?

Tested locally via `npm start`.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
