### PR TITLE
Pre-extract the boxed plugin bundle

### DIFF
--- a/backend/Dockerfiles/Dockerfile.boxed
+++ b/backend/Dockerfiles/Dockerfile.boxed
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1
+
+# Builder for boxed core plugins.
+
+ARG PYTHON_VER=3.9-bookworm
+
+FROM python:$PYTHON_VER
+
+# hadolint ignore=DL3042
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip install \
+        'packaged==0.6.0' \
+        'pipenv~=2024.0'
+
+WORKDIR /src
+COPY Pipfile.lock .
+COPY engine/plugins/ engine/plugins
+
+# Generate requirements.txt from lockfile so the standalone Python distribution
+# doesn't need pipenv installed.
+RUN pipenv requirements > requirements.txt
+
+# Build the self-contained bundle.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    packaged --python-version 3.9 plugin.sh \
+        'pip install -r requirements.txt' \
+        'python -m engine.plugins "$@"' \
+        /src
+
+# Pre-extract the plugin bundle to improve startup times.
+RUN ./plugin.sh --noexec --target .boxed/glibc

--- a/backend/Dockerfiles/Dockerfile.boxed
+++ b/backend/Dockerfiles/Dockerfile.boxed
@@ -28,4 +28,4 @@ RUN --mount=type=cache,target=/root/.cache/pip \
         /src
 
 # Pre-extract the plugin bundle to improve startup times.
-RUN ./plugin.sh --noexec --target .boxed/glibc
+RUN ./plugin.sh --noexec --target _boxed/glibc

--- a/backend/Dockerfiles/Dockerfile.engine
+++ b/backend/Dockerfiles/Dockerfile.engine
@@ -19,24 +19,10 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN wget --quiet -O - https://download.docker.com/linux/debian/gpg | apt-key add -
 
-# hadolint ignore=DL3042
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install \
-    'packaged==0.6.0' \
-    'pipenv~=2024.0'
-
-# Build self-contained core plugin bundle.
-WORKDIR /src
-COPY Pipfile.lock .
-COPY engine/plugins/ engine/plugins
-# hadolint ignore=SC2016
-RUN --mount=type=cache,target=/root/.cache/pip \
-    --mount=type=cache,target=/root/.cache/pipenv,sharing=locked \
-    pipenv requirements > requirements.txt && \
-    packaged --python-version 3.9 plugin.sh \
-        'pip install -r requirements.txt' \
-        'python -m engine.plugins "$@"' \
-        /src
+# Libc-specific boxed plugin bundle builders.
+# Built from Dockerfile.boxed by context in the bakefile.
+# hadolint ignore=DL3006
+FROM boxed-glibc AS boxed-glibc
 
 ###############################################################################
 # App stage
@@ -87,7 +73,8 @@ WORKDIR /srv/engine
 
 COPY ./engine/ ./
 COPY ./services.json /srv/engine/
-COPY --from=builder /src/plugin.sh /srv/engine/plugins/plugin.sh
+COPY boxed-plugin.sh /srv/engine/plugins/plugin.sh
+COPY --from=boxed-glibc /src/.boxed/glibc/ /srv/engine/plugins/.boxed/glibc/
 
 VOLUME ["/srv/engine/plugins"]
 

--- a/backend/Dockerfiles/Dockerfile.engine
+++ b/backend/Dockerfiles/Dockerfile.engine
@@ -74,7 +74,7 @@ WORKDIR /srv/engine
 COPY ./engine/ ./
 COPY ./services.json /srv/engine/
 COPY boxed-plugin.sh /srv/engine/plugins/plugin.sh
-COPY --from=boxed-glibc /src/.boxed/glibc/ /srv/engine/plugins/.boxed/glibc/
+COPY --from=boxed-glibc /src/_boxed/glibc/ /srv/engine/plugins/_boxed/glibc/
 
 VOLUME ["/srv/engine/plugins"]
 

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -418,15 +418,15 @@ dist/engine_scripts.zip: docker-compose.aws.yml aws_env.py
 # Docker images
 ###############################################################################
 
-dist/docker/engine: Dockerfiles/Dockerfile.engine Pipfile Pipfile.lock $(ENGINE_SRC) $(DB_LIB_SRC) $(SHARED_LIB_SRC)
+dist/docker/engine: docker-bake.hcl Dockerfiles/Dockerfile.boxed Dockerfiles/Dockerfile.engine Pipfile Pipfile.lock $(ENGINE_SRC) $(DB_LIB_SRC) $(SHARED_LIB_SRC)
 	@echo "${INFO}Building $@"
