### PR TITLE
Show friendlier error on missing container image

### DIFF
--- a/backend/utilities/plugin_runner/README.md
+++ b/backend/utilities/plugin_runner/README.md
@@ -107,11 +107,12 @@ The script will perform a sanity check on the JSON file. If the file does not co
 
 Only plugins in [backend/engine/plugins](../../engine/plugins) are supported.
 
+* Error: Container image (...) must be built locally
 * Error: pull access denied for ... repository does not exist or may require 'docker login'
 
-The container image for the plugin has not been built locally or has been removed.
+The container image for the engine or plugin has not been built locally or has been removed.
 
-Re-build the container image for the plugin.
+Re-build the container image for the engine or plugin.
 
 * Error: Read-only filesystem (or similar)
 


### PR DESCRIPTION
## Description

Checks if the engine/plugin container image exists and show a friendly reminder to build the image first.

## Motivation and Context

Small improvement to UX (even I would get confused by the Docker error).

## How Has This Been Tested?

Only changes are to plugin runner utility.  Tested locally.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
