### PR TITLE
Run Checkov via the Docker image

### DIFF
--- a/backend/Dockerfiles/Dockerfile.dind
+++ b/backend/Dockerfiles/Dockerfile.dind
@@ -22,7 +22,7 @@ RUN apk update && apk add git unzip python3 py3-pip libgcc libstdc++ && \
     apk add npm && \
     apk add go && \
     pip3 install --upgrade pip setuptools boto3 && \
-    pip3 install boto3 && \
+    pip3 install 'docker~=7.1' && \
     ln -s /usr/bin/python3 /usr/bin/python && \
     wget -O - https://raw.githubusercontent.com/aquasecurity/trivy/$TRIVY_COMMIT/contrib/install.sh | sh -s -- -b /usr/local/bin $TRIVY_VER && \
     pip3 install /src/artemislib && \

--- a/backend/Dockerfiles/Dockerfile.python3
+++ b/backend/Dockerfiles/Dockerfile.python3
@@ -1,5 +1,3 @@
-# Pinning to Python 3.11 because checkov requires aiohttp, and aiohttp is not yet functional with Python 3.12
-# This issue is tracked here: https://github.com/aio-libs/aiohttp/issues/7739
 FROM python:3.11-alpine
 
 ARG MAINTAINER
@@ -11,7 +9,6 @@ ARG TFLINT_SHA
 ARG SHELL_CHECK_VER
 ARG SHELL_CHECK_SHA
 ARG CFN_VER
-ARG CHECKOV_VER
 ARG PACKAGING_VER
 
 # Copy Artemis libraries into /src for installation
@@ -19,10 +16,9 @@ RUN mkdir -p /src
 COPY ./libs/ /src/
 
 # gitsecrets requires git
-# checkov requires awscli and libffi-dev
-RUN apk add -q --no-cache gcc musl-dev git make bash grep xz libffi-dev && \
+RUN apk add -q --no-cache gcc musl-dev git make bash grep xz && \
     pip install -q --upgrade pip && \
-    pip install -q --no-cache-dir awscli pylint packaging==$PACKAGING_VER boto3 bandit cfn-lint==$CFN_VER checkov==$CHECKOV_VER && \
+    pip install -q --no-cache-dir awscli pylint packaging==$PACKAGING_VER boto3 bandit cfn-lint==$CFN_VER && \
     pip install /src/artemislib cryptography && \
     pip install /src/artemisdb && \
     rm -r /src

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -143,8 +143,6 @@ SWIFT_PKG := ${PREFIX}/swift
 SWIFT_TAG := ${SWIFT_PKG}:latest
 SWIFTLINT_VER := 0.45.1
 
-CHECKOV_VER := 3.2.268
-
 FSB_VER := 1.9.0
 FSB_PATCH := -fix2
 OWASP_DC := 6.1.6
@@ -449,8 +447,7 @@ dist/docker/python3: Dockerfiles/Dockerfile.python3
 		--build-arg TFLINT_VER=${TFLINT_VER} \
 		--build-arg TFLINT_SHA=${TFLINT_SHA} \
 		--build-arg CFN_VER=${CFN_VER} \
-		--build-arg PACKAGING_VER=${PACKAGING_VER} \
-		--build-arg CHECKOV_VER=${CHECKOV_VER}
+		--build-arg PACKAGING_VER=${PACKAGING_VER}
 	mkdir -p ${DIST_DIR}/docker
 	${DOCKER} tag ${PYTHON_TAG} ${ECR_URL}${PYTHON_TAG}
 	${DOCKER} tag ${PYTHON_TAG} ${ECR_URL}${PYTHON_TAG}-stage-${LATEST_COMMIT}