-	$(DOCKER) build . -t ${ENGINE_TAG} -f Dockerfiles/Dockerfile.engine \
-		${DOCKER_BUILD_EXTRA_ARGS} \
-		--build-arg MAINTAINER=${MAINTAINER} \
-		--build-arg ENGINE_BASE=${ENGINE_BASE}
+	MAINTAINER=${MAINTAINER} \
+	ENGINE_BASE=${ENGINE_BASE} \
+	ENGINE_TAG=${ENGINE_TAG} \
+	ECR_URL=${ECR_URL} \
+	LATEST_COMMIT=${LATEST_COMMIT} \
+	${DOCKER} buildx bake -f docker-bake.hcl engine ${DOCKER_BUILD_EXTRA_ARGS}
 	mkdir -p ${DIST_DIR}/docker
-	${DOCKER} tag ${ENGINE_TAG} ${ECR_URL}${ENGINE_TAG}
-	${DOCKER} tag ${ENGINE_TAG} ${ECR_URL}${ENGINE_TAG}-stage-${LATEST_COMMIT}
 	touch $@
 	@echo "${OK}"
 

--- a/backend/boxed-plugin.sh
+++ b/backend/boxed-plugin.sh
@@ -15,7 +15,7 @@ for opt in "$@"; do
 done
 
 # We assume we are in a glibc-based distribution.
-PACKAGED_ROOT="$(dirname "$0")/.boxed/glibc"
+PACKAGED_ROOT="$(dirname "$0")/_boxed/glibc"
 
 export PATH="$PACKAGED_ROOT/.packaged_python/python/bin:$PATH"
 cd "$PACKAGED_ROOT" || exit 1

--- a/backend/boxed-plugin.sh
+++ b/backend/boxed-plugin.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+# Bootstrap for launching boxed plugins.
+# This script is run from within the plugin container.
+
+# Trim options passed to the legacy self-extracting executable.
+# We assume that the self-extracting executable options end with "--"
+# so we can safely trim all args before that.
+i=0
+for opt in "$@"; do
+  i=$((i+1))
+  if [ "$opt" = '--' ]; then
+    shift $i
+    break
+  fi
+done
+
+# We assume we are in a glibc-based distribution.
+PACKAGED_ROOT="$(dirname "$0")/.boxed/glibc"
+
+export PATH="$PACKAGED_ROOT/.packaged_python/python/bin:$PATH"
+cd "$PACKAGED_ROOT" || exit 1
+exec python -m engine.plugins "$@"

--- a/backend/docker-bake.hcl
+++ b/backend/docker-bake.hcl
@@ -7,6 +7,9 @@ variable "FSB_PATCH" {}
 variable "OWASP_DC" {}
 variable "OWASP_DC_SHA" {}
 
+variable "ENGINE_BASE" {}
+
+variable "ENGINE_TAG" {}
 variable "JAVA7_TAG" {}
 variable "JAVA8_TAG" {}
 variable "JAVA13_TAG" {}
@@ -32,6 +35,28 @@ function "full_tags" {
     "${ECR_URL}${base_tag}",
     "${ECR_URL}${base_tag}-stage-${LATEST_COMMIT}",
   ]
+}
+
+target "boxed-glibc" {
+  dockerfile = "Dockerfiles/Dockerfile.boxed"
+
+  args = {
+    PYTHON_VER = "3.9-bookworm"
+  }
+}
+
+target "engine" {
+  dockerfile = "Dockerfiles/Dockerfile.engine"
+  tags = full_tags(ENGINE_TAG)
+
+  contexts = {
+    boxed-glibc = "target:boxed-glibc"
+  }
+
+  args = {
+      MAINTAINER = MAINTAINER
+      ENGINE_BASE = ENGINE_BASE
+  }
 }
 
 # Standard build args for all Java targets.

--- a/backend/docker-bake.hcl
+++ b/backend/docker-bake.hcl
@@ -54,8 +54,8 @@ target "engine" {
   }
 
   args = {
-      MAINTAINER = MAINTAINER
-      ENGINE_BASE = ENGINE_BASE
+    MAINTAINER = MAINTAINER
+    ENGINE_BASE = ENGINE_BASE
   }
 }
 


### PR DESCRIPTION
## Description

Addresses two issues:

* Improves boxed plugin startup time.
* Lessens chance of free disk space errors, such as "Consider setting TMPDIR to a directory with more free space".

This is part of the longer-term effort to support distributions based on Musl libc (such as Alpine) by moving the glibc-based bundle into it's own directory. The bundle build process is now its own Dockerfile so we can re-use it (via docker-bake.hcl) to build both Glibc and Musl variants.

## Motivation and Context

Extracting the plugin bundle into each container added to the startup time of each boxed plugin and required an additional 400+ MB of free space.

## How Has This Been Tested?

TODO

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
