### PR TITLE
Fix ADO in system/services endpoint

### DIFF
--- a/backend/lambdas/api/system_services/system_services/util/service.py
+++ b/backend/lambdas/api/system_services/system_services/util/service.py
@@ -1,3 +1,4 @@
+import base64
 import functools
 import requests
 from artemisdb.artemisdb.models import Repo, Scan, User
@@ -252,7 +253,7 @@ class Service:
         self._test_bitbucket(key, service_auth_url, repo_auth_url)
 
     def _test_ado(self, key: str):
-        headers = {"Authorization": "Basic %s" % key, "Accept": "application/json"}
+        headers = {"Authorization": "Basic %s" % _base64_encode(key), "Accept": "application/json"}
         response = self._request.get(f"{self._service['url']}/{self._org}/_apis/projects", headers=headers)
         self._reachable = True
         if response.status_code == 200:
@@ -284,3 +285,7 @@ def get_api_key(service_secret):
     except ClientError:
         return None
     return None
+
+
+def _base64_encode(text: str, input_encoding="utf-8", output_encoding="utf-8") -> str:
+    return base64.b64encode(bytes(text, input_encoding)).decode(output_encoding)

--- a/backend/lambdas/api/system_services/tests/test_service.py
+++ b/backend/lambdas/api/system_services/tests/test_service.py
@@ -8,6 +8,10 @@ from system_services.util.service import Service
 from system_services.util.const import ServiceType
 
 
+MOCK_KEY = "fake_key"
+MOCK_KEY_BASE64 = "ZmFrZV9rZXk="
+
+
 class TestService(unittest.TestCase):
     @patch("system_services.util.service.get_api_key", lambda *x, **y: None)
     def test_missing_auth_key(self):
@@ -31,7 +35,7 @@ class TestService(unittest.TestCase):
 
     @responses.activate
     @patch("system_services.util.service.SERVICE_AUTH_CHECK_TIMEOUT", 123)
-    @patch("system_services.util.service.get_api_key", lambda *x, **y: "fake_key")
+    @patch("system_services.util.service.get_api_key", lambda *x, **y: MOCK_KEY)
     def test_configured_timeout(self):
         service_dict = {
             "services": {"org": {"type": ServiceType.ADO, "secret_loc": "foo", "url": "http://example.com"}}
@@ -47,7 +51,7 @@ class TestService(unittest.TestCase):
         self.assertNotEqual(actual["error"], "Connection error")
 
     @responses.activate
-    @patch("system_services.util.service.get_api_key", lambda *x, **y: "fake_key")
+    @patch("system_services.util.service.get_api_key", lambda *x, **y: MOCK_KEY)
     def test_timeout_error(self):
         service_dict = {
             "services": {"org": {"type": ServiceType.ADO, "secret_loc": "foo", "url": "http://example.com"}}
@@ -68,7 +72,7 @@ class TestService(unittest.TestCase):
         )
 
     @responses.activate
-    @patch("system_services.util.service.get_api_key", lambda *x, **y: "fake_key")
+    @patch("system_services.util.service.get_api_key", lambda *x, **y: MOCK_KEY)
     def test_connect_error(self):
         service_dict = {
             "services": {"org": {"type": ServiceType.ADO, "secret_loc": "foo", "url": "http://example.com"}}
@@ -89,7 +93,7 @@ class TestService(unittest.TestCase):
         )
 
     @responses.activate
-    @patch("system_services.util.service.get_api_key", lambda *x, **y: "fake_key")
+    @patch("system_services.util.service.get_api_key", lambda *x, **y: MOCK_KEY)
     def test_generic_request_error(self):
         service_dict = {
             "services": {"org": {"type": ServiceType.ADO, "secret_loc": "foo", "url": "http://example.com"}}
@@ -116,7 +120,7 @@ class TestADOService(unittest.TestCase):
     """Tests specific to the ADO service"""
 
     @responses.activate
-    @patch("system_services.util.service.get_api_key", lambda *x, **y: "fake_key")
+    @patch("system_services.util.service.get_api_key", lambda *x, **y: MOCK_KEY)
     def test_ado_auth_failed(self):
         service_dict = {
             "services": {"org": {"type": ServiceType.ADO, "secret_loc": "foo", "url": "http://example.com"}}
@@ -137,7 +141,7 @@ class TestADOService(unittest.TestCase):
         )
 
     @responses.activate
-    @patch("system_services.util.service.get_api_key", lambda *x, **y: "fake_key")
+    @patch("system_services.util.service.get_api_key", lambda *x, **y: MOCK_KEY)
     def test_ado_success(self):
         service_dict = {
             "services": {"org": {"type": ServiceType.ADO, "secret_loc": "foo", "url": "http://example.com"}}
@@ -146,7 +150,7 @@ class TestADOService(unittest.TestCase):
         responses.get(
             "http://example.com/repo/_apis/projects",
             status=200,
-            match=[matchers.header_matcher({"Authorization": "Basic fake_key"})],
+            match=[matchers.header_matcher({"Authorization": f"Basic {MOCK_KEY_BASE64}"})],
         )
         actual = svc.to_dict()
         self.assertEqual(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Addition to https://github.com/WarnerMedia/artemis/pull/485 to fix ADO entries in the `system/services` endpoint

## Description
<!--- Describe your changes in detail -->
- ADO services in the `system/services` endpoint were failing to authenticate successfully due to the API Key format change in https://github.com/WarnerMedia/artemis/pull/485
- This modifies the `_test_ado` function to base64 encode the API Key before use

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- ADO services were not reporting as being able to authenticate (despite being able to authenticate and pull things down just fine) due to the change in secret format.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tests pass and working in dev environment

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
