### PR TITLE
Add "authToken" auth type for .npmrc

### DIFF
--- a/backend/engine/plugins/lib/write_npmrc.py
+++ b/backend/engine/plugins/lib/write_npmrc.py
@@ -98,11 +98,10 @@ def write_npmrc(logger, npmrc, scope_list: list) -> None:
     with open(npmrc, "a") as f:
         for scope in scope_list:
             logger.info(f"Writing {scope['scope']} config to %s", npmrc)
-            
+
             if "authToken" in scope:
                 npm_config = build_npm_auth_token_config(**scope)
             else:
                 npm_config = build_npm_config(**scope)
-            
+
             f.write(npm_config)
-            

--- a/backend/engine/plugins/lib/write_npmrc.py
+++ b/backend/engine/plugins/lib/write_npmrc.py
@@ -72,8 +72,7 @@ def build_npm_config(scope, registry, token, username, email, **kwargs):
     """
     return (
         f"@{scope}:registry=https://{registry}\n"
-        f"//{registry}:_password={token}\n"
-        f"//{registry}:username={username}\n"
+        f"//{registry}:_authToken={token}\n"
         f"//{registry}:email={email}\n"
         f"//{registry}:always-auth=true\n"
     )

--- a/backend/engine/plugins/lib/write_npmrc.py
+++ b/backend/engine/plugins/lib/write_npmrc.py
@@ -98,7 +98,11 @@ def write_npmrc(logger, npmrc, scope_list: list) -> None:
     with open(npmrc, "a") as f:
         for scope in scope_list:
             logger.info(f"Writing {scope['scope']} config to %s", npmrc)
+            
             if "authToken" in scope:
-                f.write(build_npm_auth_token_config(**scope))
+                npm_config = build_npm_auth_token_config(**scope)
             else:
-                f.write(build_npm_config(**scope))
+                npm_config = build_npm_config(**scope)
+            
+            f.write(npm_config)
+            

--- a/backend/engine/plugins/lib/write_npmrc.py
+++ b/backend/engine/plugins/lib/write_npmrc.py
@@ -72,7 +72,22 @@ def build_npm_config(scope, registry, token, username, email, **kwargs):
     """
     return (
         f"@{scope}:registry=https://{registry}\n"
-        f"//{registry}:_authToken={token}\n"
+        f"//{registry}:_password={token}\n"
+        f"//{registry}:username={username}\n"
+        f"//{registry}:email={email}\n"
+        f"//{registry}:always-auth=true\n"
+    )
+
+
+def build_npm_auth_token_config(scope, registry, authToken, email, **kwargs):
+    """
+    gets the variables necessary to return the npmrc config with _authToken
+    This provides npm the necessary info to get packages from private sources.
+    **kwargs exists at the end to pick up anything extra in the config dictionary that we dont need.
+    """
+    return (
+        f"@{scope}:registry=https://{registry}\n"
+        f"//{registry}:_authToken={authToken}\n"
         f"//{registry}:email={email}\n"
         f"//{registry}:always-auth=true\n"
     )
@@ -83,4 +98,7 @@ def write_npmrc(logger, npmrc, scope_list: list) -> None:
     with open(npmrc, "a") as f:
         for scope in scope_list:
             logger.info(f"Writing {scope['scope']} config to %s", npmrc)
-            f.write(build_npm_config(**scope))
+            if "authToken" in scope:
+                f.write(build_npm_auth_token_config(**scope))
+            else:
+                f.write(build_npm_config(**scope))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Adds the option of using authToken for authenticating with .npmrc

## Description
<!--- Describe your changes in detail -->
- If an `authToken` property exists in a scope, we will use it with `_authToken` rather than the current `username` and `_password` pattern
- This is technically breaking, but it would require a scope to already include an `authToken` property despite it previously having no value.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`authToken` is preferred by some repository managers, so we should support it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Working in dev environment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
