### PR TITLE
Associate a WAFv2 WebACL with API Gateway stages

### DIFF
--- a/backend/terraform/modules/analyzer/api_groups.tf
+++ b/backend/terraform/modules/analyzer/api_groups.tf
@@ -336,7 +336,7 @@ resource "aws_lambda_permission" "groups" {
 
   # The /*/* portion grants access from any method on any resource
   # within the API Gateway "REST API".
-  source_arn = "${aws_api_gateway_deployment.api.execution_arn}/*/*"
+  source_arn = "${aws_api_gateway_stage.api.execution_arn}/*/*"
 }
 
 resource "aws_lambda_permission" "groups_members" {
@@ -347,7 +347,7 @@ resource "aws_lambda_permission" "groups_members" {
 
   # The /*/* portion grants access from any method on any resource
   # within the API Gateway "REST API".
-  source_arn = "${aws_api_gateway_deployment.api.execution_arn}/*/*"
+  source_arn = "${aws_api_gateway_stage.api.execution_arn}/*/*"
 }
 
 resource "aws_lambda_permission" "groups_keys" {
@@ -358,5 +358,5 @@ resource "aws_lambda_permission" "groups_keys" {
 
   # The /*/* portion grants access from any method on any resource
   # within the API Gateway "REST API".
-  source_arn = "${aws_api_gateway_deployment.api.execution_arn}/*/*"
+  source_arn = "${aws_api_gateway_stage.api.execution_arn}/*/*"
 }

--- a/backend/terraform/modules/analyzer/api_main.tf
+++ b/backend/terraform/modules/analyzer/api_main.tf
@@ -395,6 +395,29 @@ resource "aws_api_gateway_stage" "api" {
   stage_name    = var.api_stage
 }
 
+resource "aws_wafv2_web_acl" "api" {
+  name        = "${var.app}-acl"
+  description = "ACL for ${var.app}"
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "${var.app}-acl"
+    sampled_requests_enabled   = false
+  }
+
+  tags = var.tags
+}
+
+resource "aws_wafv2_web_acl_association" "api" {
+  resource_arn = aws_api_gateway_stage.api.arn
+  web_acl_arn  = aws_wafv2_web_acl.api.arn
+}
+
 ###############################################################################
 # Certificate and DNS
 ###############################################################################

--- a/backend/terraform/modules/analyzer/api_main.tf
+++ b/backend/terraform/modules/analyzer/api_main.tf
@@ -497,6 +497,8 @@ resource "aws_api_gateway_base_path_mapping" "api" {
   api_id      = aws_api_gateway_rest_api.api.id
   stage_name  = var.api_stage
   domain_name = aws_api_gateway_domain_name.api.*.domain_name[count.index]
+
+  depends_on = [aws_api_gateway_stage.api]
 }
 
 ################################################################################

--- a/backend/terraform/modules/analyzer/api_main.tf
+++ b/backend/terraform/modules/analyzer/api_main.tf
@@ -396,8 +396,8 @@ resource "aws_api_gateway_stage" "api" {
 }
 
 resource "aws_wafv2_web_acl" "api" {
-  name        = "${var.app}-acl"
-  description = "ACL for ${var.app}"
+  name        = "${var.app}-api-acl"
+  description = "ACL for ${var.app} API"
   scope       = "REGIONAL"
 
   default_action {
@@ -406,7 +406,7 @@ resource "aws_wafv2_web_acl" "api" {
 
   visibility_config {
     cloudwatch_metrics_enabled = false
-    metric_name                = "${var.app}-acl"
+    metric_name                = "${var.app}-api-acl"
     sampled_requests_enabled   = false
   }
 

--- a/backend/terraform/modules/analyzer/api_main.tf
+++ b/backend/terraform/modules/analyzer/api_main.tf
@@ -304,7 +304,7 @@ resource "aws_lambda_permission" "repo" {
 
   # The /*/* portion grants access from any method on any resource
   # within the API Gateway "REST API".
-  source_arn = "${aws_api_gateway_deployment.api.execution_arn}/*/*"
+  source_arn = "${aws_api_gateway_stage.api.execution_arn}/*/*"
 }
 
 resource "aws_lambda_permission" "users" {
@@ -315,7 +315,7 @@ resource "aws_lambda_permission" "users" {
 
   # The /*/* portion grants access from any method on any resource
   # within the API Gateway "REST API".
-  source_arn = "${aws_api_gateway_deployment.api.execution_arn}/*/*"
+  source_arn = "${aws_api_gateway_stage.api.execution_arn}/*/*"
 }
 
 resource "aws_lambda_permission" "users_keys" {
@@ -326,7 +326,7 @@ resource "aws_lambda_permission" "users_keys" {
 
   # The /*/* portion grants access from any method on any resource
   # within the API Gateway "REST API".
-  source_arn = "${aws_api_gateway_deployment.api.execution_arn}/*/*"
+  source_arn = "${aws_api_gateway_stage.api.execution_arn}/*/*"
 }
 
 resource "aws_lambda_permission" "users_services" {
@@ -337,7 +337,7 @@ resource "aws_lambda_permission" "users_services" {
 
   # The /*/* portion grants access from any method on any resource
   # within the API Gateway "REST API".
-  source_arn = "${aws_api_gateway_deployment.api.execution_arn}/*/*"
+  source_arn = "${aws_api_gateway_stage.api.execution_arn}/*/*"
 }
 
 resource "aws_lambda_permission" "signin" {
@@ -348,7 +348,7 @@ resource "aws_lambda_permission" "signin" {
 
   # The /*/* portion grants access from any method on any resource
   # within the API Gateway "REST API".
-  source_arn = "${aws_api_gateway_deployment.api.execution_arn}/*/*"
+  source_arn = "${aws_api_gateway_stage.api.execution_arn}/*/*"
 }
 
 resource "aws_lambda_permission" "ci-tools" {
@@ -359,7 +359,7 @@ resource "aws_lambda_permission" "ci-tools" {
 
   # The /*/* portion grants access from any method on any resource
   # within the API Gateway "REST API".
-  source_arn = "${aws_api_gateway_deployment.api.execution_arn}/*/*"
+  source_arn = "${aws_api_gateway_stage.api.execution_arn}/*/*"
 }
 
 ###############################################################################
@@ -612,7 +612,7 @@ resource "aws_lambda_permission" "authorizer" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.api-authorizer.arn
   principal     = "apigateway.amazonaws.com"
-  source_arn    = aws_api_gateway_deployment.api.execution_arn
+  source_arn    = aws_api_gateway_stage.api.execution_arn
 }
 
 ###############################################################################

--- a/backend/terraform/modules/analyzer/api_main.tf
+++ b/backend/terraform/modules/analyzer/api_main.tf
@@ -495,10 +495,8 @@ resource "aws_api_gateway_base_path_mapping" "api" {
   count = length(aws_api_gateway_domain_name.api)
 
   api_id      = aws_api_gateway_rest_api.api.id
-  stage_name  = var.api_stage
+  stage_name  = aws_api_gateway_stage.api.stage_name
   domain_name = aws_api_gateway_domain_name.api.*.domain_name[count.index]
-
-  depends_on = [aws_api_gateway_stage.api]
 }
 
 ################################################################################

--- a/backend/terraform/modules/analyzer/api_main.tf
+++ b/backend/terraform/modules/analyzer/api_main.tf
@@ -387,7 +387,12 @@ resource "aws_api_gateway_deployment" "api" {
   ]
 
   rest_api_id = aws_api_gateway_rest_api.api.id
-  stage_name  = var.api_stage
+}
+
+resource "aws_api_gateway_stage" "api" {
+  deployment_id = aws_api_gateway_deployment.api.id
+  rest_api_id   = aws_api_gateway_rest_api.api.id
+  stage_name    = var.api_stage
 }
 
 ###############################################################################
@@ -467,7 +472,7 @@ resource "aws_api_gateway_base_path_mapping" "api" {
   count = length(aws_api_gateway_domain_name.api)
 
   api_id      = aws_api_gateway_rest_api.api.id
-  stage_name  = aws_api_gateway_deployment.api.stage_name
+  stage_name  = var.api_stage
   domain_name = aws_api_gateway_domain_name.api.*.domain_name[count.index]
 }
 

--- a/backend/terraform/modules/analyzer/api_sbom.tf
+++ b/backend/terraform/modules/analyzer/api_sbom.tf
@@ -298,7 +298,7 @@ resource "aws_lambda_permission" "sbom_components" {
 
   # The /*/* portion grants access from any method on any resource
   # within the API Gateway "REST API".
-  source_arn = "${aws_api_gateway_deployment.api.execution_arn}/*/*"
+  source_arn = "${aws_api_gateway_stage.api.execution_arn}/*/*"
 }
 
 resource "aws_lambda_permission" "sbom_licenses" {
@@ -309,5 +309,5 @@ resource "aws_lambda_permission" "sbom_licenses" {
 
   # The /*/* portion grants access from any method on any resource
   # within the API Gateway "REST API".
-  source_arn = "${aws_api_gateway_deployment.api.execution_arn}/*/*"
+  source_arn = "${aws_api_gateway_stage.api.execution_arn}/*/*"
 }

--- a/backend/terraform/modules/analyzer/api_scans.tf
+++ b/backend/terraform/modules/analyzer/api_scans.tf
@@ -143,5 +143,5 @@ resource "aws_lambda_permission" "scans_batch" {
 
   # The /*/* portion grants access from any method on any resource
   # within the API Gateway "REST API".
-  source_arn = "${aws_api_gateway_deployment.api.execution_arn}/*/*"
+  source_arn = "${aws_api_gateway_stage.api.execution_arn}/*/*"
 }

--- a/backend/terraform/modules/analyzer/api_search.tf
+++ b/backend/terraform/modules/analyzer/api_search.tf
@@ -322,7 +322,7 @@ resource "aws_lambda_permission" "search_repositories" {
 
   # The /*/* portion grants access from any method on any resource
   # within the API Gateway "REST API".
-  source_arn = "${aws_api_gateway_deployment.api.execution_arn}/*/*"
+  source_arn = "${aws_api_gateway_stage.api.execution_arn}/*/*"
 }
 
 resource "aws_lambda_permission" "search_scans" {
@@ -333,7 +333,7 @@ resource "aws_lambda_permission" "search_scans" {
 
   # The /*/* portion grants access from any method on any resource
   # within the API Gateway "REST API".
-  source_arn = "${aws_api_gateway_deployment.api.execution_arn}/*/*"
+  source_arn = "${aws_api_gateway_stage.api.execution_arn}/*/*"
 }
 
 resource "aws_lambda_permission" "search_vulnerabilities" {
@@ -344,5 +344,5 @@ resource "aws_lambda_permission" "search_vulnerabilities" {
 
   # The /*/* portion grants access from any method on any resource
   # within the API Gateway "REST API".
-  source_arn = "${aws_api_gateway_deployment.api.execution_arn}/*/*"
+  source_arn = "${aws_api_gateway_stage.api.execution_arn}/*/*"
 }

--- a/backend/terraform/modules/analyzer/api_system.tf
+++ b/backend/terraform/modules/analyzer/api_system.tf
@@ -324,7 +324,7 @@ resource "aws_lambda_permission" "system_allowlist" {
 
   # The /*/* portion grants access from any method on any resource
   # within the API Gateway "REST API".
-  source_arn = "${aws_api_gateway_deployment.api.execution_arn}/*/*"
+  source_arn = "${aws_api_gateway_stage.api.execution_arn}/*/*"
 }
 
 resource "aws_lambda_permission" "system_status" {
@@ -335,7 +335,7 @@ resource "aws_lambda_permission" "system_status" {
 
   # The /*/* portion grants access from any method on any resource
   # within the API Gateway "REST API".
-  source_arn = "${aws_api_gateway_deployment.api.execution_arn}/*/*"
+  source_arn = "${aws_api_gateway_stage.api.execution_arn}/*/*"
 }
 
 resource "aws_lambda_permission" "system_services" {
@@ -346,5 +346,5 @@ resource "aws_lambda_permission" "system_services" {
 
   # The /*/* portion grants access from any method on any resource
   # within the API Gateway "REST API".
-  source_arn = "${aws_api_gateway_deployment.api.execution_arn}/*/*"
+  source_arn = "${aws_api_gateway_stage.api.execution_arn}/*/*"
 }

--- a/orchestrator/terraform/modules/heimdall/api.tf
+++ b/orchestrator/terraform/modules/heimdall/api.tf
@@ -20,10 +20,8 @@ resource "aws_api_gateway_usage_plan" "org_queue_usage" {
 
   api_stages {
     api_id = aws_api_gateway_rest_api.on_demand_api.id
-    stage  = var.api_stage
+    stage  = aws_api_gateway_stage.on_demand_api.stage_name
   }
-
-  depends_on = [aws_api_gateway_stage.on_demand_api]
 }
 
 resource "aws_api_gateway_usage_plan_key" "org-queue-plan-key" {
@@ -162,9 +160,7 @@ resource "aws_api_gateway_domain_name" "heimdall" {
 
 resource "aws_api_gateway_base_path_mapping" "on_demand" {
   api_id      = aws_api_gateway_rest_api.on_demand_api.id
-  stage_name  = var.api_stage
+  stage_name  = aws_api_gateway_stage.on_demand_api.stage_name
   domain_name = aws_api_gateway_domain_name.heimdall.domain_name
   base_path   = "on_demand"
-
-  depends_on = [aws_api_gateway_stage.on_demand_api]
 }

--- a/orchestrator/terraform/modules/heimdall/api.tf
+++ b/orchestrator/terraform/modules/heimdall/api.tf
@@ -22,6 +22,8 @@ resource "aws_api_gateway_usage_plan" "org_queue_usage" {
     api_id = aws_api_gateway_rest_api.on_demand_api.id
     stage  = var.api_stage
   }
+
+  depends_on = [aws_api_gateway_stage.on_demand_api]
 }
 
 resource "aws_api_gateway_usage_plan_key" "org-queue-plan-key" {
@@ -163,4 +165,6 @@ resource "aws_api_gateway_base_path_mapping" "on_demand" {
   stage_name  = var.api_stage
   domain_name = aws_api_gateway_domain_name.heimdall.domain_name
   base_path   = "on_demand"
+
+  depends_on = [aws_api_gateway_stage.on_demand_api]
 }

--- a/orchestrator/terraform/modules/heimdall/api.tf
+++ b/orchestrator/terraform/modules/heimdall/api.tf
@@ -20,7 +20,7 @@ resource "aws_api_gateway_usage_plan" "org_queue_usage" {
 
   api_stages {
     api_id = aws_api_gateway_rest_api.on_demand_api.id
-    stage  = aws_api_gateway_deployment.on_demand_api.stage_name
+    stage  = var.api_stage
   }
 }
 
@@ -59,7 +59,7 @@ resource "aws_lambda_permission" "on_demand" {
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.org-queue.arn
   principal     = "apigateway.amazonaws.com"
-  source_arn    = "${aws_api_gateway_deployment.on_demand_api.execution_arn}/*/on_demand"
+  source_arn    = "${aws_api_gateway_stage.on_demand_api.execution_arn}/*/on_demand"
 }
 
 # Deployment
@@ -70,7 +70,35 @@ resource "aws_api_gateway_deployment" "on_demand_api" {
   ]
 
   rest_api_id = aws_api_gateway_rest_api.on_demand_api.id
-  stage_name  = var.api_stage
+}
+
+resource "aws_api_gateway_stage" "on_demand_api" {
+  deployment_id = aws_api_gateway_deployment.on_demand_api.id
+  rest_api_id   = aws_api_gateway_rest_api.on_demand_api.id
+  stage_name    = var.api_stage
+}
+
+resource "aws_wafv2_web_acl" "on_demand_api" {
+  name        = "${var.app}-on-demand-api-acl"
+  description = "ACL for ${var.app} On-Demand API"
+  scope       = "REGIONAL"
+
+  default_action {
+    allow {}
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = false
+    metric_name                = "${var.app}-on-demand-api-acl"
+    sampled_requests_enabled   = false
+  }
+
+  tags = var.tags
+}
+
+resource "aws_wafv2_web_acl_association" "on_demand_api" {
+  resource_arn = aws_api_gateway_stage.on_demand_api.arn
+  web_acl_arn  = aws_wafv2_web_acl.on_demand_api.arn
 }
 
 ###############################################################################
@@ -132,7 +160,7 @@ resource "aws_api_gateway_domain_name" "heimdall" {
 
 resource "aws_api_gateway_base_path_mapping" "on_demand" {
   api_id      = aws_api_gateway_rest_api.on_demand_api.id
-  stage_name  = aws_api_gateway_deployment.on_demand_api.stage_name
+  stage_name  = var.api_stage
   domain_name = aws_api_gateway_domain_name.heimdall.domain_name
   base_path   = "on_demand"
 }


### PR DESCRIPTION
## Description

This associates a WAFv2 WebACL with the API Gateway stages in both the backend and orchestrator.  The WebACL is shipped with no rules by default; it is effectively a placeholder to allow rapid deployment of WAF rules in response to live incidents.

As part of this, we're also migrating from the deprecated `aws_api_gateway_deployment.stage_name` arg to `aws_api_gateway_stage`.

## Motivation and Context

Provide a pre-associated WAFv2 WebACL for incident response.

## How Has This Been Tested?

Deployed to non-prod environment.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
