### PR TITLE
Plugin runner: Support plugins that use Docker

### DIFF
--- a/backend/utilities/plugin_runner/plugin.sh
+++ b/backend/utilities/plugin_runner/plugin.sh
@@ -133,6 +133,8 @@ services:
     image: "artemis/engine:latest"
     container_name: engine
     command: ["/bin/true"]
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
   plugin:
     image: "$plugin_image"
     container_name: "$plugin"


### PR DESCRIPTION
## Description

The Plugin Runner tool now supports plugins that need to use Docker (e.g. trivy).

This is accomplished the same way we do it in the AWS deployment, by mounting the `docker.sock` in the engine as a volume that gets inherited by the plugin containers -- see [`docker-compose.aws.yml`](https://github.com/WarnerMedia/artemis/blob/a2683ea51d47e07de07b6e3e3cd1a228574f070c/backend/docker-compose.aws.yml#L7).

## Motivation and Context

Plugins that use Docker would previously just hang on execution.

## How Has This Been Tested?

Tested running the Trivy plugin locally.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
