### PR TITLE
Enable custom API log formats

### DIFF
--- a/backend/terraform/modules/analyzer/api_main.tf
+++ b/backend/terraform/modules/analyzer/api_main.tf
@@ -397,9 +397,7 @@ resource "aws_api_gateway_stage" "api" {
 
   access_log_settings {
     destination_arn = aws_cloudwatch_log_group.api.arn
-
-    # Common Log Format (CLF)
-    format = "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime]\"$context.httpMethod $context.resourcePath $context.protocol\" $context.status $context.responseLength $context.requestId $context.extendedRequestId"
+    format          = var.api_log_format
   }
 
   depends_on = [aws_cloudwatch_log_group.api]

--- a/backend/terraform/modules/analyzer/variables.tf
+++ b/backend/terraform/modules/analyzer/variables.tf
@@ -60,6 +60,12 @@ variable "api_log_retention_period" {
   default     = 30
 }
 
+variable "api_log_format" {
+  description = "API log format. Default is Common Log Format (CLF)."
+  type        = string
+  default     = "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime]\"$context.httpMethod $context.resourcePath $context.protocol\" $context.status $context.responseLength $context.requestId $context.extendedRequestId"
+}
+
 variable "db_kms_key" {
   description = "KMS key ID for database encryption"
 }

--- a/orchestrator/terraform/modules/heimdall/api.tf
+++ b/orchestrator/terraform/modules/heimdall/api.tf
@@ -79,9 +79,7 @@ resource "aws_api_gateway_stage" "on_demand_api" {
 
   access_log_settings {
     destination_arn = aws_cloudwatch_log_group.on_demand_api.arn
-
-    # Common Log Format (CLF)
-    format = "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime]\"$context.httpMethod $context.resourcePath $context.protocol\" $context.status $context.responseLength $context.requestId $context.extendedRequestId"
+    format          = var.api_log_format
   }
 
   depends_on = [aws_cloudwatch_log_group.on_demand_api]

--- a/orchestrator/terraform/modules/heimdall/variables.tf
+++ b/orchestrator/terraform/modules/heimdall/variables.tf
@@ -55,6 +55,12 @@ variable "api_log_retention_period" {
   default     = 30
 }
 
+variable "api_log_format" {
+  description = "API log format. Default is Common Log Format (CLF)."
+  type        = string
+  default     = "$context.identity.sourceIp $context.identity.caller $context.identity.user [$context.requestTime]\"$context.httpMethod $context.resourcePath $context.protocol\" $context.status $context.responseLength $context.requestId $context.extendedRequestId"
+}
+
 variable "scan_orgs" {
   description = "Orgs to queue scans for"
   default     = []


### PR DESCRIPTION
## Description

Allows the API Gateway access log format to be customized.

The default remains the same (common log format).

## Motivation and Context

Integration with security/monitoring tools may require a tool-specific custom log format (such as JSON).

## How Has This Been Tested?

Ran `terraform plan` and verified no changes to non-prod environment.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
