### PR TITLE
Gracefully handle Checkov plugin shutdown

### DIFF
--- a/backend/engine/tests/test_plugin_checkov.py
+++ b/backend/engine/tests/test_plugin_checkov.py
@@ -4,6 +4,7 @@ import os
 import tempfile
 import unittest
 from unittest.util import safe_repr
+import uuid
 
 from engine.plugins.checkov.main import Results, run_checkov
 
@@ -67,11 +68,12 @@ class TestCheckov(unittest.TestCase):
         Call run_checkov on a working path.
         The working path must be an absolute path.
         """
+        container_name = f"plugin-checkov-{uuid.uuid4()}"
         # A temporary directory is used in place of the named volume.
         # Since this directory is shared with the Checkov container, this
         # must be mounted with the same path as the host.
         with tempfile.TemporaryDirectory(prefix="artemis-checkov-test_") as tempdir:
-            return run_checkov(path, tempdir, tempdir, path, path, config)
+            return run_checkov(path, container_name, tempdir, tempdir, path, path, config)
 
     def test_with_findings(self):
         response = self._run_checkov(f"{SCRIPT_DIR}/{CHECKOV_TEST_DIR1}")


### PR DESCRIPTION
## Description

Installs a signal handler to gracefully terminate the Checkov container.

Without this, when the plugin is terminated the Checkov container would continue running and then wouldn't be removed afterwards.

> [!NOTE]
> This currently only has an effect when running the Checkov plugin via the Plugin Runner utility.
> The engine currently sends a SIGKILL to the plugin when the timeout expires, which we can't trap.

## Motivation and Context

Properly clean up the container when running via the Plugin Runner utility, and also prepare the plugin for when we add graceful shutdown to the engine.

## How Has This Been Tested?

Tested in non-prod environment as well as the Plugin Runner.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
