### PR TITLE
Plugin Runner Toolbox: Handle large output lines from the plugin

### DIFF
--- a/backend/utilities/plugin_runner/toolbox/main.go
+++ b/backend/utilities/plugin_runner/toolbox/main.go
@@ -30,11 +30,17 @@ type PluginOutput struct {
 }
 
 func NewPluginOutput(output []byte, exitCode int) *PluginOutput {
+	// Skip lint checks if the plugin process failed.
+	var lintErrors []error
+	if exitCode == 0 {
+		lintErrors = lint(output)
+	}
+
 	return &PluginOutput{
 		Output:   output,
 		ExitCode: exitCode,
 
-		LintErrors: lint(output),
+		LintErrors: lintErrors,
 	}
 }
 

--- a/backend/utilities/plugin_runner/toolbox/main.go
+++ b/backend/utilities/plugin_runner/toolbox/main.go
@@ -157,14 +157,16 @@ func installTerminateHandler(ctx context.Context) context.Context {
 	return retv
 }
 
-func reportStatus(exitCode int) {
+func reportStatus(exitCode int, outputLen int) {
 	fmt.Print(color.HiCyanString(
 		fmt.Sprintf("==> Plugin exited with status: %d ", exitCode)))
 	if exitCode == 0 {
-		color.HiGreen("(success)")
+		fmt.Print(color.HiGreenString("(success)"))
 	} else {
-		color.HiRed("(failed)")
+		fmt.Print(color.HiRedString("(failed)"))
 	}
+
+	fmt.Printf(" (%d output bytes)\n", outputLen)
 }
 
 func reportLintErrors(errs []error) {
@@ -189,6 +191,6 @@ func main() {
 		log.Fatalf("Error running plugin: %v", err)
 	}
 
-	reportStatus(output.ExitCode)
+	reportStatus(output.ExitCode, len(output.Output))
 	reportLintErrors(output.LintErrors)
 }

--- a/backend/utilities/plugin_runner/toolbox/scan_pipe.go
+++ b/backend/utilities/plugin_runner/toolbox/scan_pipe.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"bufio"
+	"io"
+)
+
+// Initial size of the line buffer, in bytes.
+const initLineBufSize = 64 * 1024
+
+// Maximum size of the line buffer, in bytes.
+const maxLineBufSize = 128 * 1024 * 1024
+
+// scanPipe reads lines from a pipe and passes it to the callback.
+//
+// The onLine callback receives the line buffer directly; since this
+// buffer is re-used, the callback must copy it if it needs to be saved.
+// The onFinish callback receives the error, if any, before the pipe is
+// closed.
+func scanPipe(in io.ReadCloser, onLine func([]byte), onFinish func(error)) {
+	scanner := bufio.NewScanner(in)
+	scanner.Buffer(make([]byte, 0, initLineBufSize), maxLineBufSize)
+
+	for scanner.Scan() {
+		onLine(scanner.Bytes())
+	}
+
+	err := scanner.Err()
+	onFinish(err)
+	if err != nil {
+		// Force-close the pipe to avoid deadlock.
+		in.Close()
+	}
+}


### PR DESCRIPTION
## Description

Previously, output lines were assumed to fit within the default Scanner maximum buffer size of 64 KB.  This has quickly been determined to be overly optimistic!

Refactored the line scanning into scanPipe(), with a new maximum line buffer size of 128 MB.  If a line exceeds this threshold, then we display an error and forcefully close the pipe in order to avoid a deadlock.

## Motivation and Context

Fixes deadlock when output (stdout or stderr) exceeds the default line buffer size.

## How Has This Been Tested?

Tested locally using the OWASP Dependency Check plugin, which writes a 270 KB result JSON.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
