### PR TITLE
Bugfix trivy license

### DIFF
--- a/backend/engine/processor/sbom_cdx.py
+++ b/backend/engine/processor/sbom_cdx.py
@@ -35,16 +35,14 @@ def process_dependency(dep: dict, scan: Scan) -> None:
     licenses = []
     for license in dep["licenses"]:
         license_id = license.get("id").lower()
-        logger.info(f'ALL LICENSE: {license}')
+        if len(license.get("name")) > 256:
+            logger.error(f"{component} License exceeds character limit: {license['name']}")
+            continue
         if license_id not in license_obj_cache:
-            try:
-                # If we don't have a local copy of the license object get it from the DB
-                license_obj_cache[license_id],_ = License.objects.get_or_create(
-                    license_id=license_id, defaults={"name": license["name"]}
-                )
-            except Exception as e:
-                logger.error(f'LICENSE TOO LONG: {license}')
-                logger.error(e)
+            # If we don't have a local copy of the license object get it from the DB
+            license_obj_cache[license_id],_ = License.objects.get_or_create(
+                license_id=license_id, defaults={"name": license["name"]}
+            )
 
         # Add the license object to the list for this component
         licenses.append(license_obj_cache[license_id])

--- a/backend/engine/processor/sbom_cdx.py
+++ b/backend/engine/processor/sbom_cdx.py
@@ -49,9 +49,10 @@ def process_dependency(dep: dict, scan: Scan) -> None:
         # Add the license object to the list for this component
         licenses.append(license_obj_cache[license_id])
 
+    # Logging when a component has more than 15 licenses, as that is usually caused by a bug by Trivy
+    if len(licenses) > 15:
+        logger.error(f"{component} potentially contains incorrect license information")
     # Update the component's set of licenses
-    if len(licenses) > 20:
-        logger.error(f"too many license reported: {licenses}")
     if licenses:
         component.licenses.set(licenses)
 

--- a/backend/engine/processor/sbom_cdx.py
+++ b/backend/engine/processor/sbom_cdx.py
@@ -38,7 +38,7 @@ def process_dependency(dep: dict, scan: Scan) -> None:
         # Character limit for licenses are 256 and Trivy SBOM at times can incorrectly
         # return out lengthy gibberish
         if len(license.get("name")) > 256:
-            logger.error(f"{component} License exceeds character limit: {license['name']}")
+            logger.error(f"{component}'s license exceeds character limit: {license['name']}")
             continue
         if license_id not in license_obj_cache:
             # If we don't have a local copy of the license object get it from the DB

--- a/backend/engine/processor/sbom_cdx.py
+++ b/backend/engine/processor/sbom_cdx.py
@@ -35,6 +35,7 @@ def process_dependency(dep: dict, scan: Scan) -> None:
     licenses = []
     for license in dep["licenses"]:
         license_id = license.get("id").lower()
+        logger.info(f'ALL LICENSE: {license}')
         if license_id not in license_obj_cache:
             try:
                 # If we don't have a local copy of the license object get it from the DB

--- a/backend/engine/processor/sbom_cdx.py
+++ b/backend/engine/processor/sbom_cdx.py
@@ -50,6 +50,8 @@ def process_dependency(dep: dict, scan: Scan) -> None:
         licenses.append(license_obj_cache[license_id])
 
     # Update the component's set of licenses
+    if len(licenses) > 20:
+        logger.error(f"too many license reported: {licenses}")
     if licenses:
         component.licenses.set(licenses)
 

--- a/backend/engine/processor/sbom_cdx.py
+++ b/backend/engine/processor/sbom_cdx.py
@@ -51,7 +51,7 @@ def process_dependency(dep: dict, scan: Scan) -> None:
 
     # Logging when a component has more than 15 licenses, as that is usually caused by a bug by Trivy
     if len(licenses) > 15:
-        logger.error(f"{component} potentially contains incorrect license information")
+        logger.warning(f"{component} potentially contains incorrect license information")
     # Update the component's set of licenses
     if licenses:
         component.licenses.set(licenses)

--- a/backend/engine/processor/sbom_cdx.py
+++ b/backend/engine/processor/sbom_cdx.py
@@ -40,11 +40,14 @@ def process_dependency(dep: dict, scan: Scan) -> None:
         if len(license.get("name")) > 256:
             logger.error(f"{component}'s license exceeds character limit: {license['name']}")
             continue
+        # If we don't have a local copy of the license object get it from the DB
         if license_id not in license_obj_cache:
-            # If we don't have a local copy of the license object get it from the DB
-            license_obj_cache[license_id], _ = License.objects.get_or_create(
-                license_id=license_id, defaults={"name": license["name"]}
-            )
+            try:
+                license_obj_cache[license_id], _ = License.objects.get_or_create(
+                    license_id=license_id, defaults={"name": license["name"]}
+                )
+            except Exception as e:
+                logger.error(f"Error inserting data for license_id {license_id}: {e}")
 
         # Add the license object to the list for this component
         licenses.append(license_obj_cache[license_id])

--- a/backend/engine/processor/sbom_cdx.py
+++ b/backend/engine/processor/sbom_cdx.py
@@ -36,12 +36,14 @@ def process_dependency(dep: dict, scan: Scan) -> None:
     for license in dep["licenses"]:
         license_id = license.get("id").lower()
         if license_id not in license_obj_cache:
