### PR TITLE
Add option to enable RDS IAM DB auth

### DIFF
--- a/backend/terraform/modules/analyzer/db.tf
+++ b/backend/terraform/modules/analyzer/db.tf
@@ -21,6 +21,9 @@ resource "aws_rds_cluster" "aurora" {
   vpc_security_group_ids          = [aws_security_group.db.id]
   final_snapshot_identifier       = "final-${local.db_prefix}-${random_id.rds_snapshot_identifier.hex}"
 
+  # Note: The Engine does not use IAM authentication, regardless of this setting.
+  iam_database_authentication_enabled = var.db_iam_authentication_enabled
+
   tags = merge(
     var.tags,
     {
@@ -79,7 +82,7 @@ resource "random_id" "rds_snapshot_identifier" {
   }
 }
 
-############################ 
+############################
 # Aurora Cluster Instance ##
 ############################
 resource "aws_rds_cluster_instance" "cluster_instance" {

--- a/backend/terraform/modules/analyzer/variables.tf
+++ b/backend/terraform/modules/analyzer/variables.tf
@@ -86,6 +86,17 @@ variable "db_ca_cert_identifier" {
   default     = "rds-ca-ecc384-g1"
 }
 
+variable "db_iam_authentication_enabled" {
+  description = <<EOD
+Enable IAM database authentication.
+
+Note: This does not affect how the Engine or API lambdas connect to the database.
+This option is to enable direct connections by users for debugging or maintenance using IAM roles.
+EOD
+  type        = bool
+  default     = false
+}
+
 variable "ui_origin_url" {
   description = "Origin URL for the UI"
 }


### PR DESCRIPTION
## Description

Adds an option to enable [IAM authentication to the RDS cluster](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/UsingWithRDS.IAMDBAuth.Connecting.html).

Enabling this option does not affect how Artemis connects to the database, it just enables an alternate method for admins to connect to the database.

## Motivation and Context

This option may be required by organization security policy.

## How Has This Been Tested?

Deployed to non-prod environment.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
