### PR TITLE
Add Docs URL To Configuration Plugin Results

### DIFF
--- a/backend/engine/plugins/github_repo_health/lib/README.md
+++ b/backend/engine/plugins/github_repo_health/lib/README.md
@@ -238,11 +238,16 @@ Configurations are of the following format:
 
             # You can explicitly set a severity by specifying it here. This will
             # bubble up to Artemis
-            "severity": "critical"
+            "severity": "critical",
+
+            # You can explicitly set a 'docs_url' by specifying it here. This will
+            # bubble up to Artemis and provide users with a link to help with 
+            # remediation
+            "docs_url": "https://example.com/wiki/branch_ci_required",
 
             # You can temporarily stop running a rule by setting 'enabled' to false.
             # You can also omit the rule altogether to achieve the same effect
-            "enabled": false,
+            "enabled": false
         },
         {
             "type": "branch_status_checks",
@@ -276,7 +281,7 @@ Configurations are of the following format:
             # The comments in that file will specify what Github API response it compares to
             "expect": {
                 "dismiss_stale_reviews": true,
-                "require_code_owner_reviews": true,
+                "require_code_owner_reviews": true
             }
         }
     ]

--- a/backend/engine/plugins/github_repo_health/lib/pyproject.toml
+++ b/backend/engine/plugins/github_repo_health/lib/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "GithubRepoHealth"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
     "jsonschema",
     "pygithub",

--- a/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/composite_rule.py
+++ b/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/composite_rule.py
@@ -26,6 +26,7 @@ class CompositeRule:
             "enabled": {"type": "boolean"},
             "name": {"type": "string"},
             "description": {"type": "string"},
+            "docs_url": {"type": "string"},
             "severity": severity_schema,
             "subrules": {
                 "type": "object",

--- a/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/branch_protection_commit_signing.py
+++ b/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/branch_protection_commit_signing.py
@@ -17,6 +17,7 @@ class BranchProtectionCommitSigning:
             "enabled": {"type": "boolean"},
             "name": {"type": "string"},
             "description": {"type": "string"},
+            "docs_url": {"type": "string"},
             "severity": severity_schema,
         },
     }

--- a/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/branch_protection_enforce_admins.py
+++ b/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/branch_protection_enforce_admins.py
@@ -17,6 +17,7 @@ class BranchProtectionEnforceAdmins:
             "enabled": {"type": "boolean"},
             "name": {"type": "string"},
             "description": {"type": "string"},
+            "docs_url": {"type": "string"},
             "severity": severity_schema,
         },
     }

--- a/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/branch_protection_pull_requests.py
+++ b/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/branch_protection_pull_requests.py
@@ -17,6 +17,7 @@ class BranchProtectionPullRequests:
             "enabled": {"type": "boolean"},
             "name": {"type": "string"},
             "description": {"type": "string"},
+            "docs_url": {"type": "string"},
             "severity": severity_schema,
             "expect": {"type": "object"},
             "min_approvals": {"type": "number"},

--- a/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/branch_protection_status_checks.py
+++ b/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/branch_protection_status_checks.py
@@ -17,6 +17,7 @@ class BranchProtectionStatusChecks:
             "enabled": {"type": "boolean"},
             "name": {"type": "string"},
             "description": {"type": "string"},
+            "docs_url": {"type": "string"},
             "severity": severity_schema,
             "expect": {"type": "object"},
             "checks": {

--- a/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/branch_rule_commit_signing.py
+++ b/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/branch_rule_commit_signing.py
@@ -19,6 +19,7 @@ class BranchRuleCommitSigning:
             "enabled": {"type": "boolean"},
             "name": {"type": "string"},
             "description": {"type": "string"},
+            "docs_url": {"type": "string"},
             "severity": severity_schema,
         },
     }

--- a/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/branch_rule_pull_requests.py
+++ b/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/branch_rule_pull_requests.py
@@ -19,6 +19,7 @@ class BranchRulePullRequests:
             "enabled": {"type": "boolean"},
             "name": {"type": "string"},
             "description": {"type": "string"},
+            "docs_url": {"type": "string"},
             "severity": severity_schema,
             "expect": {"type": "object"},
             "min_approvals": {"type": "number"},

--- a/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/branch_rule_status_checks.py
+++ b/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/branch_rule_status_checks.py
@@ -19,6 +19,7 @@ class BranchRuleStatusChecks:
             "enabled": {"type": "boolean"},
             "name": {"type": "string"},
             "description": {"type": "string"},
+            "docs_url": {"type": "string"},
             "severity": severity_schema,
             "expect": {"type": "object"},
             "checks": {

--- a/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/branch_ruleset_bypass_actors.py
+++ b/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/branch_ruleset_bypass_actors.py
@@ -17,6 +17,7 @@ class BranchRulesetBypassActors:
             "enabled": {"type": "boolean"},
             "name": {"type": "string"},
             "description": {"type": "string"},
+            "docs_url": {"type": "string"},
             "severity": severity_schema,
             "allowed_bypass_actor_ids": {"type": "array", "items": {"type": "number"}},
             "allowed_bypass_actor_types": {

--- a/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/repo_actions.py
+++ b/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/repo_actions.py
@@ -17,6 +17,7 @@ class RepoActions:
             "enabled": {"type": "boolean"},
             "name": {"type": "string"},
             "description": {"type": "string"},
+            "docs_url": {"type": "string"},
             "severity": severity_schema,
             "expect_any_of": {
                 "type": "array",

--- a/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/repo_code_scanning.py
+++ b/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/repo_code_scanning.py
@@ -17,6 +17,7 @@ class RepoCodeScanning:
             "enabled": {"type": "boolean"},
             "name": {"type": "string"},
             "description": {"type": "string"},
+            "docs_url": {"type": "string"},
             "severity": severity_schema,
         },
     }

--- a/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/repo_files.py
+++ b/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/repo_files.py
@@ -17,6 +17,7 @@ class RepoFiles:
             "enabled": {"type": "boolean"},
             "name": {"type": "string"},
             "description": {"type": "string"},
+            "docs_url": {"type": "string"},
             "severity": severity_schema,
             "files": {
                 "type": "object",

--- a/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/repo_secret_scanning.py
+++ b/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/repo_secret_scanning.py
@@ -17,6 +17,7 @@ class RepoSecretScanning:
             "enabled": {"type": "boolean"},
             "name": {"type": "string"},
             "description": {"type": "string"},
+            "docs_url": {"type": "string"},
             "severity": severity_schema,
             "require_push_protection": {"type": "boolean"},
         },

--- a/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/repo_security_alerts.py
+++ b/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/first_order_rules/repo_security_alerts.py
@@ -15,6 +15,7 @@ class RepoSecurityAlerts:
             "enabled": {"type": "boolean"},
             "name": {"type": "string"},
             "description": {"type": "string"},
+            "docs_url": {"type": "string"},
             "severity": severity_schema,
         },
     }

--- a/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/helpers.py
+++ b/backend/engine/plugins/github_repo_health/lib/src/github_repo_health/rules/helpers.py
@@ -40,6 +40,7 @@ def add_metadata(passing, check, config={}, error_message=None):
     id = config.get("id") or check.identifier
     name = config.get("name") or check.name
     description = config.get("description") or check.description
+    docs_url = config.get("docs_url")
     severity = config.get("severity")
 
     result = {
@@ -48,6 +49,10 @@ def add_metadata(passing, check, config={}, error_message=None):
         "description": description,
         "pass": passing,
     }
+
+    if docs_url is not None:
+        # docs_url is optional and should only show up if explicitly set
+        result["docs_url"] = docs_url
 
     if severity is not None:
         # Severity is optional and should only show up if explicitly set

--- a/backend/engine/plugins/github_repo_health/lib/tests/rules/test_helpers.py
+++ b/backend/engine/plugins/github_repo_health/lib/tests/rules/test_helpers.py
@@ -1,0 +1,36 @@
+import unittest
+
+from github_repo_health.rules import add_metadata, BranchProtectionCommitSigning
+
+OWNER = "owner"
+REPO = "repo"
+BRANCH = "branch"
+
+DOCS_URL = "http://example.com"
+
+
+class TestHelpers(unittest.TestCase):
+    def test_add_metadata_should_not_have_docs_url_if_not_provided(self):
+        config = {}
+        result = add_metadata(True, BranchProtectionCommitSigning, config)
+
+        expected = {
+            "id": BranchProtectionCommitSigning.identifier,
+            "name": BranchProtectionCommitSigning.name,
+            "description": BranchProtectionCommitSigning.description,
+        }
+
+        self.assertEqual(expected, result)
+
+    def test_add_metadata_should_have_docs_url_if_provided(self):
+        config = { "docs_url": DOCS_URL }
+        result = add_metadata(True, BranchProtectionCommitSigning, config)
+
+        expected = {
+            "id": BranchProtectionCommitSigning.identifier,
+            "name": BranchProtectionCommitSigning.name,
+            "description": BranchProtectionCommitSigning.description,
+            "docs_url": DOCS_URL,
+        }
+
+        self.assertEqual(expected, result)

--- a/backend/engine/plugins/github_repo_health/lib/tests/rules/test_helpers.py
+++ b/backend/engine/plugins/github_repo_health/lib/tests/rules/test_helpers.py
@@ -23,7 +23,7 @@ class TestHelpers(unittest.TestCase):
         self.assertEqual(expected, result)
 
     def test_add_metadata_should_have_docs_url_if_provided(self):
