### PR TITLE
Install latest patch version of Docker in engine nodes

### DIFF
--- a/backend/terraform/modules/analyzer/modules/engine_cluster/templates/user_data/engine.sh
+++ b/backend/terraform/modules/analyzer/modules/engine_cluster/templates/user_data/engine.sh
@@ -49,7 +49,7 @@ yum -y update
 
 # Install dependencies
 yum -y install jq
-yum -y install docker-25.0.3
+yum -y install 'docker-25.0.*'
 
 # Allow ec2-user to use docker
 usermod -a -G docker ec2-user


### PR DESCRIPTION
## Description

Instead of pinning to a specific patch version, allow Yum to install the latest patch version of Docker 25.0 to include security updates.  Currently, this is 25.0.8, which includes security updates from the previous version 25.0.3.

## Motivation and Context

Include security updates to Docker without unexpected major/minor updates.

## How Has This Been Tested?

Tested in nonprod environment.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
