### PR TITLE
Fix how Trufflehog plugin handles findings in commit messages

### DIFF
--- a/backend/engine/plugins/trufflehog/main.py
+++ b/backend/engine/plugins/trufflehog/main.py
@@ -97,8 +97,8 @@ def scrub_results(scan_results: list, error_dict: dict) -> dict:
 
         path = source_metadata.get("file")
 
-        # `path` can be None if finding is from a commit message, since it will not have a "file"
-        # property
+        # `path` can be None if finding is from a commit message, since the finding's
+        # `source_metadata` will not have a "file" property
         if path:
             for prefix in STARTS:
                 if path.startswith(prefix):

--- a/backend/engine/plugins/trufflehog/main.py
+++ b/backend/engine/plugins/trufflehog/main.py
@@ -96,9 +96,8 @@ def scrub_results(scan_results: list, error_dict: dict) -> dict:
             continue
 
         path = source_metadata.get("file")
+        line = source_metadata.get("line")
 
-        # `path` can be None if finding is from a commit message, since the finding's
-        # `source_metadata` will not have a "file" property
         if path:
             for prefix in STARTS:
                 if path.startswith(prefix):
@@ -106,6 +105,15 @@ def scrub_results(scan_results: list, error_dict: dict) -> dict:
             for suffix in ENDS:
                 if path.endswith(suffix):
                     add_to_list = False
+        else:
+            # `path` can be None if finding is from a commit message, since the finding's
+            # `source_metadata` will not have a "file" property.
+            # - Set `path` to `commit_message` to follow the pattern for non-file secrets in the
+            #   `ghas_secrets`` plugin
+            # - Set `line` to 0, as it will otherwise refer to the line in the commit message
+            #   instead of the line of code
+            path = "commit_message"
+            line = 0
 
         if add_to_list:
             item_id = str(uuid.uuid4())
@@ -119,7 +127,7 @@ def scrub_results(scan_results: list, error_dict: dict) -> dict:
             record_json = {
                 "id": item_id,
                 "filename": path,
-                "line": source_metadata.get("line"),
+                "line": line,
                 "commit": source_metadata.get("commit"),
                 "type": get_finding_type(record),
                 "author": source_metadata.get("email"),

--- a/backend/engine/plugins/trufflehog/main.py
+++ b/backend/engine/plugins/trufflehog/main.py
@@ -97,12 +97,15 @@ def scrub_results(scan_results: list, error_dict: dict) -> dict:
 
         path = source_metadata.get("file")
 
-        for prefix in STARTS:
-            if path.startswith(prefix):
-                add_to_list = False
-        for suffix in ENDS:
-            if path.endswith(suffix):
-                add_to_list = False
+        # `path` can be None if finding is from a commit message, since it will not have a "file"
+        # property
+        if path:
+            for prefix in STARTS:
+                if path.startswith(prefix):
+                    add_to_list = False
+            for suffix in ENDS:
+                if path.endswith(suffix):
+                    add_to_list = False
 
         if add_to_list:
             item_id = str(uuid.uuid4())

--- a/backend/engine/plugins/trufflehog/main.py
+++ b/backend/engine/plugins/trufflehog/main.py
@@ -108,8 +108,8 @@ def scrub_results(scan_results: list, error_dict: dict) -> dict:
         else:
             # `path` can be None if finding is from a commit message, since the finding's
             # `source_metadata` will not have a "file" property.
-            # - Set `path` to `commit_message` to follow the pattern for non-file secrets in the
-            #   `ghas_secrets`` plugin
+            # - Set `path` to "commit_message" to follow the pattern for non-file secrets in the
+            #   `ghas_secrets` plugin
             # - Set `line` to 0, as it will otherwise refer to the line in the commit message
             #   instead of the line of code
             path = "commit_message"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes how the Trufflehog plugin handles findings in commit messages

## Description
<!--- Describe your changes in detail -->
- Trufflehog can search commit messages (neat!)
- When Trufflehog finds a potential secret in commit messages, it doesn't provide anything for the `file` property.
- We weren't checking that the value in the `file` property is not `None`, so we'd error out there. This PR fixes that

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Stability fix

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests pass; working in dev environment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