-        config = { "docs_url": DOCS_URL }
+        config = {"docs_url": DOCS_URL}
         result = add_metadata(True, BranchProtectionCommitSigning, config)
 
         expected = {

--- a/backend/engine/plugins/github_repo_health/lib/tests/rules/test_helpers.py
+++ b/backend/engine/plugins/github_repo_health/lib/tests/rules/test_helpers.py
@@ -1,6 +1,7 @@
 import unittest
 
-from github_repo_health.rules import add_metadata, BranchProtectionCommitSigning
+from github_repo_health.rules import BranchProtectionCommitSigning, helpers
+from github_repo_health.rules.helpers import add_metadata
 
 OWNER = "owner"
 REPO = "repo"
@@ -15,6 +16,7 @@ class TestHelpers(unittest.TestCase):
         result = add_metadata(True, BranchProtectionCommitSigning, config)
 
         expected = {
+            "pass": True,
             "id": BranchProtectionCommitSigning.identifier,
             "name": BranchProtectionCommitSigning.name,
             "description": BranchProtectionCommitSigning.description,
@@ -27,6 +29,7 @@ class TestHelpers(unittest.TestCase):
         result = add_metadata(True, BranchProtectionCommitSigning, config)
 
         expected = {
+            "pass": True,
             "id": BranchProtectionCommitSigning.identifier,
             "name": BranchProtectionCommitSigning.name,
             "description": BranchProtectionCommitSigning.description,

--- a/backend/engine/plugins/gitlab_repo_health/rules/composite_rule.py
+++ b/backend/engine/plugins/gitlab_repo_health/rules/composite_rule.py
@@ -26,6 +26,7 @@ class CompositeRule:
             "enabled": {"type": "boolean"},
             "name": {"type": "string"},
             "description": {"type": "string"},
+            "docs_url": {"type": "string"},
             "severity": severity_schema,
             "subrules": {
                 "type": "object",

--- a/backend/engine/plugins/gitlab_repo_health/rules/first_order_rules/branch_protection_codeowner_approval.py
+++ b/backend/engine/plugins/gitlab_repo_health/rules/first_order_rules/branch_protection_codeowner_approval.py
@@ -16,6 +16,7 @@ class BranchProtectionCodeOwnerApproval:
             "enabled": {"type": "boolean"},
             "name": {"type": "string"},
             "description": {"type": "string"},
+            "docs_url": {"type": "string"},
             "severity": severity_schema,
         },
     }

--- a/backend/engine/plugins/gitlab_repo_health/rules/first_order_rules/branch_protection_commit_signing.py
+++ b/backend/engine/plugins/gitlab_repo_health/rules/first_order_rules/branch_protection_commit_signing.py
@@ -17,6 +17,7 @@ class BranchProtectionCommitSigning:
             "enabled": {"type": "boolean"},
             "name": {"type": "string"},
             "description": {"type": "string"},
+            "docs_url": {"type": "string"},
             "severity": severity_schema,
         },
     }

--- a/backend/engine/plugins/gitlab_repo_health/rules/first_order_rules/branch_protection_enforce_admins.py
+++ b/backend/engine/plugins/gitlab_repo_health/rules/first_order_rules/branch_protection_enforce_admins.py
@@ -16,6 +16,7 @@ class BranchProtectionEnforceAdmins:
             "enabled": {"type": "boolean"},
             "name": {"type": "string"},
             "description": {"type": "string"},
+            "docs_url": {"type": "string"},
             "severity": severity_schema,
         },
     }

--- a/backend/engine/plugins/gitlab_repo_health/rules/first_order_rules/branch_protection_prevent_secret_files.py
+++ b/backend/engine/plugins/gitlab_repo_health/rules/first_order_rules/branch_protection_prevent_secret_files.py
@@ -17,6 +17,7 @@ class BranchProtectionPreventSecretFiles:
             "enabled": {"type": "boolean"},
             "name": {"type": "string"},
             "description": {"type": "string"},
+            "docs_url": {"type": "string"},
             "severity": severity_schema,
         },
     }

--- a/backend/engine/plugins/gitlab_repo_health/rules/first_order_rules/branch_protection_pull_requests.py
+++ b/backend/engine/plugins/gitlab_repo_health/rules/first_order_rules/branch_protection_pull_requests.py
@@ -18,6 +18,7 @@ class BranchProtectionPullRequests:
             "enabled": {"type": "boolean"},
             "name": {"type": "string"},
             "description": {"type": "string"},
+            "docs_url": {"type": "string"},
             "severity": severity_schema,
             "expect": {"type": "object"},
             "min_approvals": {"type": "number"},

--- a/backend/engine/plugins/gitlab_repo_health/rules/first_order_rules/repo_files.py
+++ b/backend/engine/plugins/gitlab_repo_health/rules/first_order_rules/repo_files.py
@@ -18,6 +18,7 @@ class RepoFiles:
             "enabled": {"type": "boolean"},
             "name": {"type": "string"},
             "description": {"type": "string"},
+            "docs_url": {"type": "string"},
             "severity": severity_schema,
             "files": {
                 "type": "object",

--- a/backend/engine/plugins/gitlab_repo_health/rules/helpers.py
+++ b/backend/engine/plugins/gitlab_repo_health/rules/helpers.py
@@ -40,6 +40,7 @@ def add_metadata(passing, check, config={}, error_message=None):
     id = config.get("id") or check.identifier
     name = config.get("name") or check.name
     description = config.get("description") or check.description
+    docs_url = config.get("docs_url")
     severity = config.get("severity")
 
     result = {
@@ -48,6 +49,10 @@ def add_metadata(passing, check, config={}, error_message=None):
         "description": description,
         "pass": passing,
     }
+
+    if docs_url is not None:
+        # docs_url is optional and should only show up if explicitly set
+        result["docs_url"] = docs_url
 
     if severity is not None:
         # Severity is optional and should only show up if explicitly set

--- a/backend/lambdas/generators/json_report/json_report/results/configuration.py
+++ b/backend/lambdas/generators/json_report/json_report/results/configuration.py
@@ -45,6 +45,7 @@ def get_configuration(scan: Scan, params: dict) -> PLUGIN_RESULTS:
                 name = finding.get("name", "")
                 description = finding.get("description", "")
                 severity = finding.get("severity", "")
+                docs_url = finding.get("docs_url")
 
                 passing = finding.get("pass", False)
 
@@ -54,6 +55,9 @@ def get_configuration(scan: Scan, params: dict) -> PLUGIN_RESULTS:
                     "description": description,
                     "severity": severity,
                 }