--- a/backend/engine/plugins/checkov/main.py
+++ b/backend/engine/plugins/checkov/main.py
@@ -117,7 +117,7 @@ def run_checkov(
         shutil.copytree(path, srcdir)
         checkov_command += ["-d", "/tmp/base/work"]
 
-    LOG.info(f"Starting Checkov in container, path: {path}")
+    LOG.info(f"Starting {CHECKOV_IMG_REF} in container, path: {path}")
 
     stderr = docker_client.containers.run(
         CHECKOV_IMG_REF,

--- a/backend/engine/plugins/checkov/main.py
+++ b/backend/engine/plugins/checkov/main.py
@@ -257,8 +257,8 @@ def get_ckv_severities(config_dir: Path, config: dict) -> tuple[dict, Optional[s
             ckv_severities = json.load(f)
     except json.decoder.JSONDecodeError:
         error = "Severities file is not valid JSON. Aborting Checkov scan."
-    except BaseException as e:
-        error = "Could not read the severities file. Aborting Checkov scan."
+    except Exception as e:
+        error = f"Could not read the severities file: {e}"
 
     if error:
         LOG.error(f"error: {error}")

--- a/backend/engine/plugins/checkov/main.py
+++ b/backend/engine/plugins/checkov/main.py
@@ -7,7 +7,7 @@ import json
 import os
 import shutil
 import subprocess
-from typing import Optional, TypedDict
+from typing import Optional, TypedDict, Union
 from os.path import abspath
 from pathlib import Path
 
@@ -78,7 +78,7 @@ def run_checkov(
     # Don't return nonzero exit code if findings are detected.
     checkov_command = ["--soft-fail"]
 
-    config_dir, config_error = get_config_dir(path, config)
+    config_dir, config_error = get_config_dir(config)
 
     # Return unsuccessful if error is encountered getting config directory
     if config_error:
@@ -86,7 +86,6 @@ def run_checkov(
         output["errors"] = [config_error]
         return output
 
-    # TODO: Write to the temporary volume.
     external_checks_dir = config.get("external_checks_dir")
     if external_checks_dir:
         external_checks_dir = (Path(config_dir) / Path(external_checks_dir)).absolute()
@@ -133,6 +132,7 @@ def run_checkov(
     checkov_file = f"{temp_vol_mount}/output/results_json.json"
 
     error = ""
+    checkov_output: Union[list[dict], dict] = []
     try:
         with open(checkov_file) as f:
             checkov_output = json.load(f)
@@ -154,7 +154,7 @@ def run_checkov(
 
     # Checks were performed. Need to parse to figure out if any failed.
     LOG.info("Checks will be performed.")
-    output["details"], parse_error = parse_checkov(checkov_output, path, config_dir, config)
+    output["details"], parse_error = parse_checkov(checkov_output, config_dir, config)
 
     # If error occurred parsing Checkov output, return error
     if parse_error:
@@ -165,11 +165,11 @@ def run_checkov(
     return output
 
 
-def parse_checkov(checkov_output: list[dict], repo_path: str, config_dir: str, config: dict) -> tuple[list, str]:
+def parse_checkov(checkov_output: list[dict], config_dir: Path, config: dict) -> tuple[list[dict], Optional[str]]:
     """
     Parse the output of Checkov
     """
-    findings = []
+    findings: list[dict] = []
     error = None
 
     # Load severities map
@@ -207,10 +207,12 @@ def parse_checkov(checkov_output: list[dict], repo_path: str, config_dir: str, c
     return (findings, error)
 
 
-def get_config_dir(repo_path: str, config: dict) -> tuple[str, str]:
+def get_config_dir(config: dict) -> tuple[Path, Optional[str]]:
     """
     Determine if config directory should be from S3 or default (local)
     """
+    # TODO: Write to the temporary volume instead of the plugin source directory.
+
     # If an s3_config_path exists, download config from S3
     s3_config_path = config.get("s3_config_path")
     config_dir = PLUGIN_DIR
@@ -219,7 +221,7 @@ def get_config_dir(repo_path: str, config: dict) -> tuple[str, str]:
     if s3_config_path:
         config_dir = PLUGIN_DIR / "custom_config"
 
-        # boto3 has no recursive download option, but awscli does
+        # TODO: Reimplement in boto3 so it can be mocked in unit tests.
         output = subprocess.run(
             ["aws", "s3", "cp", f"s3://{s3_config_path}", config_dir, "--recursive"], capture_output=True
         )
@@ -237,7 +239,7 @@ def get_config_dir(repo_path: str, config: dict) -> tuple[str, str]:
     return (config_dir, error)
 
 
-def get_ckv_severities(config_dir: str, config: dict) -> tuple[dict, str]:
+def get_ckv_severities(config_dir: Path, config: dict) -> tuple[dict, Optional[str]]:
     """
     Read Checkov severities from JSON file, and return them as dict
     """
@@ -246,7 +248,7 @@ def get_ckv_severities(config_dir: str, config: dict) -> tuple[dict, str]:
     severities_file = config.get("severities_file")
 
     if severities_file:
-        severities_file_path = Path(config_dir) / Path(severities_file)
+        severities_file_path = config_dir / Path(severities_file)
     else:
         severities_file_path = PLUGIN_DIR / "ckv_severities.json"
 

--- a/backend/engine/plugins/checkov/main.py
+++ b/backend/engine/plugins/checkov/main.py
@@ -4,8 +4,10 @@ Checkov Plugin
 
 import docker
 import json
+import os
+import shutil
 import subprocess
-from typing import TypedDict
+from typing import Optional, TypedDict
 from os.path import abspath
 from pathlib import Path
 
@@ -34,23 +36,36 @@ def main():
     args = utils.parse_args()
     path = abspath(args.path)
 
+    errors: list[str] = []
+
+    engine_id: Optional[str] = args.engine_vars["engine_id"]
+
     (temp_vol_name, temp_vol_mount) = str(args.engine_vars.get("temp_vol_name", "")).split(":")
     if not temp_vol_name or not temp_vol_mount:
+        errors.append("Temporary volume not provided")
+
+    if errors:
         output: Results = {
             "success": False,
             "truncated": False,
-            "errors": ["Temporary volume not provided"],
+            "errors": errors,
             "details": [],
         }
     else:
-        output = run_checkov(path, temp_vol_name, temp_vol_mount, args.config)
+        output = run_checkov(path, temp_vol_name, temp_vol_mount, engine_id, args.config)
 
     print(json.dumps(output))
 
 
-def run_checkov(path: str, temp_vol_name: str, temp_vol_mount: str, config: dict = {}) -> Results:
+def run_checkov(
+    path: str, temp_vol_name: str, temp_vol_mount: str, engine_id: Optional[str] = None, config: dict = {}
+) -> Results:
     """
-    Run Checkov and return results
+    Run Checkov and return results.
+
+    The engine_id is optional. If provided, the source tree will be mounted
+    directly into the Checkov container, via inherited volumes. If omitted,
+    then a copy of the source tree will be made in the temporary volume.
     """
     # Output defaults
     output: Results = {
@@ -60,12 +75,8 @@ def run_checkov(path: str, temp_vol_name: str, temp_vol_mount: str, config: dict
         "errors": [],
     }
 
-    # We assume that the path is mounted with an identical path from the host
-    # so we can mount it directly instead of copying into the temp volume.
-    checkov_command = ["-d", path]
-
     # Don't return nonzero exit code if findings are detected.
-    checkov_command += ["--soft-fail"]
+    checkov_command = ["--soft-fail"]
 
     config_dir, config_error = get_config_dir(path, config)
 
@@ -75,19 +86,39 @@ def run_checkov(path: str, temp_vol_name: str, temp_vol_mount: str, config: dict
         output["errors"] = [config_error]
         return output
 
+    # TODO: Write to the temporary volume.
     external_checks_dir = config.get("external_checks_dir")
     if external_checks_dir:
         external_checks_dir = (Path(config_dir) / Path(external_checks_dir)).absolute()
         checkov_command += ["--run-all-external-checks", "--external-checks-dir", external_checks_dir]
 
-    checkov_command += [
-        "--download-external-modules",
-        "False",
-        "-o",
-        "json",
-        "--output-file-path",
-        "/tmp/output",
-    ]
+    # Do not scan third-party Terraform modules, as the findings are likely
+    # not actionable by the user.
+    checkov_command += ["--download-external-modules", "False"]
+
+    # Write the output to the temporary volume so we don't need to disambiguate
+    # it from other output, since the container will return stdout and stderr
+    # mixed together.
+    os.mkdir(f"{temp_vol_mount}/output")
+    checkov_command += ["-o", "json", "--output-file-path", "/tmp/base/output"]
+
+    volumes_from: list[str] = []
+    if engine_id:
+        # Mount the source tree directly to avoid copying.
+        # Note that this will inherit all of the mounts, including the docker.sock
+        # which in the future we want to avoid passing to third-party containers.
+        checkov_command += ["-d", path]
+        volumes_from.append(engine_id)
+    else:
+        # Fall back to copying the source tree into the named volume
+        # to provide to the container.
+        # This is mainly used by unit tests.
+        srcdir = f"{temp_vol_mount}/work"
+        LOG.info(f"Cloning working tree: {path} -> {srcdir}")
+        shutil.copytree(path, srcdir)
+        checkov_command += ["-d", "/tmp/base/work"]
+
+    LOG.info(f"Starting Checkov in container, path: {path}")
 
     stderr = docker_client.containers.run(
         CHECKOV_IMG_REF,
@@ -95,13 +126,11 @@ def run_checkov(path: str, temp_vol_name: str, temp_vol_mount: str, config: dict
         remove=True,
         stdout=True,
         stderr=True,
-        volumes={
-            path: {"bind": path, "mode": "ro"},
-            temp_vol_name: {"bind": "/tmp/output", "mode": "rw"},
-        },
+        volumes={temp_vol_name: {"bind": "/tmp/base", "mode": "rw"}},
+        volumes_from=volumes_from,
     ).decode("utf-8")
 
-    checkov_file = f"{temp_vol_mount}/results_json.json"
+    checkov_file = f"{temp_vol_mount}/output/results_json.json"
 
     error = ""
     try:

--- a/backend/engine/plugins/checkov/settings.json
+++ b/backend/engine/plugins/checkov/settings.json
@@ -1,5 +1,5 @@
 {
   "name": "Checkov",
   "type": "static_analysis",
-  "image": "$ECR/artemis/python:3-latest"
+  "image": "$ECR/artemis/dind:latest"
 }

--- a/backend/engine/tests/test_plugin_checkov.py
+++ b/backend/engine/tests/test_plugin_checkov.py
@@ -68,7 +68,7 @@ class TestCheckov(unittest.TestCase):
         # Since this directory is shared with the Checkov container, this
         # must be mounted with the same path as the host.
         with tempfile.TemporaryDirectory(prefix="artemis-checkov-test_") as tempdir:
-            return run_checkov(path, tempdir, tempdir, None)
+            return run_checkov(path, tempdir, tempdir, path, path, None)
 
     def test_with_findings(self):
         response = self._run_checkov(f"{SCRIPT_DIR}/{CHECKOV_TEST_DIR1}")

--- a/backend/engine/tests/test_plugin_checkov.py
+++ b/backend/engine/tests/test_plugin_checkov.py
@@ -67,8 +67,8 @@ class TestCheckov(unittest.TestCase):
         # A temporary directory is used in place of the named volume.
         # Since this directory is shared with the Checkov container, this
         # must be mounted with the same path as the host.
-        with tempfile.TemporaryDirectory("artemis-checkov-test") as tempdir:
-            return run_checkov(path, tempdir, tempdir)
+        with tempfile.TemporaryDirectory(prefix="artemis-checkov-test_") as tempdir:
+            return run_checkov(path, tempdir, tempdir, None)
 
     def test_with_findings(self):
         response = self._run_checkov(f"{SCRIPT_DIR}/{CHECKOV_TEST_DIR1}")

--- a/backend/engine/tests/test_plugin_checkov.py
+++ b/backend/engine/tests/test_plugin_checkov.py
@@ -1,8 +1,9 @@
 import os
+import tempfile
 import unittest
 from unittest.util import safe_repr
 
-from engine.plugins.checkov.main import run_checkov
+from engine.plugins.checkov.main import Results, run_checkov
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -58,8 +59,19 @@ class TestCheckov(unittest.TestCase):
             )
         )
 
+    def _run_checkov(self, path: str) -> Results:
+        """
+        Call run_checkov on a working path.
+        The working path must be an absolute path.
+        """
+        # A temporary directory is used in place of the named volume.
+        # Since this directory is shared with the Checkov container, this
+        # must be mounted with the same path as the host.
+        with tempfile.TemporaryDirectory("artemis-checkov-test") as tempdir:
+            return run_checkov(path, tempdir, tempdir)
+
     def test_with_findings(self):
-        response = run_checkov(f"{SCRIPT_DIR}/{CHECKOV_TEST_DIR1}")
+        response = self._run_checkov(f"{SCRIPT_DIR}/{CHECKOV_TEST_DIR1}")
         self.maxDiff = None
         self.assertTrue(response["success"])
         self.assertFalse(response["truncated"])
@@ -101,9 +113,9 @@ class TestCheckov(unittest.TestCase):
         )
 
     def test_without_findings(self):
-        response = run_checkov(f"{SCRIPT_DIR}/{CHECKOV_TEST_DIR2}")
+        response = self._run_checkov(f"{SCRIPT_DIR}/{CHECKOV_TEST_DIR2}")
         self.assertEqual(response, CHECKOV_EMPTY_RESPONSE)
 
     def test_no_checkov(self):
-        response = run_checkov(f"{SCRIPT_DIR}/{CHECKOV_TEST_DIR3}")
+        response = self._run_checkov(f"{SCRIPT_DIR}/{CHECKOV_TEST_DIR3}")
         self.assertEqual(response, CHECKOV_EMPTY_RESPONSE)

--- a/backend/engine/tests/test_plugin_checkov.py
+++ b/backend/engine/tests/test_plugin_checkov.py
@@ -68,7 +68,7 @@ class TestCheckov(unittest.TestCase):
         # Since this directory is shared with the Checkov container, this
         # must be mounted with the same path as the host.
         with tempfile.TemporaryDirectory(prefix="artemis-checkov-test_") as tempdir:
-            return run_checkov(path, tempdir, tempdir, path, path, None)
+            return run_checkov(path, tempdir, tempdir, path, path)
 
     def test_with_findings(self):
         response = self._run_checkov(f"{SCRIPT_DIR}/{CHECKOV_TEST_DIR1}")

--- a/backend/utilities/plugin_runner/plugin.sh
+++ b/backend/utilities/plugin_runner/plugin.sh
@@ -130,10 +130,11 @@ EOD
     cp -L "$BASEDIR/.env" "$TEMPDIR/.env" || return 1
   fi
   local basevars
-  basevars="$(jq -n --arg temp_vol_name "$temp_vol_name" \
+  basevars="$(jq -n --arg temp_vol_name "$temp_vol_name" --arg target "$target" \
     '{
       temp_vol_name:
         ("artemis-run-plugin_" + $temp_vol_name + ":/tmp/work"),
+      working_mount: ($target + ":/work/base"),
       engine_id: "engine"
     }')" || return 1
   install_plugin_arg_file engine-vars.json "$plugindir" "$basevars" || return 1


### PR DESCRIPTION
## Description

Runs Checkov via the [Docker image](https://hub.docker.com/r/bridgecrew/checkov) instead of installed via pip/pipenv.

Additionally, cleaned up lint and typehint warnings, as well as improved the comments.

> [!NOTE]
> Checkov will be removed from the Pipfile as part of the next dependency update run.

## Motivation and Context

Checkov has a very large and picky list of dependencies, which been a major source of dependency conflicts.  By using the Docker image instead, this allows us to keep other dependencies updated while updating Checkov regularly.

## How Has This Been Tested?

Tested in non-prod environment.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
