### PR TITLE
Fix for errors when pulling ADO repositories

### DIFF
--- a/backend/engine/processor/processor.py
+++ b/backend/engine/processor/processor.py
@@ -221,6 +221,7 @@ class EngineProcessor:
             self.action_details.branch,
             self.action_details.diff_base,
             self.service_dict.get("http_basic_auth", False),
+            self.service_dict.get("append_dot_git_suffix", True),
             self.scan.get_scan_object().include_paths,
             self.scan.get_scan_object().exclude_paths,
         )

--- a/backend/engine/utils/git.py
+++ b/backend/engine/utils/git.py
@@ -33,6 +33,7 @@ def git_pull(
     branch: str = None,
     diff_base: str = None,
     http_basic_auth: bool = False,
+    append_dot_git_suffix: bool = True,
     include: list = None,
     exclude: list = None,
 ) -> bool:
@@ -50,7 +51,7 @@ def git_pull(
     url = repo
     if not public and not http_basic_auth:
         url = repo.replace("https://", "https://%s@" % api_key)
-        if not url.endswith(".git"):
+        if not url.endswith(".git") and append_dot_git_suffix:
             url += ".git"
     # !!! IMPORTANT !!!
     # Doing 'git init' then 'git pull' rather than 'git clone' so that the

--- a/backend/engine/utils/git.py
+++ b/backend/engine/utils/git.py
@@ -70,6 +70,7 @@ def git_pull(
 
     # Pull the repo
     args = ["git", "pull", url]
+    log.info(url.replace(api_key, "xxx"))
     if branch:
         args.append(branch)
     r = subprocess.run(args, cwd=base, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)

--- a/backend/engine/utils/git.py
+++ b/backend/engine/utils/git.py
@@ -71,7 +71,6 @@ def git_pull(
 
     # Pull the repo
     args = ["git", "pull", url]
-    log.info(url.replace(api_key, "xxx"))
     if branch:
         args.append(branch)
     r = subprocess.run(args, cwd=base, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False)

--- a/backend/lambdas/api/repo/repo/services/ado.py
+++ b/backend/lambdas/api/repo/repo/services/ado.py
@@ -112,10 +112,8 @@ def _query(
 
 
 def _get_repo(url: str, org_name: str, project: str, repo: str, api_key: str) -> requests.Response:
-    encoded_api_key = _base64_encode(api_key)
-
     req = Template(ADO_REPO_QUERY).substitute(service_url=url, org=org_name, project=project, repo=repo)
-    return _query_azure_api(req, encoded_api_key)
+    return _query_azure_api(req, api_key)
 
 
 def _verify_branch_exists(refs_url: str, branch: str, api_key: str) -> bool:
@@ -147,7 +145,7 @@ def _check_diff(url: str, api_key: str, org_name: str, project: str, repo: str, 
 
 
 def _query_azure_api(url: str, api_key: str) -> requests.Response:
-    headers = {"Authorization": "Basic %s" % api_key, "Accept": "application/json"}
+    headers = {"Authorization": "Basic %s" % _base64_encode(api_key), "Accept": "application/json"}
     response = requests.get(url, headers=headers)
     if response.status_code != 200:
         log.error("Error retrieving Azure query: %s", response.text)

--- a/backend/lambdas/api/repo/repo/services/ado.py
+++ b/backend/lambdas/api/repo/repo/services/ado.py
@@ -173,7 +173,7 @@ def _queue_repo(
     # Queue the repo
     scan_id = AWSConnect().queue_repo_for_scan(
         name=org_repo,
-        repo_url=repo["remoteUrl"],
+        repo_url=repo["webUrl"],
         # We need to convert from bytes to KiB
         repo_size=int(repo["size"] / 1024),
         service=service,

--- a/backend/lambdas/api/repo/repo/services/ado.py
+++ b/backend/lambdas/api/repo/repo/services/ado.py
@@ -53,7 +53,8 @@ def _query(
     if not req_list:
         return queued, failed, unauthorized
 
-    # The stored key is already in the format: user:pass
+    # The stored key is in the format: ":api_key" (username:pass, with an empty username)
+    # It is NOT base64 encoded. Encode it before using it for Basic auth
     key = get_api_key(service_secret)
 
     log.info("Querying %s API for %d repos", service, len(req_list))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fix for errors when pulling down Azure DevOps repositories

## Description
- Pulling using HTTP Basic Auth with Azure DevOps was broken. This PR makes changes to allow using the `https://<apikey>@<vcs>/` pattern with Azure DevOps
  - As a result, Azure DevOps secrets should now be stored as `:<apikey>` instead of as `base64(:<apikey>)`
- Azure DevOps does not support cloning with a `.git` suffix, so this PR adds a `append_dot_git_suffix` parameter (that defaults to `True`) to prevent the addition of the suffix

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Azure DevOps integration has been broken. This should fix it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests pass and working in dev environment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