+
+                if docs_url:
+                    item["docs_url"] = docs_url
 
                 if (
                     (not passing)

--- a/ui/src/api/server.ts
+++ b/ui/src/api/server.ts
@@ -538,6 +538,7 @@ export function makeServer() {
 					description:
 						"Lorem ipsum sit amet justo donec enim diam vulputate ut pharetra sit",
 					severity: "medium",
+					docs_url: "http://example.com",
 				},
 				github_branch_check2: {
 					name: "Branch - Check 2",

--- a/ui/src/features/scans/scansSchemas.ts
+++ b/ui/src/features/scans/scansSchemas.ts
@@ -169,6 +169,7 @@ export interface ConfigurationDetails {
 	name: string;
 	description: string;
 	severity: Severities;
+	docs_url?: string;
 }
 
 export interface ResultsConfiguration {

--- a/ui/src/locale/en/messages.po
+++ b/ui/src/locale/en/messages.po
@@ -1516,8 +1516,8 @@ msgid "Low: {count}"
 msgstr "Low: {count}"
 
 #: src/pages/ResultsPage.tsx:4548
-msgid "Documentation"
-msgstr "Documentation"
+#~ msgid "Documentation"
+#~ msgstr "Documentation"
 
 #: src/pages/UsersPage.tsx:563
 msgid "Admin"
@@ -1676,6 +1676,7 @@ msgid "Scan time can not be in the future"
 msgstr "Scan time can not be in the future"
 
 #: src/pages/ResultsPage.tsx:3185
+#: src/pages/ResultsPage.tsx:4548
 #: src/pages/SearchPage.tsx:2265
 #: src/pages/SearchPage.tsx:2774
 msgid "Remediation"

--- a/ui/src/locale/en/messages.po
+++ b/ui/src/locale/en/messages.po
@@ -13,10 +13,10 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/pages/ResultsPage.tsx:3579
-#: src/pages/ResultsPage.tsx:3580
-#: src/pages/ResultsPage.tsx:3936
-#: src/pages/ResultsPage.tsx:3937
+#: src/pages/ResultsPage.tsx:3627
+#: src/pages/ResultsPage.tsx:3628
+#: src/pages/ResultsPage.tsx:3984
+#: src/pages/ResultsPage.tsx:3985
 msgid "Line must be a positive integer"
 msgstr "Line must be a positive integer"
 
@@ -24,7 +24,7 @@ msgstr "Line must be a positive integer"
 msgid "Key removed"
 msgstr "Key removed"
 
-#: src/pages/ResultsPage.tsx:5957
+#: src/pages/ResultsPage.tsx:6022
 msgid "Scan ID"
 msgstr "Scan ID"
 
@@ -45,7 +45,7 @@ msgstr "Mixed"
 msgid "{0, plural, one {# Medium static analysis result} other {# Medium static analysis results}}"
 msgstr "{0, plural, one {# Medium static analysis result} other {# Medium static analysis results}}"
 
-#: src/pages/ResultsPage.tsx:5055
+#: src/pages/ResultsPage.tsx:5120
 msgid "Wrap long lines"
 msgstr "Wrap long lines"
 
@@ -54,11 +54,11 @@ msgid "Scans"
 msgstr "Scans"
 
 #: src/components/ActivityTable.tsx:790
-#: src/pages/ResultsPage.tsx:3611
-#: src/pages/ResultsPage.tsx:3844
-#: src/pages/ResultsPage.tsx:3979
-#: src/pages/ResultsPage.tsx:4145
-#: src/pages/ResultsPage.tsx:4295
+#: src/pages/ResultsPage.tsx:3659
+#: src/pages/ResultsPage.tsx:3892
+#: src/pages/ResultsPage.tsx:4027
+#: src/pages/ResultsPage.tsx:4193
+#: src/pages/ResultsPage.tsx:4343
 #: src/pages/UserSettings.tsx:2055
 msgid "Type"
 msgstr "Type"
@@ -70,16 +70,16 @@ msgstr "Copy to clipboard"
 #: src/custom/SearchMetaField.tsx:53
 #: src/pages/ResultsPage.tsx:3426
 #: src/pages/ResultsPage.tsx:3435
-#: src/pages/ResultsPage.tsx:3827
-#: src/pages/ResultsPage.tsx:3845
-#: src/pages/ResultsPage.tsx:4278
-#: src/pages/ResultsPage.tsx:4296
-#: src/pages/ResultsPage.tsx:4309
-#: src/pages/ResultsPage.tsx:4585
-#: src/pages/ResultsPage.tsx:4594
-#: src/pages/ResultsPage.tsx:5413
-#: src/pages/ResultsPage.tsx:5422
-#: src/pages/ResultsPage.tsx:5431
+#: src/pages/ResultsPage.tsx:3875
+#: src/pages/ResultsPage.tsx:3893
+#: src/pages/ResultsPage.tsx:4326
+#: src/pages/ResultsPage.tsx:4344
+#: src/pages/ResultsPage.tsx:4357
+#: src/pages/ResultsPage.tsx:4650
+#: src/pages/ResultsPage.tsx:4659
+#: src/pages/ResultsPage.tsx:5478
+#: src/pages/ResultsPage.tsx:5487
+#: src/pages/ResultsPage.tsx:5496
 #: src/pages/SearchPage.tsx:2483
 msgid "Contains"
 msgstr "Contains"
@@ -157,13 +157,13 @@ msgstr "User updated"
 msgid "(disabled)"
 msgstr "(disabled)"
 
-#: src/pages/ResultsPage.tsx:5060
-#: src/pages/ResultsPage.tsx:5063
+#: src/pages/ResultsPage.tsx:5125
+#: src/pages/ResultsPage.tsx:5128
 msgid "Download scan results"
 msgstr "Download scan results"
 
-#: src/pages/ResultsPage.tsx:3581
-#: src/pages/ResultsPage.tsx:3938
+#: src/pages/ResultsPage.tsx:3629
+#: src/pages/ResultsPage.tsx:3986
 msgid "Line must be less than {LINE_MAX}"
 msgstr "Line must be less than {LINE_MAX}"
 
@@ -180,14 +180,14 @@ msgstr "Hidden finding created by:"
 msgid "v{0} ({1}), REPLACE ME: ADD A PAGE FOOTER HERE"
 msgstr "v{0} ({1}), REPLACE ME: ADD A PAGE FOOTER HERE"
 
-#: src/pages/ResultsPage.tsx:5629
-#: src/pages/ResultsPage.tsx:5638
-#: src/pages/ResultsPage.tsx:5655
-#: src/pages/ResultsPage.tsx:5664
+#: src/pages/ResultsPage.tsx:5694
+#: src/pages/ResultsPage.tsx:5703
+#: src/pages/ResultsPage.tsx:5720
+#: src/pages/ResultsPage.tsx:5729
 msgid "No"
 msgstr "No"
 
-#: src/pages/ResultsPage.tsx:6018
+#: src/pages/ResultsPage.tsx:6083
 msgid "End Date / Scan Time Elapsed"
 msgstr "End Date / Scan Time Elapsed"
 
@@ -197,7 +197,7 @@ msgid "Priority"
 msgstr "Priority"
 
 #: src/components/ActivityTable.tsx:743
-#: src/pages/ResultsPage.tsx:6982
+#: src/pages/ResultsPage.tsx:7047
 msgid "New Scan"
 msgstr "New Scan"
 
@@ -216,7 +216,7 @@ msgstr "Meta Data Sample1 / Sample2"
 msgid "No results match current filters"
 msgstr "No results match current filters"
 
-#: src/pages/ResultsPage.tsx:5162
+#: src/pages/ResultsPage.tsx:5227
 msgid "Id/Line location must be less than {VULN_ID_LENGTH} characters"
 msgstr "Id/Line location must be less than {VULN_ID_LENGTH} characters"
 
@@ -250,8 +250,8 @@ msgstr "More Actions..."
 msgid "Unable to link service account: {0}"
 msgstr "Unable to link service account: {0}"
 
-#: src/pages/ResultsPage.tsx:3691
-#: src/pages/ResultsPage.tsx:4053
+#: src/pages/ResultsPage.tsx:3739
+#: src/pages/ResultsPage.tsx:4101
 msgid "Found in Source File"
 msgstr "Found in Source File"
 
@@ -284,7 +284,7 @@ msgstr "Open Settings Menu"
 msgid "Remove User"
 msgstr "Remove User"
 
-#: src/pages/ResultsPage.tsx:4392
+#: src/pages/ResultsPage.tsx:4440
 msgid "Name must be less than {NAME_LENGTH} characters"
 msgstr "Name must be less than {NAME_LENGTH} characters"
 
@@ -329,12 +329,12 @@ msgstr "Prism"
 msgid "Vulnerability:"
 msgstr "Vulnerability:"
 
-#: src/pages/ResultsPage.tsx:5220
-#: src/pages/ResultsPage.tsx:5421
+#: src/pages/ResultsPage.tsx:5285
+#: src/pages/ResultsPage.tsx:5486
 msgid "Id/Line"
 msgstr "Id/Line"
 
-#: src/pages/ResultsPage.tsx:6370
+#: src/pages/ResultsPage.tsx:6435
 msgid "Overview"
 msgstr "Overview"
 
@@ -354,6 +354,11 @@ msgstr "No technology inventory detected"
 #: src/pages/SearchPage.tsx:3352
 msgid "Component name must be less than {COMPONENT_NAME_LENGTH} characters"
 msgstr "Component name must be less than {COMPONENT_NAME_LENGTH} characters"
+
+#: src/pages/ResultsPage.tsx:3509
+#: src/pages/ResultsPage.tsx:3511
+msgid "View Documentation"
+msgstr "View Documentation"
 
 #: src/app/scanPlugins.ts:182
 #~ msgid "Trivy Container Images"
@@ -377,8 +382,8 @@ msgstr "Copied"
 msgid "Scope value not within user's scan organizations or does not end with /repo or /path_name_pattern"
 msgstr "Scope value not within user's scan organizations or does not end with /repo or /path_name_pattern"
 
-#: src/pages/ResultsPage.tsx:4419
-#: src/pages/ResultsPage.tsx:4584
+#: src/pages/ResultsPage.tsx:4467
+#: src/pages/ResultsPage.tsx:4649
 #: src/pages/SearchPage.tsx:3896
 #: src/pages/UserSettings.tsx:1082
 #: src/pages/UserSettings.tsx:1434
@@ -420,9 +425,9 @@ msgstr "{0, plural, one {# Secret detected} other {# Secrets detected}}"
 
 #: src/components/ActivityTable.tsx:808
 #: src/pages/ResultsPage.tsx:3271
-#: src/pages/ResultsPage.tsx:3620
-#: src/pages/ResultsPage.tsx:3990
-#: src/pages/ResultsPage.tsx:4428
+#: src/pages/ResultsPage.tsx:3668
+#: src/pages/ResultsPage.tsx:4038
+#: src/pages/ResultsPage.tsx:4476
 #: src/pages/UserSettings.tsx:1117
 #: src/pages/UsersPage.tsx:575
 msgid "Actions"
@@ -451,12 +456,12 @@ msgstr "Component license must be less than {COMPONENT_LICENSE_LENGTH} character
 #: src/pages/ResultsPage.tsx:786
 #: src/pages/ResultsPage.tsx:2517
 #: src/pages/ResultsPage.tsx:2615
-#: src/pages/ResultsPage.tsx:6393
+#: src/pages/ResultsPage.tsx:6458
 msgid "Static Analysis"
 msgstr "Static Analysis"
 
 #: src/pages/ResultsPage.tsx:2653
-#: src/pages/ResultsPage.tsx:6464
+#: src/pages/ResultsPage.tsx:6529
 msgid "Hidden Findings"
 msgstr "Hidden Findings"
 
@@ -480,7 +485,7 @@ msgstr "Last Login: {0}"
 msgid "Queued"
 msgstr "Queued"
 
-#: src/pages/ResultsPage.tsx:6364
+#: src/pages/ResultsPage.tsx:6429
 msgid "Report Sections Tabs"
 msgstr "Report Sections Tabs"
 
@@ -506,7 +511,7 @@ msgstr "Batched Scan"
 msgid "Fetching static analysis results..."
 msgstr "Fetching static analysis results..."
 
-#: src/pages/ResultsPage.tsx:6977
+#: src/pages/ResultsPage.tsx:7042
 msgid "Refresh Scan Results"
 msgstr "Refresh Scan Results"
 
@@ -516,9 +521,9 @@ msgstr "{0, plural, one {# Critical configuration result} other {# Critical conf
 
 #: src/pages/ResultsPage.tsx:2864
 #: src/pages/ResultsPage.tsx:3265
-#: src/pages/ResultsPage.tsx:3614
-#: src/pages/ResultsPage.tsx:4422
-#: src/pages/ResultsPage.tsx:5239
+#: src/pages/ResultsPage.tsx:3662
+#: src/pages/ResultsPage.tsx:4470
+#: src/pages/ResultsPage.tsx:5304
 #: src/pages/SearchPage.tsx:2787
 #: src/pages/SearchPage.tsx:4053
 msgid "Severity"
@@ -530,12 +535,12 @@ msgstr "Severity"
 msgid "Not Specified"
 msgstr "Not Specified"
 
-#: src/pages/ResultsPage.tsx:6597
-#: src/pages/ResultsPage.tsx:6606
+#: src/pages/ResultsPage.tsx:6662
+#: src/pages/ResultsPage.tsx:6671
 msgid "Service or org required"
 msgstr "Service or org required"
 
-#: src/pages/ResultsPage.tsx:5170
+#: src/pages/ResultsPage.tsx:5235
 msgid "Component/commit must be less than {COMPONENT_LENGTH} characters"
 msgstr "Component/commit must be less than {COMPONENT_LENGTH} characters"
 
@@ -575,7 +580,7 @@ msgstr "GitHub Advanced Security Secrets"
 msgid "Shell Check (Shell)"
 msgstr "Shell Check (Shell)"
 
-#: src/pages/ResultsPage.tsx:5999
+#: src/pages/ResultsPage.tsx:6064
 msgid "Start Date"
 msgstr "Start Date"
 
@@ -623,13 +628,13 @@ msgstr "Meta Data Field1"
 msgid "Unable to remove user"
 msgstr "Unable to remove user"
 
-#: src/pages/ResultsPage.tsx:4987
-#: src/pages/ResultsPage.tsx:4990
-#: src/pages/ResultsPage.tsx:4996
-#: src/pages/ResultsPage.tsx:4999
-#: src/pages/ResultsPage.tsx:5005
-#: src/pages/ResultsPage.tsx:5008
-#: src/pages/ResultsPage.tsx:5011
+#: src/pages/ResultsPage.tsx:5052
+#: src/pages/ResultsPage.tsx:5055
+#: src/pages/ResultsPage.tsx:5061
+#: src/pages/ResultsPage.tsx:5064
+#: src/pages/ResultsPage.tsx:5070
+#: src/pages/ResultsPage.tsx:5073
+#: src/pages/ResultsPage.tsx:5076
 msgid "(dark)"
 msgstr "(dark)"
 
@@ -664,12 +669,12 @@ msgstr "Trivy SBOM"
 
 #: src/pages/ResultsPage.tsx:2884
 #: src/pages/ResultsPage.tsx:2975
-#: src/pages/ResultsPage.tsx:5370
-#: src/pages/ResultsPage.tsx:5600
-#: src/pages/ResultsPage.tsx:5695
-#: src/pages/ResultsPage.tsx:5718
-#: src/pages/ResultsPage.tsx:5737
+#: src/pages/ResultsPage.tsx:5435
+#: src/pages/ResultsPage.tsx:5665
 #: src/pages/ResultsPage.tsx:5760
+#: src/pages/ResultsPage.tsx:5783
+#: src/pages/ResultsPage.tsx:5802
+#: src/pages/ResultsPage.tsx:5825
 #: src/pages/SearchPage.tsx:2445
 #: src/pages/UserSettings.tsx:770
 #: src/pages/UserSettings.tsx:792
@@ -710,7 +715,7 @@ msgstr "Update"
 msgid "Before"
 msgstr "Before"
 
-#: src/features/scans/scansSchemas.ts:473
+#: src/features/scans/scansSchemas.ts:474
 msgid "May only contain the characters: A-Z, a-z, 0-9, ., -, _, /"
 msgstr "May only contain the characters: A-Z, a-z, 0-9, ., -, _, /"
 
@@ -727,7 +732,7 @@ msgstr "Active"
 msgid "Pylint (Python)"
 msgstr "Pylint (Python)"
 
-#: src/pages/ResultsPage.tsx:4979
+#: src/pages/ResultsPage.tsx:5044
 #: src/pages/UserSettings.tsx:832
 msgid "Theme"
 msgstr "Theme"
@@ -736,7 +741,7 @@ msgstr "Theme"
 msgid "Veracode SBOM"
 msgstr "Veracode SBOM"
 
-#: src/pages/ResultsPage.tsx:5479
+#: src/pages/ResultsPage.tsx:5544
 msgid "No hidden findings"
 msgstr "No hidden findings"
 
@@ -844,7 +849,7 @@ msgstr "View successful results"
 msgid "Secret: {count}"
 msgstr "Secret: {count}"
 
-#: src/pages/ResultsPage.tsx:5148
+#: src/pages/ResultsPage.tsx:5213
 #: src/pages/SearchPage.tsx:3442
 msgid "Invalid category"
 msgstr "Invalid category"
@@ -869,7 +874,7 @@ msgstr "Remove this hidden finding? This finding will again appear in scan resul
 msgid "Trivy Container Image"
 msgstr "Trivy Container Image"
 
-#: src/pages/ResultsPage.tsx:5039
+#: src/pages/ResultsPage.tsx:5104
 msgid "Show line numbers"
 msgstr "Show line numbers"
 
@@ -877,7 +882,7 @@ msgstr "Show line numbers"
 msgid "{0, plural, one {# High vulnerability} other {# High vulnerabilities}}"
 msgstr "{0, plural, one {# High vulnerability} other {# High vulnerabilities}}"
 
-#: src/pages/ResultsPage.tsx:5809
+#: src/pages/ResultsPage.tsx:5874
 msgid "Issues Found"
 msgstr "Issues Found"
 
@@ -913,7 +918,7 @@ msgstr "Severity:"
 msgid "Issue Title"
 msgstr "Issue Title"
 
-#: src/pages/ResultsPage.tsx:5571
+#: src/pages/ResultsPage.tsx:5636
 msgid "Scan Options"
 msgstr "Scan Options"
 
@@ -954,8 +959,8 @@ msgstr "Repository"
 msgid "Git Secrets"
 msgstr "Git Secrets"
 
-#: src/pages/ResultsPage.tsx:5544
-#: src/pages/ResultsPage.tsx:5550
+#: src/pages/ResultsPage.tsx:5609
+#: src/pages/ResultsPage.tsx:5615
 #: src/pages/SearchPage.tsx:692
 #: src/pages/SearchPage.tsx:706
 #: src/pages/SearchPage.tsx:749
@@ -965,8 +970,8 @@ msgstr "Git Secrets"
 msgid "{0}"
 msgstr "{0}"
 
-#: src/pages/ResultsPage.tsx:3609
-#: src/pages/ResultsPage.tsx:3826
+#: src/pages/ResultsPage.tsx:3657
+#: src/pages/ResultsPage.tsx:3874
 msgid "File"
 msgstr "File"
 
@@ -986,8 +991,8 @@ msgstr "Critical"
 msgid "Welcome to Artemis"
 msgstr "Welcome to Artemis"
 
-#: src/pages/ResultsPage.tsx:3514
-#: src/pages/ResultsPage.tsx:3516
+#: src/pages/ResultsPage.tsx:3562
+#: src/pages/ResultsPage.tsx:3564
 msgid "View in Version Control"
 msgstr "View in Version Control"
 
@@ -1013,7 +1018,7 @@ msgstr "Click for more information"
 msgid "Generating JSON File..."
 msgstr "Generating JSON File..."
 
-#: src/pages/ResultsPage.tsx:4367
+#: src/pages/ResultsPage.tsx:4415
 msgid "No secrets found"
 msgstr "No secrets found"
 
@@ -1029,8 +1034,8 @@ msgstr "Linked Accounts"
 msgid "Aqua CLI Scanner (Docker)"
 msgstr "Aqua CLI Scanner (Docker)"
 
-#: src/pages/ResultsPage.tsx:5205
-#: src/pages/ResultsPage.tsx:5348
+#: src/pages/ResultsPage.tsx:5270
+#: src/pages/ResultsPage.tsx:5413
 msgid "Category"
 msgstr "Category"
 
@@ -1051,11 +1056,11 @@ msgstr "Must be a valid service name [azure|bitbucket|github] or hostname"
 msgid "Not found"
 msgstr "Not found"
 
-#: src/pages/ResultsPage.tsx:5743
+#: src/pages/ResultsPage.tsx:5808
 msgid "Exclude Paths ({0})"
 msgstr "Exclude Paths ({0})"
 
-#: src/pages/ResultsPage.tsx:5245
+#: src/pages/ResultsPage.tsx:5310
 #: src/pages/UserSettings.tsx:1107
 msgid "Expires"
 msgstr "Expires"
@@ -1126,14 +1131,14 @@ msgstr "Name:"
 msgid "Fetching API keys..."
 msgstr "Fetching API keys..."
 
-#: src/pages/ResultsPage.tsx:3576
-#: src/pages/ResultsPage.tsx:3933
+#: src/pages/ResultsPage.tsx:3624
+#: src/pages/ResultsPage.tsx:3981
 msgid "File path must be less than {FILEPATH_LENGTH} characters"
 msgstr "File path must be less than {FILEPATH_LENGTH} characters"
 
 #: src/pages/ResultsPage.tsx:2515
 #: src/pages/ResultsPage.tsx:2624
-#: src/pages/ResultsPage.tsx:6409
+#: src/pages/ResultsPage.tsx:6474
 msgid "Secrets"
 msgstr "Secrets"
 
@@ -1145,7 +1150,7 @@ msgstr "Batched Scan: {0}"
 msgid "Invalid vulnerability id matcher"
 msgstr "Invalid vulnerability id matcher"
 
-#: src/pages/ResultsPage.tsx:6836
+#: src/pages/ResultsPage.tsx:6901
 msgid "Results for the specified scan can not be found."
 msgstr "Results for the specified scan can not be found."
 
@@ -1179,7 +1184,7 @@ msgstr "Close repository details"
 msgid "No static analysis findings detected"
 msgstr "No static analysis findings detected"
 
-#: src/pages/ResultsPage.tsx:5587
+#: src/pages/ResultsPage.tsx:5652
 msgid "Categories"
 msgstr "Categories"
 
@@ -1206,8 +1211,8 @@ msgid "Hidden finding removed"
 msgstr "Hidden finding removed"
 
 #: src/pages/ResultsPage.tsx:3170
-#: src/pages/ResultsPage.tsx:4483
-#: src/pages/ResultsPage.tsx:4593
+#: src/pages/ResultsPage.tsx:4532
+#: src/pages/ResultsPage.tsx:4658
 #: src/pages/SearchPage.tsx:2250
 #: src/pages/SearchPage.tsx:2761
 msgid "Description"
@@ -1240,8 +1245,8 @@ msgstr "API Key:"
 msgid "Software Bill of Materials"
 msgstr "Software Bill of Materials"
 
-#: src/features/scans/scansSchemas.ts:522
-#: src/features/scans/scansSchemas.ts:540
+#: src/features/scans/scansSchemas.ts:523
+#: src/features/scans/scansSchemas.ts:541
 msgid "Invalid path, longer than {MAX_PATH_LENGTH} characters"
 msgstr "Invalid path, longer than {MAX_PATH_LENGTH} characters"
 
@@ -1258,7 +1263,7 @@ msgstr "Date can not be after {format}"
 msgid "Reset"
 msgstr "Reset"
 
-#: src/pages/ResultsPage.tsx:4823
+#: src/pages/ResultsPage.tsx:4888
 msgid "No technologies found"
 msgstr "No technologies found"
 
@@ -1275,7 +1280,7 @@ msgstr "No repository or path name pattern supplied after scan organization pref
 msgid "View in the National Vulnerability Database"
 msgstr "View in the National Vulnerability Database"
 
-#: src/pages/ResultsPage.tsx:6610
+#: src/pages/ResultsPage.tsx:6675
 msgid "User does not have access to this service"
 msgstr "User does not have access to this service"
 
@@ -1299,7 +1304,7 @@ msgstr "Modify Hidden Finding"
 msgid "Features"
 msgstr "Features"
 
-#: src/features/scans/scansSchemas.ts:489
+#: src/features/scans/scansSchemas.ts:490
 msgid "Contains one of more of the following invalid characters: space, \\, ~, ^, :, ?, *, ["
 msgstr "Contains one of more of the following invalid characters: space, \\, ~, ^, :, ?, *, ["
 
@@ -1307,8 +1312,8 @@ msgstr "Contains one of more of the following invalid characters: space, \\, ~, 
 msgid "Username:"
 msgstr "Username:"
 
-#: src/pages/ResultsPage.tsx:3586
-#: src/pages/ResultsPage.tsx:3943
+#: src/pages/ResultsPage.tsx:3634
+#: src/pages/ResultsPage.tsx:3991
 msgid "Resource must be less than {RESOURCE_LENGTH} characters"
 msgstr "Resource must be less than {RESOURCE_LENGTH} characters"
 
@@ -1316,7 +1321,7 @@ msgstr "Resource must be less than {RESOURCE_LENGTH} characters"
 msgid "Enry Technology Discovery"
 msgstr "Enry Technology Discovery"
 
-#: src/pages/ResultsPage.tsx:4640
+#: src/pages/ResultsPage.tsx:4705
 msgid "No Name"
 msgstr "No Name"
 
@@ -1397,7 +1402,7 @@ msgstr "Hide This Finding"
 msgid "Component must be less than {COMPONENT_LENGTH} characters"
 msgstr "Component must be less than {COMPONENT_LENGTH} characters"
 
-#: src/pages/ResultsPage.tsx:4657
+#: src/pages/ResultsPage.tsx:4722
 msgid "No configuration findings"
 msgstr "No configuration findings"
 
@@ -1419,7 +1424,7 @@ msgid "Expiration Date"
 msgstr "Expiration Date"
 
 #: src/components/StatusCell.tsx:734
-#: src/pages/ResultsPage.tsx:6834
+#: src/pages/ResultsPage.tsx:6899
 msgid "Error"
 msgstr "Error"
 
@@ -1436,11 +1441,11 @@ msgstr "Users"
 msgid "Open this scan in a new tab"
 msgstr "Open this scan in a new tab"
 
-#: src/pages/ResultsPage.tsx:5939
+#: src/pages/ResultsPage.tsx:6004
 msgid "Potential Security Issues Found"
 msgstr "Potential Security Issues Found"
 
-#: src/pages/ResultsPage.tsx:5866
+#: src/pages/ResultsPage.tsx:5931
 #: src/pages/SearchPage.tsx:1560
 #: src/pages/SearchPage.tsx:1778
 #: src/pages/SearchPage.tsx:2106
@@ -1450,8 +1455,8 @@ msgstr "Potential Security Issues Found"
 msgid "Service"
 msgstr "Service"
 
-#: src/pages/ResultsPage.tsx:5085
-#: src/pages/ResultsPage.tsx:5088
+#: src/pages/ResultsPage.tsx:5150
+#: src/pages/ResultsPage.tsx:5153
 msgid "Download SBOM results"
 msgstr "Download SBOM results"
 
@@ -1466,8 +1471,8 @@ msgstr "Include paths: {0} ; Exclude paths: {1}"
 msgid "Standard"
 msgstr "Standard"
 
-#: src/features/scans/scansSchemas.ts:466
-#: src/features/scans/scansSchemas.ts:470
+#: src/features/scans/scansSchemas.ts:467
+#: src/features/scans/scansSchemas.ts:471
 #: src/pages/ResultsPage.tsx:971
 #: src/pages/ResultsPage.tsx:984
 #: src/pages/SearchPage.tsx:3441
@@ -1510,11 +1515,15 @@ msgstr "Vulnerability Raw"
 msgid "Low: {count}"
 msgstr "Low: {count}"
 
+#: src/pages/ResultsPage.tsx:4548
+msgid "Documentation"
+msgstr "Documentation"
+
 #: src/pages/UsersPage.tsx:563
 msgid "Admin"
 msgstr "Admin"
 
-#: src/pages/ResultsPage.tsx:4673
+#: src/pages/ResultsPage.tsx:4738
 msgid "Tag"
 msgstr "Tag"
 
@@ -1522,7 +1531,7 @@ msgstr "Tag"
 msgid "Organization/Repository Path"
 msgstr "Organization/Repository Path"
 
-#: src/pages/ResultsPage.tsx:3722
+#: src/pages/ResultsPage.tsx:3770
 #: src/pages/SearchPage.tsx:1640
 #: src/pages/SearchPage.tsx:1962
 msgid "Details"
@@ -1552,7 +1561,7 @@ msgstr "Create a user administrator API key"
 msgid "{0, plural, one {# Medium configuration result} other {# Medium configuration results}}"
 msgstr "{0, plural, one {# Medium configuration result} other {# Medium configuration results}}"
 
-#: src/pages/ResultsPage.tsx:4399
+#: src/pages/ResultsPage.tsx:4447
 #: src/pages/SearchPage.tsx:1458
 #: src/pages/SearchPage.tsx:3311
 #: src/pages/SearchPage.tsx:3319
@@ -1581,7 +1590,7 @@ msgstr "Reason"
 msgid "License Match"
 msgstr "License Match"
 
-#: src/pages/ResultsPage.tsx:5329
+#: src/pages/ResultsPage.tsx:5394
 msgid "These findings will be excluded from all results for this repository, including all branches"
 msgstr "These findings will be excluded from all results for this repository, including all branches"
 
@@ -1721,14 +1730,14 @@ msgid "Invalid remediation matcher"
 msgstr "Invalid remediation matcher"
 
 #: src/components/TableMenu.tsx:94
-#: src/pages/ResultsPage.tsx:4917
+#: src/pages/ResultsPage.tsx:4982
 msgid "Generating JSON File"
 msgstr "Generating JSON File"
 
 #: src/pages/ResultsPage.tsx:1423
 #: src/pages/ResultsPage.tsx:1542
-#: src/pages/ResultsPage.tsx:3702
-#: src/pages/ResultsPage.tsx:4064
+#: src/pages/ResultsPage.tsx:3750
+#: src/pages/ResultsPage.tsx:4112
 msgid "{0} (Line {1})"
 msgstr "{0} (Line {1})"
 
@@ -1741,7 +1750,7 @@ msgid "Unable to get current user details"
 msgstr "Unable to get current user details"
 
 #: src/pages/ResultsPage.tsx:2642
-#: src/pages/ResultsPage.tsx:6441
+#: src/pages/ResultsPage.tsx:6506
 msgid "Inventory"
 msgstr "Inventory"
 
@@ -1750,7 +1759,7 @@ msgstr "Inventory"
 msgid "One or more file or directory paths separated by a comma or newline. Supports glob patterns (*, **, etc.)"
 msgstr "One or more file or directory paths separated by a comma or newline. Supports glob patterns (*, **, etc.)"
 
-#: src/pages/ResultsPage.tsx:5701
+#: src/pages/ResultsPage.tsx:5766
 msgid "Include Paths ({0})"
 msgstr "Include Paths ({0})"
 
@@ -1758,7 +1767,7 @@ msgstr "Include Paths ({0})"
 msgid "GoSec (Golang)"
 msgstr "GoSec (Golang)"
 
-#: src/pages/ResultsPage.tsx:5154
+#: src/pages/ResultsPage.tsx:5219
 msgid "Location/File path must be less than {FILEPATH_LENGTH} characters"
 msgstr "Location/File path must be less than {FILEPATH_LENGTH} characters"
 
@@ -1831,8 +1840,8 @@ msgid "What are hidden findings?"
 msgstr "What are hidden findings?"
 
 #: src/custom/SearchMetaField.tsx:56
-#: src/pages/ResultsPage.tsx:3836
-#: src/pages/ResultsPage.tsx:4287
+#: src/pages/ResultsPage.tsx:3884
+#: src/pages/ResultsPage.tsx:4335
 #: src/pages/SearchPage.tsx:2486
 msgid "Exact"
 msgstr "Exact"
@@ -1854,7 +1863,7 @@ msgstr "Hidden finding last updated:"
 msgid "What are my scan organizations?"
 msgstr "What are my scan organizations?"
 
-#: src/pages/ResultsPage.tsx:5837
+#: src/pages/ResultsPage.tsx:5902
 msgid "Copy link to these scan results"
 msgstr "Copy link to these scan results"
 
@@ -1863,7 +1872,7 @@ msgid "Time can not be after {format}"
 msgstr "Time can not be after {format}"
 
 #: src/pages/MainPage.tsx:1070
-#: src/pages/ResultsPage.tsx:5634
+#: src/pages/ResultsPage.tsx:5699
 msgid "Scan Developer Dependencies"
 msgstr "Scan Developer Dependencies"
 
@@ -1871,7 +1880,7 @@ msgstr "Scan Developer Dependencies"
 msgid "Include a clear and meaningful reason for why this finding is being hidden"
 msgstr "Include a clear and meaningful reason for why this finding is being hidden"
 
-#: src/pages/ResultsPage.tsx:5792
+#: src/pages/ResultsPage.tsx:5857
 msgid "{dt} / {elapsed} Elapsed"
 msgstr "{dt} / {elapsed} Elapsed"
 
@@ -1886,7 +1895,7 @@ msgstr "error"
 msgid "Created"
 msgstr "Created"
 
-#: src/pages/ResultsPage.tsx:5660
+#: src/pages/ResultsPage.tsx:5725
 msgid "Batch Priority"
 msgstr "Batch Priority"
 
@@ -1895,8 +1904,8 @@ msgstr "Batch Priority"
 #: src/components/WelcomeDialog.tsx:95
 #: src/pages/ResultsPage.tsx:1806
 #: src/pages/ResultsPage.tsx:2080
-#: src/pages/ResultsPage.tsx:7013
-#: src/pages/ResultsPage.tsx:7019
+#: src/pages/ResultsPage.tsx:7078
+#: src/pages/ResultsPage.tsx:7084
 #: src/pages/UserSettings.tsx:1065
 #: src/pages/UserSettings.tsx:1072
 #: src/pages/UserSettings.tsx:1852
@@ -1928,7 +1937,7 @@ msgstr "Moderate: {count}"
 msgid "FindSecBugs (Java 7)"
 msgstr "FindSecBugs (Java 7)"
 
-#: src/pages/ResultsPage.tsx:5912
+#: src/pages/ResultsPage.tsx:5977
 msgid "Not specified"
 msgstr "Not specified"
 
@@ -1966,7 +1975,7 @@ msgstr "Branch Name (optional)"
 msgid "Artemis - Search"
 msgstr "Artemis - Search"
 
-#: src/pages/ResultsPage.tsx:4180
+#: src/pages/ResultsPage.tsx:4228
 msgid "No details"
 msgstr "No details"
 
@@ -1980,7 +1989,7 @@ msgid "Repository Match"
 msgstr "Repository Match"
 
 #: src/components/ActivityTable.tsx:307
-#: src/pages/ResultsPage.tsx:7029
+#: src/pages/ResultsPage.tsx:7094
 msgid "New scan with these options"
 msgstr "New scan with these options"
 
@@ -2009,8 +2018,8 @@ msgstr "OWASP Check (Java)"
 msgid "Meta Data Field1 Missing"
 msgstr "Meta Data Field1 Missing"
 
-#: src/features/scans/scansSchemas.ts:521
-#: src/features/scans/scansSchemas.ts:539
+#: src/features/scans/scansSchemas.ts:522
+#: src/features/scans/scansSchemas.ts:540
 msgid "Invalid path, must be relative to repository base directory and contain valid characters"
 msgstr "Invalid path, must be relative to repository base directory and contain valid characters"
 
@@ -2024,7 +2033,7 @@ msgid "Component:"
 msgstr "Component:"
 
 #: src/components/TableMenu.tsx:117
-#: src/pages/ResultsPage.tsx:4968
+#: src/pages/ResultsPage.tsx:5033
 msgid "I Acknowledge"
 msgstr "I Acknowledge"
 
@@ -2042,11 +2051,11 @@ msgstr "Duplicate scope"
 msgid "Last Qualified Scan Time"
 msgstr "Last Qualified Scan Time"
 
-#: src/pages/ResultsPage.tsx:4672
+#: src/pages/ResultsPage.tsx:4737
 msgid "Image"
 msgstr "Image"
 
-#: src/pages/ResultsPage.tsx:6877
+#: src/pages/ResultsPage.tsx:6942
 msgid "Back to Scans"
 msgstr "Back to Scans"
 
@@ -2066,8 +2075,8 @@ msgstr "<0><1>Hidden findings are global to this repository. They will be applie
 msgid "Email Address"
 msgstr "Email Address"
 
-#: src/pages/ResultsPage.tsx:5819
-#: src/pages/ResultsPage.tsx:5938
+#: src/pages/ResultsPage.tsx:5884
+#: src/pages/ResultsPage.tsx:6003
 msgid "No Issues Found"
 msgstr "No Issues Found"
 
@@ -2085,7 +2094,7 @@ msgstr "Component license null must be either \"true\" or \"false\""
 msgid "Back"
 msgstr "Back"
 
-#: src/pages/ResultsPage.tsx:6761
+#: src/pages/ResultsPage.tsx:6826
 msgid "Artemis - Scan Results: {0} (default)"
 msgstr "Artemis - Scan Results: {0} (default)"
 
@@ -2129,7 +2138,7 @@ msgstr "Invalid license matcher"
 msgid "Linking GitHub User..."
 msgstr "Linking GitHub User..."
 
-#: src/pages/ResultsPage.tsx:6695
+#: src/pages/ResultsPage.tsx:6760
 msgid "Artemis - Scan Results"
 msgstr "Artemis - Scan Results"
 
@@ -2146,8 +2155,8 @@ msgstr "At least 1 scope is required"
 msgid "Unable to get user details"
 msgstr "Unable to get user details"
 
-#: src/pages/ResultsPage.tsx:5543
-#: src/pages/ResultsPage.tsx:5549
+#: src/pages/ResultsPage.tsx:5608
+#: src/pages/ResultsPage.tsx:5614
 msgid "{0} (not run)"
 msgstr "{0} (not run)"
 
@@ -2163,7 +2172,7 @@ msgstr "Description Match"
 msgid "ARTEMIS"
 msgstr "ARTEMIS"
 
-#: src/pages/ResultsPage.tsx:4737
+#: src/pages/ResultsPage.tsx:4802
 msgid "Technology"
 msgstr "Technology"
 
@@ -2176,18 +2185,18 @@ msgid "Don't show this dialog again on this browser"
 msgstr "Don't show this dialog again on this browser"
 
 #: src/pages/ResultsPage.tsx:3418
-#: src/pages/ResultsPage.tsx:3819
-#: src/pages/ResultsPage.tsx:4270
-#: src/pages/ResultsPage.tsx:4577
-#: src/pages/ResultsPage.tsx:5340
+#: src/pages/ResultsPage.tsx:3867
+#: src/pages/ResultsPage.tsx:4318
+#: src/pages/ResultsPage.tsx:4642
+#: src/pages/ResultsPage.tsx:5405
 msgid "Filter Results"
 msgstr "Filter Results"
 
-#: src/pages/ResultsPage.tsx:4829
+#: src/pages/ResultsPage.tsx:4894
 msgid "Base Images"
 msgstr "Base Images"
 
-#: src/pages/ResultsPage.tsx:6457
+#: src/pages/ResultsPage.tsx:6522
 msgid "Raw"
 msgstr "Raw"
 
@@ -2199,7 +2208,7 @@ msgstr "Meta Data Field2"
 msgid "No findings are hidden"
 msgstr "No findings are hidden"
 
-#: src/pages/ResultsPage.tsx:5832
+#: src/pages/ResultsPage.tsx:5897
 msgid "Scan Results"
 msgstr "Scan Results"
 
@@ -2211,11 +2220,11 @@ msgstr "Found in source files:"
 msgid "View successful results in new tab"
 msgstr "View successful results in new tab"
 
-#: src/pages/ResultsPage.tsx:4993
-#: src/pages/ResultsPage.tsx:5002
-#: src/pages/ResultsPage.tsx:5014
-#: src/pages/ResultsPage.tsx:5017
-#: src/pages/ResultsPage.tsx:5020
+#: src/pages/ResultsPage.tsx:5058
+#: src/pages/ResultsPage.tsx:5067
+#: src/pages/ResultsPage.tsx:5079
+#: src/pages/ResultsPage.tsx:5082
+#: src/pages/ResultsPage.tsx:5085
 msgid "(light)"
 msgstr "(light)"
 
@@ -2224,9 +2233,9 @@ msgid "Click the \"Update\" button to add these source files to this hidden find
 msgstr "Click the \"Update\" button to add these source files to this hidden finding"
 
 #: src/pages/ResultsPage.tsx:3109
-#: src/pages/ResultsPage.tsx:3588
-#: src/pages/ResultsPage.tsx:4402
-#: src/pages/ResultsPage.tsx:5173
+#: src/pages/ResultsPage.tsx:3636
+#: src/pages/ResultsPage.tsx:4450
+#: src/pages/ResultsPage.tsx:5238
 #: src/pages/SearchPage.tsx:1436
 #: src/pages/SearchPage.tsx:3282
 msgid "Invalid severity"
@@ -2244,7 +2253,7 @@ msgstr "Email required"
 msgid "How do I provide this data?"
 msgstr "How do I provide this data?"
 
-#: src/pages/ResultsPage.tsx:5902
+#: src/pages/ResultsPage.tsx:5967
 msgid "Initiated By"
 msgstr "Initiated By"
 
@@ -2252,7 +2261,7 @@ msgstr "Initiated By"
 msgid "Table Options"
 msgstr "Table Options"
 
-#: src/pages/ResultsPage.tsx:3949
+#: src/pages/ResultsPage.tsx:3997
 msgid "Commit must be less than {COMMIT_LENGTH} characters"
 msgstr "Commit must be less than {COMMIT_LENGTH} characters"
 
@@ -2266,7 +2275,7 @@ msgstr "Components or Licenses"
 msgid "This column is filtered"
 msgstr "This column is filtered"
 
-#: src/features/scans/scansSchemas.ts:479
+#: src/features/scans/scansSchemas.ts:480
 msgid "Missing \"Organization/\" Prefix"
 msgstr "Missing \"Organization/\" Prefix"
 
@@ -2278,7 +2287,7 @@ msgstr "API Key Added"
 msgid "Fetching vulnerability results..."
 msgstr "Fetching vulnerability results..."
 
-#: src/pages/ResultsPage.tsx:5943
+#: src/pages/ResultsPage.tsx:6008
 #: src/pages/SearchPage.tsx:4257
 msgid "Results"
 msgstr "Results"
@@ -2296,10 +2305,10 @@ msgstr "Add Scope"
 msgid "Unable to get system status"
 msgstr "Unable to get system status"
 
-#: src/pages/ResultsPage.tsx:5628
-#: src/pages/ResultsPage.tsx:5637
-#: src/pages/ResultsPage.tsx:5654
-#: src/pages/ResultsPage.tsx:5663
+#: src/pages/ResultsPage.tsx:5693
+#: src/pages/ResultsPage.tsx:5702
+#: src/pages/ResultsPage.tsx:5719
+#: src/pages/ResultsPage.tsx:5728
 msgid "Yes"
 msgstr "Yes"
 
@@ -2353,10 +2362,10 @@ msgstr "Meta data field2 null must be either \"true\" or \"false\""
 #: src/pages/ResultsPage.tsx:1694
 #: src/pages/ResultsPage.tsx:1708
 #: src/pages/ResultsPage.tsx:1722
-#: src/pages/ResultsPage.tsx:6247
-#: src/pages/ResultsPage.tsx:6249
-#: src/pages/ResultsPage.tsx:6315
-#: src/pages/ResultsPage.tsx:6317
+#: src/pages/ResultsPage.tsx:6312
+#: src/pages/ResultsPage.tsx:6314
+#: src/pages/ResultsPage.tsx:6380
+#: src/pages/ResultsPage.tsx:6382
 msgid "Any"
 msgstr "Any"
 
@@ -2370,7 +2379,7 @@ msgstr "Add"
 msgid "Purple"
 msgstr "Purple"
 
-#: src/pages/ResultsPage.tsx:5677
+#: src/pages/ResultsPage.tsx:5742
 msgid "Batch Description"
 msgstr "Batch Description"
 
@@ -2414,13 +2423,13 @@ msgid "Low"
 msgstr "Low"
 
 #: src/pages/ResultsPage.tsx:1872
-#: src/pages/ResultsPage.tsx:4131
+#: src/pages/ResultsPage.tsx:4179
 msgid "Finding Details"
 msgstr "Finding Details"
 
 #: src/pages/ResultsPage.tsx:2513
 #: src/pages/ResultsPage.tsx:2606
-#: src/pages/ResultsPage.tsx:6377
+#: src/pages/ResultsPage.tsx:6442
 #: src/pages/SearchPage.tsx:3425
 #: src/pages/SearchPage.tsx:3429
 #: src/pages/SearchPage.tsx:4047
@@ -2431,7 +2440,7 @@ msgstr "Vulnerabilities"
 msgid "View failed results"
 msgstr "View failed results"
 
-#: src/pages/ResultsPage.tsx:5852
+#: src/pages/ResultsPage.tsx:5917
 msgid "Organization / Repository"
 msgstr "Organization / Repository"
 
@@ -2443,7 +2452,7 @@ msgstr "To proceed, click “I Acknowledge\" below."
 msgid "Where is the source code you want to scan?"
 msgstr "Where is the source code you want to scan?"
 
-#: src/pages/ResultsPage.tsx:5598
+#: src/pages/ResultsPage.tsx:5663
 msgid "Plugins"
 msgstr "Plugins"
 
@@ -2463,18 +2472,18 @@ msgid "This form contains unresolved errors. Please resolve these errors"
 msgstr "This form contains unresolved errors. Please resolve these errors"
 
 #: src/pages/ResultsPage.tsx:3451
-#: src/pages/ResultsPage.tsx:3861
-#: src/pages/ResultsPage.tsx:4320
-#: src/pages/ResultsPage.tsx:4610
-#: src/pages/ResultsPage.tsx:5447
+#: src/pages/ResultsPage.tsx:3909
+#: src/pages/ResultsPage.tsx:4368
+#: src/pages/ResultsPage.tsx:4675
+#: src/pages/ResultsPage.tsx:5512
 #: src/pages/UsersPage.tsx:1275
 msgid "Clear all filters"
 msgstr "Clear all filters"
 
 #: src/components/ActivityTable.tsx:886
 #: src/components/ActivityTable.tsx:896
-#: src/pages/ResultsPage.tsx:5875
-#: src/pages/ResultsPage.tsx:5882
+#: src/pages/ResultsPage.tsx:5940
+#: src/pages/ResultsPage.tsx:5947
 msgid "Default"
 msgstr "Default"
 
@@ -2503,11 +2512,11 @@ msgstr "Default Branch"
 msgid "Component Name Match"
 msgstr "Component Name Match"
 
-#: src/pages/ResultsPage.tsx:5981
+#: src/pages/ResultsPage.tsx:6046
 msgid "Queued Date / Queued Time Elapsed"
 msgstr "Queued Date / Queued Time Elapsed"
 
-#: src/pages/ResultsPage.tsx:5611
+#: src/pages/ResultsPage.tsx:5676
 msgid "Commit History"
 msgstr "Commit History"
 
@@ -2515,8 +2524,8 @@ msgstr "Commit History"
 msgid "Any Qualified Scan"
 msgstr "Any Qualified Scan"
 
-#: src/pages/ResultsPage.tsx:5210
-#: src/pages/ResultsPage.tsx:5412
+#: src/pages/ResultsPage.tsx:5275
+#: src/pages/ResultsPage.tsx:5477
 msgid "Location/File"
 msgstr "Location/File"
 
@@ -2532,8 +2541,8 @@ msgstr "Show {label} plugins"
 msgid "Generating CSV File"
 msgstr "Generating CSV File"
 
-#: src/pages/ResultsPage.tsx:5234
-#: src/pages/ResultsPage.tsx:5430
+#: src/pages/ResultsPage.tsx:5299
+#: src/pages/ResultsPage.tsx:5495
 msgid "Component/Commit"
 msgstr "Component/Commit"
 
@@ -2551,7 +2560,7 @@ msgstr "Multiple different validities reported"
 msgid "Any License"
 msgstr "Any License"
 
-#: src/pages/ResultsPage.tsx:6181
+#: src/pages/ResultsPage.tsx:6246
 msgid "Never"
 msgstr "Never"
 
@@ -2565,8 +2574,8 @@ msgstr "Scan started"
 msgid "Meta data field2 must be less than {META_FIELD2_LENGTH} characters"
 msgstr "Meta data field2 must be less than {META_FIELD2_LENGTH} characters"
 
-#: src/features/scans/scansSchemas.ts:499
 #: src/features/scans/scansSchemas.ts:500
+#: src/features/scans/scansSchemas.ts:501
 msgid "Positive integer"
 msgstr "Positive integer"
 
@@ -2574,7 +2583,7 @@ msgstr "Positive integer"
 msgid "Linked:"
 msgstr "Linked:"
 
-#: src/pages/ResultsPage.tsx:6789
+#: src/pages/ResultsPage.tsx:6854
 msgid "Scan in progress, results subject to change"
 msgstr "Scan in progress, results subject to change"
 
@@ -2608,24 +2617,24 @@ msgstr "Component version required"
 msgid "Search For"
 msgstr "Search For"
 
-#: src/pages/ResultsPage.tsx:3610
-#: src/pages/ResultsPage.tsx:3835
-#: src/pages/ResultsPage.tsx:3978
-#: src/pages/ResultsPage.tsx:4286
+#: src/pages/ResultsPage.tsx:3658
+#: src/pages/ResultsPage.tsx:3883
+#: src/pages/ResultsPage.tsx:4026
+#: src/pages/ResultsPage.tsx:4334
 msgid "Line"
 msgstr "Line"
 
-#: src/pages/ResultsPage.tsx:3987
-#: src/pages/ResultsPage.tsx:4114
-#: src/pages/ResultsPage.tsx:4308
+#: src/pages/ResultsPage.tsx:4035
+#: src/pages/ResultsPage.tsx:4162
+#: src/pages/ResultsPage.tsx:4356
 msgid "Commit"
 msgstr "Commit"
 
 #: src/components/ActivityTable.tsx:757
 #: src/components/ActivityTable.tsx:770
 #: src/pages/MainPage.tsx:1156
-#: src/pages/ResultsPage.tsx:6996
-#: src/pages/ResultsPage.tsx:7009
+#: src/pages/ResultsPage.tsx:7061
+#: src/pages/ResultsPage.tsx:7074
 msgid "Start Scan"
 msgstr "Start Scan"
 
@@ -2658,11 +2667,11 @@ msgstr "Fetching repositories..."
 msgid "Category:"
 msgstr "Category:"
 
-#: src/pages/ResultsPage.tsx:3908
+#: src/pages/ResultsPage.tsx:3956
 msgid "No static analysis findings"
 msgstr "No static analysis findings"
 
-#: src/pages/ResultsPage.tsx:3891
+#: src/pages/ResultsPage.tsx:3939
 msgid "No Type"
 msgstr "No Type"
 
@@ -2691,7 +2700,7 @@ msgid "{0, plural, one {# Source file not covered by this hidden finding} other 
 msgstr "{0, plural, one {# Source file not covered by this hidden finding} other {# Source files not covered by this hidden finding}}"
 
 #: src/components/ActivityTable.tsx:793
-#: src/pages/ResultsPage.tsx:5878
+#: src/pages/ResultsPage.tsx:5943
 msgid "Branch"
 msgstr "Branch"
 
@@ -2762,7 +2771,7 @@ msgstr "Must be between 1-256 characters"
 msgid "Return to login"
 msgstr "Return to login"
 
-#: src/pages/ResultsPage.tsx:6845
+#: src/pages/ResultsPage.tsx:6910
 msgid "Please wait"
 msgstr "Please wait"
 
@@ -2784,7 +2793,7 @@ msgid "Invalid component version matcher"
 msgstr "Invalid component version matcher"
 
 #: src/components/ActivityTable.tsx:805
-#: src/pages/ResultsPage.tsx:5926
+#: src/pages/ResultsPage.tsx:5991
 msgid "Status"
 msgstr "Status"
 
@@ -2844,7 +2853,7 @@ msgstr "Modify User"
 msgid "An unknown error occurred"
 msgstr "An unknown error occurred"
 
-#: src/pages/ResultsPage.tsx:4854
+#: src/pages/ResultsPage.tsx:4919
 msgid "No base images found"
 msgstr "No base images found"
 
@@ -2852,7 +2861,7 @@ msgstr "No base images found"
 msgid "Download as CSV"
 msgstr "Download as CSV"
 
-#: src/pages/ResultsPage.tsx:4076
+#: src/pages/ResultsPage.tsx:4124
 msgid "Found in {0}"
 msgstr "Found in {0}"
 
@@ -2864,7 +2873,7 @@ msgstr "Pull Request Title"
 msgid "Remove API key named \"{0}\"?"
 msgstr "Remove API key named \"{0}\"?"
 
-#: src/pages/ResultsPage.tsx:6986
+#: src/pages/ResultsPage.tsx:7051
 msgid "Start a new scan using the same options used in this scan?<0/>Initiating a new scan will navigate to the main scan page to display scan progress."
 msgstr "Start a new scan using the same options used in this scan?<0/>Initiating a new scan will navigate to the main scan page to display scan progress."
 
@@ -2876,17 +2885,17 @@ msgstr "Veracode SCA"
 msgid "Pull Request Review"
 msgstr "Pull Request Review"
 
-#: src/features/scans/scansSchemas.ts:467
-#: src/pages/ResultsPage.tsx:6599
+#: src/features/scans/scansSchemas.ts:468
+#: src/pages/ResultsPage.tsx:6664
 msgid "Invalid value"
 msgstr "Invalid value"
 
-#: src/pages/ResultsPage.tsx:5526
+#: src/pages/ResultsPage.tsx:5591
 msgid "{label}"
 msgstr "{label}"
 
-#: src/pages/ResultsPage.tsx:3977
-#: src/pages/ResultsPage.tsx:4277
+#: src/pages/ResultsPage.tsx:4025
+#: src/pages/ResultsPage.tsx:4325
 msgid "Location"
 msgstr "Location"
 
@@ -2911,7 +2920,7 @@ msgstr "Red"
 msgid "Hidden finding updated"
 msgstr "Hidden finding updated"
 
-#: src/pages/ResultsPage.tsx:6760
+#: src/pages/ResultsPage.tsx:6825
 msgid "Artemis - Scan Results: {0} ({1})"
 msgstr "Artemis - Scan Results: {0} ({1})"
 
@@ -2923,7 +2932,7 @@ msgstr "Secret Raw: {count}"
 msgid "User API key count exceeds {maxCount}. Currently users can only manage {maxCount} keys at a time. Please remove some expired or unused keys"
 msgstr "User API key count exceeds {maxCount}. Currently users can only manage {maxCount} keys at a time. Please remove some expired or unused keys"
 
-#: src/pages/ResultsPage.tsx:4151
+#: src/pages/ResultsPage.tsx:4199
 msgid "Found By"
 msgstr "Found By"
 
@@ -2960,8 +2969,8 @@ msgstr "End"
 msgid "Bundler Audit (Ruby)"
 msgstr "Bundler Audit (Ruby)"
 
-#: src/features/scans/scansSchemas.ts:550
-#: src/features/scans/scansSchemas.ts:588
+#: src/features/scans/scansSchemas.ts:551
+#: src/features/scans/scansSchemas.ts:589
 msgid "At least one scan feature or plugin must be enabled"
 msgstr "At least one scan feature or plugin must be enabled"
 
@@ -2969,7 +2978,7 @@ msgstr "At least one scan feature or plugin must be enabled"
 msgid "Medium: {count}"
 msgstr "Medium: {count}"
 
-#: src/pages/ResultsPage.tsx:6847
+#: src/pages/ResultsPage.tsx:6912
 msgid "Fetching scan results..."
 msgstr "Fetching scan results..."
 
@@ -3002,7 +3011,7 @@ msgid "Invalid repository name"
 msgstr "Invalid repository name"
 
 #: src/components/TableMenu.tsx:116
-#: src/pages/ResultsPage.tsx:4967
+#: src/pages/ResultsPage.tsx:5032
 msgid "Confirm Download"
 msgstr "Confirm Download"
 
@@ -3020,7 +3029,7 @@ msgstr "Invalid plugin"
 #: src/pages/ResultsPage.tsx:741
 #: src/pages/ResultsPage.tsx:2512
 #: src/pages/ResultsPage.tsx:2633
-#: src/pages/ResultsPage.tsx:6425
+#: src/pages/ResultsPage.tsx:6490
 msgid "Configuration"
 msgstr "Configuration"
 
@@ -3073,7 +3082,7 @@ msgid "Pull Request Body"
 msgstr "Pull Request Body"
 
 #: src/pages/ResultsPage.tsx:2955
-#: src/pages/ResultsPage.tsx:3982
-#: src/pages/ResultsPage.tsx:4148
+#: src/pages/ResultsPage.tsx:4030
+#: src/pages/ResultsPage.tsx:4196
 msgid "Validity"
 msgstr "Validity"

--- a/ui/src/pages/ResultsPage.tsx
+++ b/ui/src/pages/ResultsPage.tsx
@@ -3496,6 +3496,54 @@ export const VulnTabContent = (props: {
 	);
 };
 
+export const DocumentationHotLink = (props: {
+	url: string;
+	addTitle?: boolean;
+}) => {
+	const { i18n } = useLingui();
+	const { url, addTitle } = props;
+
+	// note: use i18n instead of <Trans> element for tooltip title
+	// otherwise, a11y can't determine the title properly
+	const text = addTitle ? (
+		<Trans>View Documentation</Trans>
+	) : (
+		i18n._(t`View Documentation`)
+	);
+
+	if (addTitle) {
+		return (
+			<Box>
+				<Button
+					startIcon={<OpenInNewIcon />}
+					href={url}
+					target="_blank"
+					rel="noopener noreferrer nofollow"
+					size="small"
+				>
+					{text}
+				</Button>
+			</Box>
+		);
+	} else {
+		return (
+			<Box>
+				<Tooltip title={text}>
+					<span>
+						<Button
+							endIcon={<OpenInNewIcon />}
+							href={url}
+							target="_blank"
+							rel="noopener noreferrer nofollow"
+							size="small"
+						></Button>
+					</span>
+				</Tooltip>
+			</Box>
+		);
+	}
+};
+
 export const SourceCodeHotLink = (props: {
 	row: RowDef | null;
 	addTitle?: boolean;
@@ -4458,6 +4506,7 @@ export const ConfigTabContent = (props: {
 			rule,
 			name: info.name,
 			description: info.description,
+			docs_url: info.docs_url,
 			severity: info.severity,
 			repo: scan.repo,
 			service: scan.service,
@@ -4491,6 +4540,21 @@ export const ConfigTabContent = (props: {
 										secondary={selectedRow?.description ?? ""}
 									/>
 								</ListItem>
+								{ selectedRow?.docs_url && 
+									<ListItem key="config-documentation-link">
+										<ListItemText
+											primary = {
+												<>
+													{i18n._(t`Remediation`)}
+													<CustomCopyToClipboard
+														copyTarget={selectedRow?.docs_url}
+													/>
+												</>
+											}
+											secondary={<DocumentationHotLink url={selectedRow.docs_url} addTitle />}
+										/>
+									</ListItem>
+								}
 							</List>
 						</Grid>
 					</Grid>
@@ -4515,6 +4579,7 @@ export const ConfigTabContent = (props: {
 				id: rule,
 				name: info.name,
 				description: info.description,
+				docs_url: info.docs_url,
 				severity: info.severity,
 			});
 		}

--- a/ui/src/pages/ResultsPage.tsx
+++ b/ui/src/pages/ResultsPage.tsx
@@ -4540,10 +4540,10 @@ export const ConfigTabContent = (props: {
 										secondary={selectedRow?.description ?? ""}
 									/>
 								</ListItem>
-								{ selectedRow?.docs_url && 
+								{selectedRow?.docs_url && (
 									<ListItem key="config-documentation-link">
 										<ListItemText
-											primary = {
+											primary={
 												<>
 													{i18n._(t`Remediation`)}
 													<CustomCopyToClipboard
@@ -4551,10 +4551,15 @@ export const ConfigTabContent = (props: {
 													/>
 												</>
 											}
-											secondary={<DocumentationHotLink url={selectedRow.docs_url} addTitle />}
+											secondary={
+												<DocumentationHotLink
+													url={selectedRow.docs_url}
+													addTitle
+												/>
+											}
 										/>
 									</ListItem>
-								}
+								)}
 							</List>
 						</Grid>
 					</Grid>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds an optional "docs_url" field to configuration plugin results

## Description
<!--- Describe your changes in detail -->
- Adds a "docs_url" field to `github_repo_health` and `gitlab_repo_health`
- On the UI side, if `docs_url` is present, the link will be clickable on the "Details" pop-up for a configuration finding, like below:
<img width="916" alt="Screenshot 2024-11-19 at 3 27 10 PM" src="https://github.com/user-attachments/assets/88c20dde-dfdb-4814-8136-0aea65d3def3">

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
The `description` field is limited for explaining how to remediate an issue. This allows a link to be used instead so that administrators can configure a Wiki or PDF to explain remediation steps for each finding.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Working in dev environment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.