### PR TITLE
Clean up Terraform deprecation warning for aws_cloudwatch_event_rule

### DIFF
--- a/orchestrator/terraform/modules/scheduler/main.tf
+++ b/orchestrator/terraform/modules/scheduler/main.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudwatch_event_rule" "schedule" {
   name                = "${var.app}-run-${var.name}-scan"
   description         = var.description
-  is_enabled          = var.enabled
+  state               = var.enabled ? "ENABLED" : "DISABLED"
   schedule_expression = var.schedule_expression
 }
 


### PR DESCRIPTION
## Description

`aws_cloudwatch_event_rule.is_enabled` has been deprecated in favor of `state`.  See: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule#is_enabled-1

## Motivation and Context

Clean up Terraform warning.

## How Has This Been Tested?

Ran `terraform plan` and confirmed no changes and no warnings.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
