### PR TITLE
Handle exception in users lambdas

### DIFF
--- a/backend/lambdas/api/users_keys/users_keys/util/parsers.py
+++ b/backend/lambdas/api/users_keys/users_keys/util/parsers.py
@@ -42,7 +42,10 @@ def parse_event(event):
 
 
 def parse_body(event, admin, features, user_id):
-    body = json.loads(event.get("body") or "{}")
+    try:
+        body = json.loads(event.get("body") or "{}")
+    except json.JSONDecodeError as e:
+        raise ValidationError("Error decoding json") from e
 
     for field in ["name", "scope"]:
         if field not in body:

--- a/backend/lambdas/api/users_services/users_services/util/parsers.py
+++ b/backend/lambdas/api/users_services/users_services/util/parsers.py
@@ -30,7 +30,10 @@ def parse_event(event):
 
 
 def parse_body(event, admin):
-    body = json.loads(event.get("body") or "{}")
+    try:
+        body = json.loads(event.get("body") or "{}")
+    except json.JSONDecodeError as e:
+        raise ValidationError("Error decoding json") from e
 
     for field in ["name", "params"]:
         if field not in body:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Handles `JSONDecodeError`s in the users lambdas

## Description
<!--- Describe your changes in detail -->
- `users_keys` and `users_services` would occasionally raise a `JSONDecodeError` with message `Expecting value: line 1 column 1 (char 0)`. We can reproduce this error message outside of Artemis with `python -c "import json; json.loads('')"`, implying the problem is when the body is empty string.
- The existing `or "{}"` should cover this case, as empty string is falsey. So, something else is going. That said, any `JSONDecodeError` should be treated as validation failing, so we handle that case generically by raising `ValidationError` instead of handling this particular error.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- These lambdas were occasionally crashing with errors. This PR handles the underlying error that caused these crashes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Working in dev environment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
