### PR TITLE
Use boxed runner for SwiftLint

### DIFF
--- a/backend/Makefile
+++ b/backend/Makefile
@@ -142,6 +142,7 @@ VERACODE_FLAG := $(shell egrep "veracode_enabled\s+=\s+(true|false)" ${TERRAFORM
 SWIFT_PKG := ${PREFIX}/swift
 SWIFT_TAG := ${SWIFT_PKG}:latest
 SWIFTLINT_VER := 0.45.1
+SWIFTLINT_SHA := 3b5075a5cdf17fc5aaf03636b81d96b29ff5040ee24ca11e1fafc3b43e0fb9e4
 
 FSB_VER := 1.9.0
 FSB_PATCH := -fix2
@@ -545,7 +546,8 @@ dist/docker/swift: Dockerfiles/Dockerfile.swift
 	$(DOCKER) build . --pull  -t ${SWIFT_TAG} -f Dockerfiles/Dockerfile.swift \
 		${DOCKER_BUILD_EXTRA_ARGS} \
 		--build-arg MAINTAINER=${MAINTAINER} \
-		--build-arg SWIFTLINT_VER=${SWIFTLINT_VER}
+		--build-arg SWIFTLINT_VER=${SWIFTLINT_VER} \
+		--build-arg SWIFTLINT_SHA=${SWIFTLINT_SHA}
 	mkdir -p ${DIST_DIR}/docker
 	if [ ! -z ${ACCOUNT_ID} ]; then \
 		${DOCKER} tag ${SWIFT_TAG} ${ECR_URL}${SWIFT_TAG} ; \

--- a/backend/engine/plugins/swiftlint/settings.json
+++ b/backend/engine/plugins/swiftlint/settings.json
@@ -1,5 +1,6 @@
 {
   "name": "SwiftLint",
   "type": "static_analysis",
-  "image": "$ECR/artemis/swift:latest"
+  "image": "$ECR/artemis/swift:latest",
+  "runner": "boxed"
 }


### PR DESCRIPTION
## Description

Switches the SwiftLint plugin to used the boxed runner.

This enables us to slim down the Swift container image by only including SwiftLint.  We now also verify the SHA-256 hash of the downloaded zip file.

## Motivation and Context

Simplify SwiftLint plugin (no separate dependencies to maintain in Dockerfile.swift).

## How Has This Been Tested?

Tested in nonprod environment.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
