### PR TITLE
Support optional access logging

### DIFF
--- a/ui/terraform/environments/example/main.tf
+++ b/ui/terraform/environments/example/main.tf
@@ -38,6 +38,10 @@ module "analyzer-ui" {
   profile           = local.profile
   cloudfront_domain = "artemis-ui.example.com"
   zone_name         = "artemis.example.com"
+
+  # Link to managed policy ID: SecurityHeadersPolicy
+  # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-response-headers-policies.html#managed-response-headers-policies-security
+  response_headers_policy_id = "67f7725c-6f97-4210-82d7-5512b31e9d03"
 }
 
 output "cloudfront_url" {

--- a/ui/terraform/modules/analyzer-ui/cloudfront.tf
+++ b/ui/terraform/modules/analyzer-ui/cloudfront.tf
@@ -105,6 +105,15 @@ resource "aws_cloudfront_distribution" "ui" {
     ssl_support_method             = "sni-only"
     minimum_protocol_version       = "TLSv1.2_2021"
   }
+
+  dynamic "logging_config" {
+    for_each = var.logging != null ? [var.logging] : []
+    content {
+      bucket          = logging_config.value.bucket
+      prefix          = logging_config.value.prefix
+      include_cookies = logging_config.value.include_cookies
+    }
+  }
 }
 
 ###############################################################################

--- a/ui/terraform/modules/analyzer-ui/variables.tf
+++ b/ui/terraform/modules/analyzer-ui/variables.tf
@@ -42,3 +42,13 @@ variable "backend_app" {
   description = "The application name for the backend deployment"
   default     = "artemis"
 }
+
+variable "logging" {
+  type = object({
+    bucket          = string
+    prefix          = string
+    include_cookies = bool
+  })
+  description = "Enable access logs. The S3 bucket must already exist. If not set, logging will be disabled."
+  default     = null
+}


### PR DESCRIPTION
## Description

Allows optional CloudFront access logging to S3.

We don't automatically create the S3 bucket for logging since different setups likely have unique logging policies -- for example, some shops may have a single bucket to unify their access log collection with specific access controls.

Also: Fixes missing `response_headers_policy_id` in the example main.tf.

## Motivation and Context

Supports enabling access logs.

## How Has This Been Tested?

Tested in nonprod environment.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
