### PR TITLE
Re-enable default caching for docker build

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -8,6 +8,8 @@ build/
 build_scripts/
 dist/
 end_to_end_tests/
+htmlcov/
+images/
 k8s/
 localstack/
 venv/

--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -14,6 +14,3 @@ venv/
 
 Makefile
 README.md
-
-# Allow .temp directory
-!/.temp

--- a/backend/Dockerfiles/Dockerfile.engine
+++ b/backend/Dockerfiles/Dockerfile.engine
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 ARG ENGINE_BASE=3.9-slim-bullseye
 
 ###############################################################################
@@ -7,7 +8,8 @@ FROM python:3.9-bullseye AS builder
 
 # Install the Docker repository
 # hadolint ignore=DL3008
-RUN apt-get update \
+RUN --mount=type=cache,target=/var/cache/apt \
+    apt-get update \
     && apt-get install -y --no-install-recommends \
         lsb-release \
         software-properties-common \
@@ -17,19 +19,20 @@ RUN apt-get update \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN wget --quiet -O - https://download.docker.com/linux/debian/gpg | apt-key add -
 
-RUN pip install --no-cache-dir \
+# hadolint ignore=DL3042
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install \
     'packaged==0.6.0' \
-    'pipenv~=2024.0' \
-    'setuptools<74' \
-    'virtualenv==20.26.3' \
-    'wheel~=0.44.0'
+    'pipenv~=2024.0'
 
 # Build self-contained core plugin bundle.
 WORKDIR /src
 COPY Pipfile.lock .
 COPY engine/plugins/ engine/plugins
 # hadolint ignore=SC2016
-RUN pipenv requirements > requirements.txt && \
+RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=cache,target=/root/.cache/pipenv \
+    pipenv requirements > requirements.txt && \
     packaged --python-version 3.9 plugin.sh \
         'pip install -r requirements.txt' \
         'python -m engine.plugins "$@"' \
@@ -60,7 +63,10 @@ COPY --from=builder /etc/apt /etc/apt
 # - Install Pipenv environment
 # - Install Artemis libraries
 # hadolint ignore=DL3008,DL3013,DL3042
-RUN apt-get update \
+RUN --mount=type=cache,target=/var/cache/apt \
+    --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=cache,target=/root/.cache/pipenv \
+    apt-get update \
     && grep security /etc/apt/sources.list > /etc/apt/security.sources.list \
     && apt-get upgrade -y \
     && apt-get upgrade -y -o Dir::Etc::Sourcelist=/etc/apt/security.sources.list \
@@ -75,7 +81,6 @@ RUN apt-get update \
     && pipenv install --system --deploy \
     && pip install /src/artemislib \
     && pip install /src/artemisdb \
-    && rm -rf /root/.cache/pip /root/.cache/pipenv \
     && rm -r /src
 
 WORKDIR /srv/engine

--- a/backend/Dockerfiles/Dockerfile.engine
+++ b/backend/Dockerfiles/Dockerfile.engine
@@ -8,7 +8,7 @@ FROM python:3.9-bullseye AS builder
 
 # Install the Docker repository
 # hadolint ignore=DL3008
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update \
     && apt-get install -y --no-install-recommends \
         lsb-release \
@@ -31,7 +31,7 @@ COPY Pipfile.lock .
 COPY engine/plugins/ engine/plugins
 # hadolint ignore=SC2016
 RUN --mount=type=cache,target=/root/.cache/pip \
-    --mount=type=cache,target=/root/.cache/pipenv \
+    --mount=type=cache,target=/root/.cache/pipenv,sharing=locked \
     pipenv requirements > requirements.txt && \
     packaged --python-version 3.9 plugin.sh \
         'pip install -r requirements.txt' \
@@ -63,9 +63,9 @@ COPY --from=builder /etc/apt /etc/apt
 # - Install Pipenv environment
 # - Install Artemis libraries
 # hadolint ignore=DL3008,DL3013,DL3042
