### PR TITLE
Remove cwe2 dependency

### DIFF
--- a/backend/Pipfile
+++ b/backend/Pipfile
@@ -13,7 +13,6 @@ aws-lambda-powertools = "~=3.3"
 boto3 = "~=1.35"
 boto3-stubs = {extras = ["ec2", "lambda", "s3", "secretsmanager", "sqs"], version = "~=1.35"}
 cryptography = "~=43.0"
-cwe2 = "~=3.0"
 django = "~=4.2"
 docker = "~=7.1"
 graphql-query = "~=1.4"

--- a/backend/Pipfile.lock
+++ b/backend/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "372ffb2532a641ed237ff4317092564f388f2349307110aadf63d93033cd3f60"
+            "sha256": "d0cfed8eb9ec56edf8671f1e611a73f49afa9bb16ed086bd9a3da4d42415040f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -439,15 +439,6 @@
             "markers": "python_version >= '3.7'",
             "version": "==43.0.3"
         },
-        "cwe2": {
-            "hashes": [
-                "sha256:abef03eb853f5c1851df6af5167bd9fe73a53dddb119fdbc5c3afc7d50b9f55b",
-                "sha256:cfdcea629e45dfcd2cdc54ef26b3ad6e30dc794575eebb57eeffc59718dd49bb"
-            ],
-            "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==3.0.0"
-        },
         "deprecated": {
             "hashes": [
                 "sha256:353bc4a8ac4bfc96800ddab349d89c25dec1079f65fd53acdcc1e0b975b21320",
@@ -596,14 +587,6 @@
             ],
             "markers": "python_version >= '3.6'",
             "version": "==3.10"
-        },
-        "importlib-resources": {
-            "hashes": [
-                "sha256:980862a1d16c9e147a59603677fa2aa5fd82b87f223b6cb870695bcfce830065",
-                "sha256:ac29d5f956f01d5e4bb63102a5a19957f1b9175e45649977264a1416783bb717"
-            ],
-            "markers": "python_version >= '3.8'",
-            "version": "==6.4.5"
         },
         "jinja2": {
             "hashes": [
@@ -1187,13 +1170,6 @@
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.9.0.post0"
         },
-        "pytz": {
-            "hashes": [
-                "sha256:2aa355083c50a0f93fa581709deac0c9ad65cca8a9e9beac660adcbd493c798a",
-                "sha256:31c7c1817eb7fae7ca4b8c7ee50c72f93aa2dd863de768e1ef4245d426aa0725"
-            ],
-            "version": "==2024.2"
-        },
         "pyyaml": {
             "hashes": [
                 "sha256:01179a4a8559ab5de078078f37e5c1a30d76bb88519906844fd7bdea1b7729ff",
@@ -1602,14 +1578,6 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==1.18.3"
-        },
-        "zipp": {
-            "hashes": [
-                "sha256:2c9958f6430a2040341a52eb608ed6dd93ef4392e02ffe219417c1b28b5dd1f4",
-                "sha256:ac1bbe05fd2991f160ebce24ffbac5f6d11d83dc90891255885223d42b3cd931"
-            ],
-            "markers": "python_version < '3.10'",
-            "version": "==3.21.0"
         }
     },
     "develop": {


### PR DESCRIPTION
## Description

This is a follow-up to: https://github.com/WarnerMedia/artemis/pull/376

Removes the cwe2 dependency as it is no longer used in any modules.

## Motivation and Context

Reduce the size of our dependencies -- cwe2 was the second-largest non-dev dependency we were bringing in.

## How Has This Been Tested?

Tested locally.  Search for "cwe2" in the codebase no longer returns any results.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
