### PR TITLE
Fix `is_valid_timestamp` for strings with timezone

### DIFF
--- a/orchestrator/lambdas/layers/heimdall_utils/heimdall_utils/utils.py
+++ b/orchestrator/lambdas/layers/heimdall_utils/heimdall_utils/utils.py
@@ -3,7 +3,7 @@ import json
 import logging
 import time
 from collections import namedtuple
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from json import JSONDecodeError
 from typing import Optional
 
@@ -133,6 +133,6 @@ def is_valid_timestamp(timestamp: str) -> bool:
 
 
 def get_datetime_from_past(days: int) -> datetime:
-    current_timestamp = datetime.now()
+    current_timestamp = datetime.now(timezone.utc)
     three_months_ago = current_timestamp - timedelta(days=days)
     return three_months_ago

--- a/orchestrator/lambdas/layers/heimdall_utils/heimdall_utils/utils.py
+++ b/orchestrator/lambdas/layers/heimdall_utils/heimdall_utils/utils.py
@@ -109,7 +109,6 @@ def parse_timestamp(timestamp: Optional[str] = None) -> str:
 
     Notes:
         - The function uses the current system time to calculate the 3-month offset.
-        - All returned timestamps are in UTC (denoted by the 'Z' suffix).
     """
     if timestamp and is_valid_timestamp(timestamp):
         return timestamp

--- a/orchestrator/lambdas/layers/heimdall_utils/heimdall_utils/utils.py
+++ b/orchestrator/lambdas/layers/heimdall_utils/heimdall_utils/utils.py
@@ -17,7 +17,7 @@ logging.getLogger("urllib3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)
 
 DYNAMODB_TTL_DAYS = 60
-TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
+TIMESTAMP_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 
 
 # -- This constant represents the maximum age for a HEIMDALL Scan --

--- a/orchestrator/lambdas/layers/heimdall_utils/heimdall_utils/utils.py
+++ b/orchestrator/lambdas/layers/heimdall_utils/heimdall_utils/utils.py
@@ -102,7 +102,7 @@ def parse_timestamp(timestamp: Optional[str] = None) -> str:
     Examples:
         >>> parse_timestamp()
         {"level":"DEBUG","location":"parse_timestamp","message":"Generating Default timestamp"}
-        "2024-04-24T22:35:36Z"  # Output will vary based on the current date and time
+        "2024-01-01T6:14:57-0800"  # Output will vary based on the current date, time, and timezone
 
         >>> parse_timestamp("2024-06-24T22:50:00Z")
         "2024-06-24T22:50:00Z"

--- a/orchestrator/lambdas/tests/test_utils.py
+++ b/orchestrator/lambdas/tests/test_utils.py
@@ -28,7 +28,7 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(test_dict, result)
 
     def test_is_valid_timestamp_utc(self):
-        # Checks relative to current time plus a max scan age.
+        # Checks relative to current time minus a max scan age.
         # Make sure to change this before 9998
         time = "9999-01-01T00:00:00Z"
         self.assertTrue(utils.is_valid_timestamp(time))

--- a/orchestrator/lambdas/tests/test_utils.py
+++ b/orchestrator/lambdas/tests/test_utils.py
@@ -30,15 +30,11 @@ class TestUtils(unittest.TestCase):
     def test_is_valid_timestamp_utc(self):
         # Checks relative to current time plus a max scan age.
         # Make sure to change this before 9998
-        time = "9999-01-01T00:00:00Z";
-
-        self.assertTrue(utils.is_valid_timestamp(time));
+        time = "9999-01-01T00:00:00Z"
+        self.assertTrue(utils.is_valid_timestamp(time))
 
     def test_is_valid_timestamp_localized(self):
         # Checks relative to current time minus a max scan age.
         # Make sure to change this before 9998
-        time = "9999-01-01T00:00:00-08:00";
-
-        self.assertTrue(utils.is_valid_timestamp(time));
-
-        
+        time = "9999-01-01T00:00:00-08:00"
+        self.assertTrue(utils.is_valid_timestamp(time))

--- a/orchestrator/lambdas/tests/test_utils.py
+++ b/orchestrator/lambdas/tests/test_utils.py
@@ -26,3 +26,19 @@ class TestUtils(unittest.TestCase):
         result = self.json_utils.get_json_from_response(json.dumps(test_dict))
 
         self.assertEqual(test_dict, result)
+
+    def test_is_valid_timestamp_utc(self):
+        # Checks relative to current time plus a max scan age.
+        # Make sure to change this before 9998
+        time = "9999-01-01T00:00:00Z";
+
+        self.assertTrue(utils.is_valid_timestamp(time));
+
+    def test_is_valid_timestamp_localized(self):
+        # Checks relative to current time minus a max scan age.
+        # Make sure to change this before 9998
+        time = "9999-01-01T00:00:00-08:00";
+
+        self.assertTrue(utils.is_valid_timestamp(time));
+
+        


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Timestamp format was `%Y-%m-%dT%H:%M:%SZ`
  - This works fine with times in UTC (with a "Z" at the end), but doesn't parse non-UTC timezones
- Gitlab seems to not use UTC. This example was taken from their docs: `2024-06-28T03:44:20-07:00`
  - This would fail with the previous timestamp format

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Previously, this bug would cause issues retrieving timestamp information for Gitlab.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in dev environment and by crafting strings

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
