### PR TITLE
Fix Docker deprecation warning when building images

### DIFF
--- a/backend/Dockerfiles/Dockerfile.engine
+++ b/backend/Dockerfiles/Dockerfile.engine
@@ -57,6 +57,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && apt-get upgrade -y \
     && apt-get upgrade -y -o Dir::Etc::Sourcelist=/etc/apt/security.sources.list \
     && apt-get install -y --no-install-recommends \
+        docker-buildx-plugin \
         docker-ce-cli \
         git \
         openssh-client \


### PR DESCRIPTION
## Description

Install the Docker buildx (aka [BuildKit](https://docs.docker.com/build/buildkit/)) plugin in the engine container. Docker will use BuildKit as the default builder when the engine attempts to build container images during a scan.

## Motivation and Context

This fixes the Docker warning in the engine logs:

> DEPRECATED: The legacy builder is deprecated and will be removed in a future release.

## How Has This Been Tested?

Tested in non-prod environment.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
