### PR TITLE
Remove lint_api_spec target

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -321,12 +321,6 @@ style-test:
 	@echo "${OK}"
 .PHONY: style-test
 
-lint_api_spec:
-	@echo "${INFO}Linting API spec"
-	docker run --rm -v $(CURDIR)/lambdas/api/spec.yaml:/project/spec.yaml wework/speccy lint spec.yaml
-	@echo "${OK}"
-.PHONY: lint_api_spec
-
 artemis_scan:
 	@echo "${INFO}Running Artemis scan"
 	$(CURDIR)/ci-tools/shell/artemis-scan.sh ${ARTEMIS_SCAN_ARGS} github ${REPO_NAME} ${BRANCH_NAME} ${SEVERITY_LEVELS}


### PR DESCRIPTION
## Description

Removes the `lint_api_spec` target in backend/Makefile.

This was replaced by the `redocly-lint` target in ui/Makefile in https://github.com/WarnerMedia/artemis/pull/357.

## Motivation and Context

Remove outdated target.

## How Has This Been Tested?

N/A -- no references to this target anywhere else in the code or docs.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