-            # If we don't have a local copy of the license object get it from the DB
-            license_obj_cache[license_id],_ = License.objects.get_or_create(
-                license_id=license_id, defaults={"name": license["name"]}
-            )
-            if len(license_id) > 250:
-                logger.error(f'LICENSE TOO LONG: {license_id}')
+            try:
+                # If we don't have a local copy of the license object get it from the DB
+                license_obj_cache[license_id],_ = License.objects.get_or_create(
+                    license_id=license_id, defaults={"name": license["name"]}
+                )
+            except Exception as e:
+                logger.error(f'LICENSE TOO LONG: {license_id}, {license.get("name")}')
+                logger.error(e)
 
         # Add the license object to the list for this component
         licenses.append(license_obj_cache[license_id])

--- a/backend/engine/processor/sbom_cdx.py
+++ b/backend/engine/processor/sbom_cdx.py
@@ -56,7 +56,7 @@ def process_dependency(dep: dict, scan: Scan) -> None:
         # Add the license object to the list for this component
         licenses.append(license_obj_cache[license_id])
 
-    # Check if the component's license count exceeds the threshold of what is deemed suspiciousg
+    # Check if the component's license count exceeds the threshold of what is deemed suspicious
     if len(licenses) > MAX_LICENCE_COUNT:
         logger.warning(f"{component} potentially contains incorrect license information")
     # Update the component's set of licenses

--- a/backend/engine/processor/sbom_cdx.py
+++ b/backend/engine/processor/sbom_cdx.py
@@ -40,7 +40,7 @@ def process_dependency(dep: dict, scan: Scan) -> None:
             license_obj_cache[license_id], created = License.objects.get_or_create(
                 license_id=license_id, defaults={"name": license["name"]}
             )
-            if not created:
+            if created:
                 logger.error(f'LICENSE TOO LONG: {license_id}')
 
         # Add the license object to the list for this component

--- a/backend/engine/processor/sbom_cdx.py
+++ b/backend/engine/processor/sbom_cdx.py
@@ -35,12 +35,14 @@ def process_dependency(dep: dict, scan: Scan) -> None:
     licenses = []
     for license in dep["licenses"]:
         license_id = license.get("id").lower()
+        # Character limit for licenses are 256 and Trivy SBOM at times can incorrectly
+        # return out lengthy gibberish
         if len(license.get("name")) > 256:
             logger.error(f"{component} License exceeds character limit: {license['name']}")
             continue
         if license_id not in license_obj_cache:
             # If we don't have a local copy of the license object get it from the DB
-            license_obj_cache[license_id],_ = License.objects.get_or_create(
+            license_obj_cache[license_id], _ = License.objects.get_or_create(
                 license_id=license_id, defaults={"name": license["name"]}
             )
 

--- a/backend/engine/processor/sbom_cdx.py
+++ b/backend/engine/processor/sbom_cdx.py
@@ -42,7 +42,7 @@ def process_dependency(dep: dict, scan: Scan) -> None:
                     license_id=license_id, defaults={"name": license["name"]}
                 )
             except Exception as e:
-                logger.error(f'LICENSE TOO LONG: {license_id}, {license.get("name")}')
+                logger.error(f'LICENSE TOO LONG: {license}')
                 logger.error(e)
 
         # Add the license object to the list for this component

--- a/backend/engine/processor/sbom_cdx.py
+++ b/backend/engine/processor/sbom_cdx.py
@@ -37,10 +37,10 @@ def process_dependency(dep: dict, scan: Scan) -> None:
         license_id = license.get("id").lower()
         if license_id not in license_obj_cache:
             # If we don't have a local copy of the license object get it from the DB
-            license_obj_cache[license_id], created = License.objects.get_or_create(
+            license_obj_cache[license_id],_ = License.objects.get_or_create(
                 license_id=license_id, defaults={"name": license["name"]}
             )
-            if created:
+            if len(license_id) > 250:
                 logger.error(f'LICENSE TOO LONG: {license_id}')
 
         # Add the license object to the list for this component

--- a/backend/engine/processor/sbom_cdx.py
+++ b/backend/engine/processor/sbom_cdx.py
@@ -37,9 +37,11 @@ def process_dependency(dep: dict, scan: Scan) -> None:
         license_id = license.get("id").lower()
         if license_id not in license_obj_cache:
             # If we don't have a local copy of the license object get it from the DB
-            license_obj_cache[license_id], _ = License.objects.get_or_create(
+            license_obj_cache[license_id], created = License.objects.get_or_create(
                 license_id=license_id, defaults={"name": license["name"]}
             )
+            if not created:
+                logger.error(f'LICENSE TOO LONG: {license_id}')
 
         # Add the license object to the list for this component
         licenses.append(license_obj_cache[license_id])


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Our version of Trivy is currently facing a bug where it returns long passages of gibberish for their license information on their SBOM reports. Examples of this contain random metadata about the library or even the entire license agreement split into hundreds of licenses. This will just catch those instances and then log them. 
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Trivy SBOM scans would error out when there were too many characters in a license
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
in a dev environment
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.