-RUN --mount=type=cache,target=/var/cache/apt \
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/root/.cache/pip \
-    --mount=type=cache,target=/root/.cache/pipenv \
+    --mount=type=cache,target=/root/.cache/pipenv,sharing=locked \
     apt-get update \
     && grep security /etc/apt/sources.list > /etc/apt/security.sources.list \
     && apt-get upgrade -y \

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -421,7 +421,7 @@ dist/engine_scripts.zip: docker-compose.aws.yml aws_env.py
 dist/docker/engine: Dockerfiles/Dockerfile.engine Pipfile Pipfile.lock $(ENGINE_SRC) $(DB_LIB_SRC) $(SHARED_LIB_SRC)
 	@echo "${INFO}Building $@"
 	$(DOCKER) build . -t ${ENGINE_TAG} -f Dockerfiles/Dockerfile.engine \
-		--no-cache --force-rm \
+		${DOCKER_BUILD_EXTRA_ARGS} \
 		--build-arg MAINTAINER=${MAINTAINER} \
 		--build-arg ENGINE_BASE=${ENGINE_BASE}
 	mkdir -p ${DIST_DIR}/docker
@@ -433,7 +433,7 @@ dist/docker/engine: Dockerfiles/Dockerfile.engine Pipfile Pipfile.lock $(ENGINE_
 dist/docker/python3: Dockerfiles/Dockerfile.python3
 	@echo "${INFO}Building $@"
 	$(DOCKER) build . --pull -t ${PYTHON_TAG} -f Dockerfiles/Dockerfile.python3 \
-		--no-cache --force-rm \
+		${DOCKER_BUILD_EXTRA_ARGS} \
 		--build-arg MAINTAINER=${MAINTAINER} \
 		--build-arg GIT_SECRETS_VER=${GIT_SECRETS_VER} \
 		--build-arg SHELL_CHECK_VER=${SHELLCHECKVER} \
@@ -451,7 +451,7 @@ dist/docker/python3: Dockerfiles/Dockerfile.python3
 dist/docker/node14: Dockerfiles/Dockerfile.node14
 	@echo "${INFO}Building $@"
 	$(DOCKER) build . --pull -t ${NODE_TAG} -f Dockerfiles/Dockerfile.node14 \
-		--no-cache --force-rm \
+		${DOCKER_BUILD_EXTRA_ARGS} \
 		--build-arg MAINTAINER=${MAINTAINER}
 	mkdir -p ${DIST_DIR}/docker
 	${DOCKER} tag ${NODE_TAG} ${ECR_URL}${NODE_TAG}
@@ -462,7 +462,7 @@ dist/docker/node14: Dockerfiles/Dockerfile.node14
 dist/docker/php: Dockerfiles/Dockerfile.php
 	@echo "${INFO}Building $@"
 	$(DOCKER) build . --pull -t ${PHP_TAG} -f Dockerfiles/Dockerfile.php \
-		--no-cache --force-rm \
+		${DOCKER_BUILD_EXTRA_ARGS} \
 		--build-arg MAINTAINER=${MAINTAINER} \
 		--build-arg PHP_SCANNER_VER=${PHP_SCANNER_VER}
 	mkdir -p ${DIST_DIR}/docker
@@ -474,7 +474,7 @@ dist/docker/php: Dockerfiles/Dockerfile.php
 dist/docker/dind: Dockerfiles/Dockerfile.dind
 	@echo "${INFO}Building $@"
 	$(DOCKER) build . --pull -t ${DIND_TAG} -f Dockerfiles/Dockerfile.dind \
-		--no-cache --force-rm \
+		${DOCKER_BUILD_EXTRA_ARGS} \
 		--build-arg MAINTAINER=${MAINTAINER} \
 		--build-arg TRIVY_VER=${TRIVY_VER} \
 		--build-arg TRIVY_COMMIT=${TRIVY_COMMIT} \
@@ -491,7 +491,7 @@ dist/docker/dind: Dockerfiles/Dockerfile.dind
 dist/docker/golang: Dockerfiles/Dockerfile.golang
 	@echo "${INFO}Building $@"
 	$(DOCKER) build . --pull -t ${GOLANG_TAG} -f Dockerfiles/Dockerfile.golang \
-		--no-cache --force-rm \
+		${DOCKER_BUILD_EXTRA_ARGS} \
 		--build-arg MAINTAINER=${MAINTAINER} \
 		--build-arg ENRYVER=${ENRYVER} \
 		--build-arg ENRYSHA=${ENRYSHA} \
@@ -506,7 +506,7 @@ dist/docker/golang: Dockerfiles/Dockerfile.golang
 dist/docker/ruby: Dockerfiles/Dockerfile.ruby
 	@echo "${INFO}Building $@"
 	$(DOCKER) build . --pull -t ${RUBY_TAG} -f Dockerfiles/Dockerfile.ruby \
-		--no-cache --force-rm \
+		${DOCKER_BUILD_EXTRA_ARGS} \
 		--build-arg MAINTAINER=${MAINTAINER} \
 		--build-arg RUBY_VER=3.3-slim-bookworm
 	mkdir -p ${DIST_DIR}/docker
@@ -518,7 +518,7 @@ dist/docker/ruby: Dockerfiles/Dockerfile.ruby
 dist/docker/db_maintenance: libs/* utilities/db_maintenance/*
 	@echo "${INFO}Building $@"
 	$(DOCKER) build . --pull -t ${DB_MAINT_TAG} -f utilities/db_maintenance/Dockerfile \
-		--no-cache --force-rm \
+		${DOCKER_BUILD_EXTRA_ARGS} \
 		--build-arg MAINTAINER=${MAINTAINER}
 	mkdir -p ${DIST_DIR}/docker
 	${DOCKER} tag ${DB_MAINT_TAG} ${ECR_URL}${DB_MAINT_TAG}
@@ -531,7 +531,7 @@ dist/docker/veracode: Dockerfiles/Dockerfile.veracode
 ifeq (${VERACODE_FLAG}, true)
 	@echo "${INFO}Building $@"
 	$(DOCKER) build . --pull -t ${VERACODE_TAG} -f Dockerfiles/Dockerfile.veracode \
-		--no-cache --force-rm \
+		${DOCKER_BUILD_EXTRA_ARGS} \
 		--build-arg MAINTAINER=${MAINTAINER}
 	mkdir -p ${DIST_DIR}/docker
 	${DOCKER} tag ${VERACODE_TAG} ${ECR_URL}${VERACODE_TAG}
@@ -543,7 +543,7 @@ endif
 dist/docker/swift: Dockerfiles/Dockerfile.swift
 	@echo "${INFO}Building $@"
 	$(DOCKER) build . --pull  -t ${SWIFT_TAG} -f Dockerfiles/Dockerfile.swift \
-		--no-cache --force-rm \
+		${DOCKER_BUILD_EXTRA_ARGS} \
 		--build-arg MAINTAINER=${MAINTAINER} \
 		--build-arg SWIFTLINT_VER=${SWIFTLINT_VER}
 	mkdir -p ${DIST_DIR}/docker


### PR DESCRIPTION
## Description

When running `docker build`, removes the `--no-cache` and `--force-rm` options from always being set.

If needed, these can be set using the `DOCKER_BUILD_EXTRA_ARGS` var, e.g.:

```
make dist/docker/engine DOCKER_BUILD_EXTRA_ARGS='--no-cache --force-rm'
```

This will not affect CI deploys since we assume that each CI run will start with an empty cache anyway.

To inaugurate this change, Dockerfile.engine has been updated to use cache mounts for Apt, Pip, and Pipenv.

## Motivation and Context

We want to make use of both layer caches and cache mounts when building our container images to improve the local dev cycle.  There may be additional tweaks needed to .dockerignore to avoid unnecessary rebuilds, but this is a first start.

## How Has This Been Tested?

Tested in non-prod environment as part of the 2024-12-09 "omnibus" deployment with Django 4.2.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
