### PR TITLE
Enable access logging for API Gateway stages

### DIFF
--- a/backend/terraform/modules/analyzer/variables.tf
+++ b/backend/terraform/modules/analyzer/variables.tf
@@ -54,6 +54,12 @@ variable "api_stage" {
   description = "API stage name"
 }
 
+variable "api_log_retention_period" {
+  description = "API log retention period (days)"
+  type        = number
+  default     = 30
+}
+
 variable "db_kms_key" {
   description = "KMS key ID for database encryption"
 }

--- a/orchestrator/terraform/modules/heimdall/api.tf
+++ b/orchestrator/terraform/modules/heimdall/api.tf
@@ -76,6 +76,15 @@ resource "aws_api_gateway_stage" "on_demand_api" {
   deployment_id = aws_api_gateway_deployment.on_demand_api.id
   rest_api_id   = aws_api_gateway_rest_api.on_demand_api.id
   stage_name    = var.api_stage
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.on_demand_api.arn
+
+    # Common Log Format (CLF)
+    format = "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime]\"$context.httpMethod $context.resourcePath $context.protocol\" $context.status $context.responseLength $context.requestId $context.extendedRequestId"
+  }
+
+  depends_on = [aws_cloudwatch_log_group.on_demand_api]
 }
 
 resource "aws_wafv2_web_acl" "on_demand_api" {
@@ -163,4 +172,19 @@ resource "aws_api_gateway_base_path_mapping" "on_demand" {
   stage_name  = aws_api_gateway_stage.on_demand_api.stage_name
   domain_name = aws_api_gateway_domain_name.heimdall.domain_name
   base_path   = "on_demand"
+}
+
+################################################################################
+# Logging
+################################################################################
+
+resource "aws_cloudwatch_log_group" "on_demand_api" {
+  # Name should match the standard API Gateway naming convention.
+  # If the log group was previously automatically created by API Gateway, this
+  # resource must be imported first.
+  name = "API-Gateway-Execution-Logs_${var.app}-on-demand-api/${var.api_stage}"
+
+  retention_in_days = var.api_log_retention_period
+
+  tags = var.tags
 }

--- a/orchestrator/terraform/modules/heimdall/variables.tf
+++ b/orchestrator/terraform/modules/heimdall/variables.tf
@@ -49,6 +49,12 @@ variable "api_stage" {
   description = "API stage name"
 }
 
+variable "api_log_retention_period" {
+  description = "API log retention period (days)"
+  type        = number
+  default     = 30
+}
+
 variable "scan_orgs" {
   description = "Orgs to queue scans for"
   default     = []


### PR DESCRIPTION
## Description

Enables [access logs for the API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html) stages for artemis-rest-api and heimdall-on-demand-api.

The log format is [CLF (Common Log Format)](https://httpd.apache.org/docs/current/logs.html#common) to make it easier out-of-the-box for log aggregators to parse the logs.

Note that additional account-wide manual configuration is required outside of Terraform to enable API Gateway to send logs to CloudWatch: [Permissions for CloudWatch logging](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html#set-up-access-logging-permissions)

## Motivation and Context

Improve ability to debug and analyze REST API calls.

## How Has This Been Tested?

Tested in non-prod environment.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
