### PR TITLE
Set tags on the Engine EBS volumes

### DIFF
--- a/backend/terraform/modules/analyzer/modules/engine_cluster/main.tf
+++ b/backend/terraform/modules/analyzer/modules/engine_cluster/main.tf
@@ -110,6 +110,17 @@ resource "aws_launch_template" "engine-template" {
     )
   }
 
+  tag_specifications {
+    resource_type = "volume"
+
+    tags = merge(
+      var.tags,
+      {
+        Name = "Artemis Engine ${var.name}"
+      }
+    )
+  }
+
   tags = merge(
     var.tags,
     {


### PR DESCRIPTION
## Description

Sets tags on the EBS volumes attached to the Engine EC2 instances.

## Motivation and Context

Identify the EBS volumes as belonging to the Artemis Engine instances. This will make it easier to determine which EBS volumes don't belong to Artemis.

## How Has This Been Tested?

TODO

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
