### PR TITLE
Remove hardcoded secrets from bandit results

### DIFF
--- a/backend/engine/plugins/bandit/main.py
+++ b/backend/engine/plugins/bandit/main.py
@@ -44,6 +44,10 @@ def build_dict(data: dict, path: str) -> list:
                 "line": warnings.get("line_range")[0],
                 "type": "{}: {}".format(warnings.get("test_id"), warnings.get("test_name")),
             }
+
+            if warnings.get("test_id") == "B105":
+                items["message"] = "Possible hardcoded password"
+
             results_list.append(items)
     return results_list
 

--- a/backend/engine/tests/test_plugin_bandit.py
+++ b/backend/engine/tests/test_plugin_bandit.py
@@ -342,6 +342,38 @@ class TestPluginBandit(unittest.TestCase):
         actual = bandit.build_dict(data, "/src")
         self.assertEqual(expected, actual)
 
+    def test_build_dict_B105(self):
+        data = {
+            "errors": [],
+            "generated_at": "2019-06-07T17:33:47.000000+00:00",
+            "metrics": {},
+            "results": {
+                "code": 'ssn_plus_one = "123-45-67890"\n',
+                "filename": "test.py",
+                "issue_confidence": "MEDIUM",
+                "issue_cwe": {"id": 259, "link": "https://cwe.mitre.org/data/definitions/259.html"},
+                "issue_severity": "LOW",
+                "issue_text": "Possible hardcoded password: '123-45-67890'",
+                "line_number": 17,
+                "line_range": [17],
+                "more_info": "https://bandit.readthedocs.io/en/1.8.0/plugins/b105_hardcoded_password_string.html",
+                "test_id": "B105",
+                "test_name": "hardcoded_password_string",
+            },
+        }
+        expected = [
+            {
+                "filename": "test.py",
+                "severity": "low",
+                "message": "Possible hardcoded password",
+                "line": 17,
+                "type": "B105: hardcoded_password_string",
+            }
+        ]
+
+        actual = bandit.build_dict(data, "src")
+        self.assertEqual(expected, actual)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The messages for the[ bandit test rule: B105](https://bandit.readthedocs.io/en/latest/plugins/b105_hardcoded_password_string.html) return the hardcoded secret value in their messages. This PR eliminates the hardcoded secrets from the bandit results.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
tested in a dev environment 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Pic
![Embed something funny here](https://giphy.com/trending-gifs)