### PR TITLE
Explicitly set permissions for jobs

### DIFF
--- a/.github/workflows/test_backend.yml
+++ b/.github/workflows/test_backend.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # actions/checkout@v4.2.2
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # actions/setup-python@v5.6.0

--- a/.github/workflows/test_orchestrator.yml
+++ b/.github/workflows/test_orchestrator.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # actions/checkout@v4.2.2
       - name: setup python environment

--- a/.github/workflows/test_ui.yml
+++ b/.github/workflows/test_ui.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   test:
     runs-on: artemis-ui-test-runner-4
+    permissions:
+      contents: read
     env:
       UI_PATH: ./ui
       HADOLINT_URL: https://github.com/hadolint/hadolint/releases/download/v2.10.0/hadolint-Linux-x86_64


### PR DESCRIPTION
## Description

Explicitly sets the `permissions` block for each GitHub Actions job.

## Motivation and Context

Resolves CodeQL "Workflow does not contain permissions" findings.

## How Has This Been Tested?

Tested workflows via this PR.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
