### PR TITLE
Modify ADO to obey `nat_connect` from `services.json`

### DIFF
--- a/backend/lambdas/api/repo/repo/post.py
+++ b/backend/lambdas/api/repo/repo/post.py
@@ -125,7 +125,12 @@ def post_repo(event_parser: EventParser, identity=None):
         )
     elif service_type == "ado":
         s_response = process_ado(
-            req_list, event["service_id"], service_dict.get("url"), service_dict.get("secret_loc"), identity=identity
+            req_list,
+            event["service_id"],
+            service_dict.get("url"),
+            service_dict.get("secret_loc"),
+            service_dict.get("nat_connect"),
+            identity=identity,
         )
     else:
         s_response = PROCESS_RESPONSE_TUPLE([], [], [])

--- a/backend/lambdas/api/repo/repo/services/ado.py
+++ b/backend/lambdas/api/repo/repo/services/ado.py
@@ -25,13 +25,26 @@ ADO_DIFF_QUERY = (
 )
 
 
-def process_ado(req_list: list, service: str, service_url: str, service_secret: str, identity: Identity):
+def process_ado(
+    req_list: list,
+    service: str,
+    service_url: str,
+    service_secret: str,
+    nat_connect: bool,
+    identity: Identity,
+):
     options_map = build_options_map(req_list)
-    return _query(req_list, options_map, service, service_url, service_secret, identity=identity)
+    return _query(req_list, options_map, service, service_url, service_secret, nat_connect, identity=identity)
 
 
 def _query(
-    req_list: list, options_map: dict, service: str, service_url: str, service_secret: str, identity: Identity
+    req_list: list,
+    options_map: dict,
+    service: str,
+    service_url: str,
+    service_secret: str,
+    nat_connect: bool,
+    identity: Identity,
 ) -> PROCESS_RESPONSE_TUPLE:
     unauthorized = []
     queued = []
@@ -87,7 +100,9 @@ def _query(
 
         log.info("Queuing repo")
 
-        scan_id = _queue_repo(service, org_repo, repo_dict, branch_name, options_map[org_repo], identity=identity)
+        scan_id = _queue_repo(
+            service, org_repo, repo_dict, branch_name, options_map[org_repo], nat_connect, identity=identity
+        )
         full_scan_id = f"{org_repo}/{scan_id}"
         queued.append(full_scan_id)
         log.info("Queued %s", full_scan_id)
@@ -145,7 +160,15 @@ def _get_api_response_error(status_code: int, response_dict: dict or None) -> st
     return default_error
 
 
-def _queue_repo(service: str, org_repo: str, repo: dict, branch_name: str, options: dict, identity: Identity) -> str:
+def _queue_repo(
+    service: str,
+    org_repo: str,
+    repo: dict,
+    branch_name: str,
+    options: dict,
+    nat_connect: bool,
+    identity: Identity,
+) -> str:
     # Queue the repo
     scan_id = AWSConnect().queue_repo_for_scan(
         name=org_repo,
@@ -166,6 +189,7 @@ def _queue_repo(service: str, org_repo: str, repo: dict, branch_name: str, optio
         diff_base=options["diff_base"],
         schedule_run=options["schedule_run"],
         batch_id=options["batch_id"],
+        nat_queue=nat_connect,
         include_paths=options["include_paths"],
         exclude_paths=options["exclude_paths"],
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Azure DevOps was not obeying the `nat_connect` field in a `services.json` entry

## Description
<!--- Describe your changes in detail -->
- Azure DevOps just didn't obey the `nat_connect` field. This PR makes it do that

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- We have `nat_connect` fields, so let's use them

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Working in dev environment
- Tests pass

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
