### PR TITLE
Update Terraform configurations to ignore certain fields

### DIFF
--- a/backend/terraform/modules/analyzer/messaging.tf
+++ b/backend/terraform/modules/analyzer/messaging.tf
@@ -126,7 +126,12 @@ resource "aws_cloudwatch_event_rule" "every-minute" {
   name                = "${var.app}-run-every-minute"
   description         = "Event that fires every minute"
   schedule_expression = "rate(1 minute)"
-  state               = !var.enable_task_queue_metrics ? "ENABLED" : "DISABLED"
+  state               = "DISABLED"
+  lifecycle {
+    ignore_changes = [
+      state
+    ]
+  }
 }
 
 resource "aws_cloudwatch_event_target" "queue-metrics" {

--- a/backend/terraform/modules/analyzer/variables.tf
+++ b/backend/terraform/modules/analyzer/variables.tf
@@ -398,11 +398,6 @@ variable "repo_handler_environment_variables" {
   default     = {}
 }
 
-variable "enable_task_queue_metrics" {
-  description = "Whether to enable the task-queue-metrics Lambda"
-  default     = false
-}
-
 ################################################
 # Engine Cluster Customization
 ################################################

--- a/orchestrator/terraform/modules/heimdall/lambdas.tf
+++ b/orchestrator/terraform/modules/heimdall/lambdas.tf
@@ -437,6 +437,13 @@ resource "aws_cloudwatch_event_rule" "repo-scan-loop-rate" {
   description         = "The rate at which repo-scan-loop lambda runs"
   schedule_expression = var.repo_scan_loop_rate
   state               = var.scanning_enabled ? "ENABLED" : "DISABLED"
+
+  lifecycle {
+    ignore_changes = [
+      schedule_expression
+    ]
+  }
+
   tags = merge(
     var.tags,
     {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR Updates the terraform configurations to ignore updates to: 
- The `schedule_expression` in the `heimdall-repo-scan-loop-rate` cloudwatch rule
- The `state` for the `artemis-run-every-minute` cloudwatch rule

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

This PR will allow users to update these configurations without them being overwritten by new terraform updates. 



## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
ran `terraform plan` locally

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Pic
![Embed something funny here](https://giphy.com/trending-gifs)