### PR TITLE
Use boxed runner for Node.js-related plugins

### DIFF
--- a/backend/Dockerfiles/Dockerfile.boxed
+++ b/backend/Dockerfiles/Dockerfile.boxed
@@ -14,6 +14,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 WORKDIR /src
 COPY Pipfile.lock .
+COPY libs/ libs/
 COPY engine/plugins/ engine/plugins
 
 # Generate requirements.txt from lockfile so the standalone Python distribution
@@ -23,7 +24,7 @@ RUN pipenv requirements > requirements.txt
 # Build the self-contained bundle.
 RUN --mount=type=cache,target=/root/.cache/pip \
     packaged --python-version 3.9 plugin.sh \
-        'pip install -r requirements.txt' \
+        'pip install -r requirements.txt /src/libs/artemisdb /src/libs/artemislib' \
         'python -m engine.plugins "$@"' \
         /src
 

--- a/backend/Dockerfiles/Dockerfile.node14
+++ b/backend/Dockerfiles/Dockerfile.node14
@@ -3,38 +3,24 @@ FROM node:14-bullseye-slim
 ARG MAINTAINER
 LABEL maintainer=$MAINTAINER
 
-# Copy Artemis libraries into /src for installation
-RUN mkdir -p /src
-COPY ./libs/ /src/
-
 # Run all additional config in a single RUN to reduce the layers:
 # - Apply security updates
 # - Base requirements to execute script
-# - Symlink python3 to python for Analyzer Engine benefit
-# - Install eslint-plugin-security
-# - Install eslint
-# - Upgrade pip and install boto3 for plugin utils
+# - Install eslint and security plugin.
+# - Upgrade pip
 # - Install nodejsscan
-# - Install psycopg2
-# - Install requests
-# - Install Artemis libraries from /src
-# - Clean up /src
-RUN apt-get update && \
+# hadolint ignore=DL3008,DL3013,DL3016,DL3042
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/root/.cache/pip \
+    apt-get update && \
     grep security /etc/apt/sources.list > /etc/apt/security.sources.list && \
     apt-get upgrade -y && \
     apt-get upgrade -y -o Dir::Etc::Sourcelist=/etc/apt/security.sources.list && \
     apt-get install python3 python3-pip git -y --no-install-recommends && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
-    ln -s /usr/bin/python3 /usr/bin/python && \
     npm install eslint-plugin-security && \
     npm install typescript@5.1.6 @typescript-eslint/parser@5.50.0 && \
     npm install -g eslint@8.57.0 npm@7.8.0 && \
-    pip3 install --upgrade setuptools && \
-    pip3 install --upgrade pip boto3 && \
-    pip3 install nodejsscan && \
-    pip3 install psycopg2-binary && \
-    pip3 install requests && \
-    pip3 install /src/artemislib && \
-    pip3 install /src/artemisdb && \
-    rm -r /src
+    pip3 install --upgrade pip setuptools && \
+    pip3 install nodejsscan

--- a/backend/engine/plugins/eslint/settings.json
+++ b/backend/engine/plugins/eslint/settings.json
@@ -1,5 +1,6 @@
 {
     "name": "ESLint Static Scanner",
     "type": "static_analysis",
-    "image": "$ECR/artemis/node:14-latest"
+    "image": "$ECR/artemis/node:14-latest",
+    "runner": "boxed"
 }

--- a/backend/engine/plugins/node_dependencies/settings.json
+++ b/backend/engine/plugins/node_dependencies/settings.json
@@ -2,5 +2,6 @@
     "name": "NPM Audit Scanner",
     "type": "vulnerability",
     "image": "$ECR/artemis/node:14-latest",
+    "runner": "boxed",
     "writable": true
 }

--- a/backend/engine/plugins/nodejsscan/settings.json
+++ b/backend/engine/plugins/nodejsscan/settings.json
@@ -1,5 +1,6 @@
 {
     "name": "Nodejsscan",
     "type": "static_analysis",
-    "image": "$ECR/artemis/node:14-latest"
+    "image": "$ECR/artemis/node:14-latest",
+    "runner": "boxed"
 }


### PR DESCRIPTION
## Description

Use the boxed runner for the eslint, node_dependencies, and nodejsscan plugins.

We also now include artemisdb and artemislib in the boxed plugin bundle.

## Motivation and Context

Reduce dependencies to maintain in Dockerfile.node14.

## How Has This Been Tested?

Tested in nonprod.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
