### PR TITLE
Improve parsing of findsecbugs results

### DIFF
--- a/backend/engine/plugins/lib/findsecbugs_common/parsing_util.py
+++ b/backend/engine/plugins/lib/findsecbugs_common/parsing_util.py
@@ -23,12 +23,14 @@ def parse_cli_output(output_list):
 
 
 def parse_line(output: str) -> tuple[str, str, str]:
-    split = output.split(":")
+    seperator = ":"
+
+    split = output.split(seperator)
     split_len = len(split)
 
     if split_len >= 3:
         output_type = split[0]
-        message_and_file = ":".join(split[1:-1])
+        message_and_file = seperator.join(split[1:-1])
         line_text = split[-1]
     elif split_len == 2:
         output_type, message_and_file = split
@@ -36,16 +38,18 @@ def parse_line(output: str) -> tuple[str, str, str]:
         # So, we set `line_text` to empty string
         line_text = ""
     else:  # split_len < 2
-        raise Exception(f"Unexpected case. 1 or fewer ':' in output line: {output}")
+        raise Exception(f'Unexpected case. 1 or fewer "{seperator}" in output line: {output}')
 
     return output_type, message_and_file, line_text
 
 
 def parse_message_and_file(output: str) -> tuple[str, str]:
-    split = output.split("At ")
+    seperator = "At "
+
+    split = output.split(seperator)
 
     if len(split) >= 2:
-        message = "At ".join(split[0:-1])
+        message = seperator.join(split[0:-1])
         filename = split[-1]
     else:
         message = output

--- a/backend/engine/plugins/lib/findsecbugs_common/parsing_util.py
+++ b/backend/engine/plugins/lib/findsecbugs_common/parsing_util.py
@@ -33,8 +33,8 @@ def parse_line(output: str) -> tuple[str, str, str]:
     elif split_len == 2:
         output_type, message_and_file = split
         # In at least one case, split_len is 2 because no line number is provided.
-        # So, we set `line_text` to -1 as it will be parsed into an integer.
-        line_text = "-1"
+        # So, we set `line_text` to empty string
+        line_text = ""
     else:  # split_len < 2
         raise Exception(f"Unexpected case. 1 or fewer ':' in output line: {output}")
 

--- a/backend/engine/plugins/lib/findsecbugs_common/parsing_util.py
+++ b/backend/engine/plugins/lib/findsecbugs_common/parsing_util.py
@@ -53,7 +53,7 @@ def parse_message_and_file(output: str) -> tuple[str, str]:
         filename = split[-1]
     else:
         message = output
-        filename = "Not provided"
+        filename = "Unknown"
 
     return message, filename
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Improves the parsing of findsecbugs results

## Description
<!--- Describe your changes in detail -->
- The Findsecbugs plugins would fail if results had anything other than exactly two colons (`:`) or was lacking a filename. This handles those cases
- The one case that isn't handled is if there are no colons in the line. I could not get this to trigger in my testing, so it would be unclear how we should parse the line in that case. Instead, we raise a specific exception so that we can easily debug.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Findsecbugs was crashing frequently and this handles those cases more gracefully.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Working in dev environment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
