### PR TITLE
Engine - Gracefully shutdown containers when timeout is exceeded

### DIFF
--- a/backend/engine/utils/plugin.py
+++ b/backend/engine/utils/plugin.py
@@ -375,8 +375,9 @@ def run_plugin(
     # The temporary named volume is automatically deleted after the plugin
     # container exits.
     with temporary_volume(f"{TEMP_VOLUME_NAME_PREFIX}-{plugin}") as volname:
+        container_name = get_container_name()
         plugin_command = get_plugin_command(
-            scan, plugin, settings, depth, include_dev, volname, scan_images, plugin_config, services
+            scan, plugin, container_name, settings, depth, include_dev, volname, scan_images, plugin_config, services
         )
         try:
             # Run the plugin inside the settings.image
@@ -388,6 +389,19 @@ def run_plugin(
                 timeout=settings.timeout,
             )
         except subprocess.TimeoutExpired:
+            stop_command = get_plugin_stop_command(container_name)
+            stop_response = subprocess.run(
+                stop_command,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                check=False,
+            )
+
+            if stop_response.returncode != 0:
+                log.error("Failed to stop container after timeout. Returned %d", stop_response.returncode)
+                log.debug("stdout: %s", stop_response.stdout)
+                log.debug("stderr: %s", stop_response.stderr)
+
             return Result(
                 name=settings.name,
                 type=settings.plugin_type,
@@ -676,9 +690,14 @@ def get_iso_timestamp() -> str:
     return datetime.utcnow().replace(tzinfo=timezone.utc).isoformat(timespec="microseconds")
 
 
+def get_container_name() -> str:
+    return f"plugin-{ENGINE_ID}"
+
+
 def get_plugin_command(
     scan: Scan,
     plugin: str,
+    container_name: str,
     settings: PluginSettings,
     depth: Optional[str],
     include_dev: bool,
@@ -699,7 +718,7 @@ def get_plugin_command(
         "run",
         "--rm",
         "--name",
-        f"plugin-{ENGINE_ID}",
+        container_name,
         "--volumes-from",
         ENGINE_ID,
         "-v",
@@ -788,6 +807,16 @@ def get_plugin_command(
             json.dumps(plugin_config),
         ]
     )
+
+    return cmd
+
+
+def get_plugin_stop_command(container_name: str) -> list[str]:
+    cmd = [
+        "docker",
+        "stop",
+        container_name,
+    ]
 
     return cmd
 

--- a/backend/engine/utils/plugin.py
+++ b/backend/engine/utils/plugin.py
@@ -394,6 +394,7 @@ def run_plugin(
                 stop_command,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
+                encoding="utf-8",
                 check=False,
             )
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Stops the docker container when timeout is reached.

## Description
<!--- Describe your changes in detail -->
- Runs `docker stop <container-name>` when plugin timeout has been reached
  - Previously, we just let `subprocess.run` kill the original `docker run ...` process, but the container would still run in the background. With this change, we tell the container to stop with SIGTERM, give it the default 10s grace period, then SIGKILL if it still hasn't exited.
- As a note, this currently doesn't do anything, as no active plugins specify a timeout in their `settings.json` and we do not set a default timeout.
  - As a result, this change was tested by hardcoding the timeout to a small value.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Containers currently continue running, orphaned, after the timeout has been reached. This fixes that.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Tested in dev environment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
