### PR TITLE
Reformat ejected CRA scripts with Prettier

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -24,7 +24,7 @@ trim_trailing_whitespace = false
 indent_style = space
 indent_size = 2
 
-[*.{go,js,jsx,ts,tsx}]
+[*.{go,js,jsx,mjs,ts,tsx}]
 indent_style = tab
 
 ; Ejected configuration from Create React App.

--- a/ui/.prettierignore
+++ b/ui/.prettierignore
@@ -1,3 +1,9 @@
-# Ignore artifacts:
-build
-coverage
+# Ignore all files by default.
+*
+
+# Source files.
+!/src/**/*.ts
+!/src/**/*.tsx
+
+# Recurse into subdirectories.
+!*/

--- a/ui/.prettierignore
+++ b/ui/.prettierignore
@@ -11,5 +11,8 @@
 !/config/**/*.js
 !/config/**/*.mjs
 
+# Ejected Create-React-App scripts.
+!/scripts/*.js
+
 # Recurse into subdirectories.
 !*/

--- a/ui/.prettierignore
+++ b/ui/.prettierignore
@@ -5,5 +5,11 @@
 !/src/**/*.ts
 !/src/**/*.tsx
 
+# Configuration files.
+!/*.js
+!/*.mjs
+!/config/**/*.js
+!/config/**/*.mjs
+
 # Recurse into subdirectories.
 !*/

--- a/ui/config/env.js
+++ b/ui/config/env.js
@@ -1,28 +1,28 @@
-'use strict';
+"use strict";
 
-const fs = require('fs');
-const path = require('path');
-const paths = require('./paths');
+const fs = require("fs");
+const path = require("path");
+const paths = require("./paths");
 
 // Make sure that including paths.js after env.js will read .env variables.
-delete require.cache[require.resolve('./paths')];
+delete require.cache[require.resolve("./paths")];
 
 const NODE_ENV = process.env.NODE_ENV;
 if (!NODE_ENV) {
-  throw new Error(
-    'The NODE_ENV environment variable is required but was not specified.'
-  );
+	throw new Error(
+		"The NODE_ENV environment variable is required but was not specified.",
+	);
 }
 
 // https://github.com/bkeepers/dotenv#what-other-env-files-can-i-use
 const dotenvFiles = [
-  `${paths.dotenv}.${NODE_ENV}.local`,
-  // Don't include `.env.local` for `test` environment
-  // since normally you expect tests to produce the same
-  // results for everyone
-  NODE_ENV !== 'test' && `${paths.dotenv}.local`,
-  `${paths.dotenv}.${NODE_ENV}`,
-  paths.dotenv,
+	`${paths.dotenv}.${NODE_ENV}.local`,
+	// Don't include `.env.local` for `test` environment
+	// since normally you expect tests to produce the same
+	// results for everyone
+	NODE_ENV !== "test" && `${paths.dotenv}.local`,
+	`${paths.dotenv}.${NODE_ENV}`,
+	paths.dotenv,
 ].filter(Boolean);
 
 // Load environment variables from .env* files. Suppress warnings using silent
@@ -30,14 +30,14 @@ const dotenvFiles = [
 // that have already been set.  Variable expansion is supported in .env files.
 // https://github.com/motdotla/dotenv
 // https://github.com/motdotla/dotenv-expand
-dotenvFiles.forEach(dotenvFile => {
-  if (fs.existsSync(dotenvFile)) {
-    require('dotenv-expand').expand(
-      require('dotenv').config({
-        path: dotenvFile,
-      })
-    );
-  }
+dotenvFiles.forEach((dotenvFile) => {
+	if (fs.existsSync(dotenvFile)) {
+		require("dotenv-expand").expand(
+			require("dotenv").config({
+				path: dotenvFile,
+			}),
+		);
+	}
 });
 
 // We support resolving modules according to `NODE_PATH`.
@@ -50,55 +50,55 @@ dotenvFiles.forEach(dotenvFile => {
 // https://github.com/facebook/create-react-app/issues/1023#issuecomment-265344421
 // We also resolve them to make sure all tools using them work consistently.
 const appDirectory = fs.realpathSync(process.cwd());
-process.env.NODE_PATH = (process.env.NODE_PATH || '')
-  .split(path.delimiter)
-  .filter(folder => folder && !path.isAbsolute(folder))
-  .map(folder => path.resolve(appDirectory, folder))
-  .join(path.delimiter);
+process.env.NODE_PATH = (process.env.NODE_PATH || "")
+	.split(path.delimiter)
+	.filter((folder) => folder && !path.isAbsolute(folder))
+	.map((folder) => path.resolve(appDirectory, folder))
+	.join(path.delimiter);
 
 // Grab NODE_ENV and REACT_APP_* environment variables and prepare them to be
 // injected into the application via DefinePlugin in webpack configuration.
 const REACT_APP = /^REACT_APP_/i;
 
 function getClientEnvironment(publicUrl) {
-  const raw = Object.keys(process.env)
-    .filter(key => REACT_APP.test(key))
-    .reduce(
-      (env, key) => {
-        env[key] = process.env[key];
-        return env;
-      },
-      {
-        // Useful for determining whether we’re running in production mode.
-        // Most importantly, it switches React into the correct mode.
-        NODE_ENV: process.env.NODE_ENV || 'development',
-        // Useful for resolving the correct path to static assets in `public`.
-        // For example, <img src={process.env.PUBLIC_URL + '/img/logo.png'} />.
-        // This should only be used as an escape hatch. Normally you would put
-        // images into the `src` and `import` them in code to get their paths.
-        PUBLIC_URL: publicUrl,
-        // We support configuring the sockjs pathname during development.
-        // These settings let a developer run multiple simultaneous projects.
-        // They are used as the connection `hostname`, `pathname` and `port`
-        // in webpackHotDevClient. They are used as the `sockHost`, `sockPath`
-        // and `sockPort` options in webpack-dev-server.
-        WDS_SOCKET_HOST: process.env.WDS_SOCKET_HOST,
-        WDS_SOCKET_PATH: process.env.WDS_SOCKET_PATH,
-        WDS_SOCKET_PORT: process.env.WDS_SOCKET_PORT,
-        // Whether or not react-refresh is enabled.
-        // It is defined here so it is available in the webpackHotDevClient.
-        FAST_REFRESH: process.env.FAST_REFRESH !== 'false',
-      }
-    );
-  // Stringify all values so we can feed into webpack DefinePlugin
-  const stringified = {
-    'process.env': Object.keys(raw).reduce((env, key) => {
-      env[key] = JSON.stringify(raw[key]);
-      return env;
-    }, {}),
-  };
+	const raw = Object.keys(process.env)
+		.filter((key) => REACT_APP.test(key))
+		.reduce(
+			(env, key) => {
+				env[key] = process.env[key];
+				return env;
+			},
+			{
+				// Useful for determining whether we’re running in production mode.
+				// Most importantly, it switches React into the correct mode.
+				NODE_ENV: process.env.NODE_ENV || "development",
+				// Useful for resolving the correct path to static assets in `public`.
+				// For example, <img src={process.env.PUBLIC_URL + '/img/logo.png'} />.
+				// This should only be used as an escape hatch. Normally you would put
+				// images into the `src` and `import` them in code to get their paths.
+				PUBLIC_URL: publicUrl,
+				// We support configuring the sockjs pathname during development.
+				// These settings let a developer run multiple simultaneous projects.
+				// They are used as the connection `hostname`, `pathname` and `port`
+				// in webpackHotDevClient. They are used as the `sockHost`, `sockPath`
+				// and `sockPort` options in webpack-dev-server.
+				WDS_SOCKET_HOST: process.env.WDS_SOCKET_HOST,
+				WDS_SOCKET_PATH: process.env.WDS_SOCKET_PATH,
+				WDS_SOCKET_PORT: process.env.WDS_SOCKET_PORT,
+				// Whether or not react-refresh is enabled.
+				// It is defined here so it is available in the webpackHotDevClient.
+				FAST_REFRESH: process.env.FAST_REFRESH !== "false",
+			},
+		);
+	// Stringify all values so we can feed into webpack DefinePlugin
+	const stringified = {
+		"process.env": Object.keys(raw).reduce((env, key) => {
+			env[key] = JSON.stringify(raw[key]);
+			return env;
+		}, {}),
+	};
 
-  return { raw, stringified };
+	return { raw, stringified };
 }
 
 module.exports = getClientEnvironment;

--- a/ui/config/getHttpsConfig.js
+++ b/ui/config/getHttpsConfig.js
@@ -1,69 +1,69 @@
-'use strict';
+"use strict";
 
-const fs = require('fs');
-const path = require('path');
-const crypto = require('crypto');
-const chalk = require('react-dev-utils/chalk');
-const paths = require('./paths');
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+const chalk = require("react-dev-utils/chalk");
+const paths = require("./paths");
 
 // Ensure the certificate and key provided are valid and if not
 // throw an easy to debug error
 function validateKeyAndCerts({ cert, key, keyFile, crtFile }) {
-  let encrypted;
-  try {
-    // publicEncrypt will throw an error with an invalid cert
-    encrypted = crypto.publicEncrypt(cert, Buffer.from('test'));
-  } catch (err) {
-    throw new Error(
-      `The certificate "${chalk.yellow(crtFile)}" is invalid.\n${err.message}`
-    );
-  }
+	let encrypted;
+	try {
+		// publicEncrypt will throw an error with an invalid cert
+		encrypted = crypto.publicEncrypt(cert, Buffer.from("test"));
+	} catch (err) {
+		throw new Error(
+			`The certificate "${chalk.yellow(crtFile)}" is invalid.\n${err.message}`,
+		);
+	}
 
-  try {
-    // privateDecrypt will throw an error with an invalid key
-    crypto.privateDecrypt(key, encrypted);
-  } catch (err) {
-    throw new Error(
-      `The certificate key "${chalk.yellow(keyFile)}" is invalid.\n${
-        err.message
-      }`
-    );
-  }
+	try {
+		// privateDecrypt will throw an error with an invalid key
+		crypto.privateDecrypt(key, encrypted);
+	} catch (err) {
+		throw new Error(
+			`The certificate key "${chalk.yellow(keyFile)}" is invalid.\n${
+				err.message
+			}`,
+		);
+	}
 }
 
 // Read file and throw an error if it doesn't exist
 function readEnvFile(file, type) {
-  if (!fs.existsSync(file)) {
-    throw new Error(
-      `You specified ${chalk.cyan(
-        type
-      )} in your env, but the file "${chalk.yellow(file)}" can't be found.`
-    );
-  }
-  return fs.readFileSync(file);
+	if (!fs.existsSync(file)) {
+		throw new Error(
+			`You specified ${chalk.cyan(
+				type,
+			)} in your env, but the file "${chalk.yellow(file)}" can't be found.`,
+		);
+	}
+	return fs.readFileSync(file);
 }
 
 // Get the https config
 // Return server HTTP / HTTPS configuration, with cert configuration if provided in env
 function getHttpsConfig() {
-  const { SSL_CRT_FILE, SSL_KEY_FILE, HTTPS } = process.env;
-  const isHttps = HTTPS === 'true';
+	const { SSL_CRT_FILE, SSL_KEY_FILE, HTTPS } = process.env;
+	const isHttps = HTTPS === "true";
 
-  if (isHttps && SSL_CRT_FILE && SSL_KEY_FILE) {
-    const crtFile = path.resolve(paths.appPath, SSL_CRT_FILE);
-    const keyFile = path.resolve(paths.appPath, SSL_KEY_FILE);
-    const config = {
-      cert: readEnvFile(crtFile, 'SSL_CRT_FILE'),
-      key: readEnvFile(keyFile, 'SSL_KEY_FILE'),
-    };
+	if (isHttps && SSL_CRT_FILE && SSL_KEY_FILE) {
+		const crtFile = path.resolve(paths.appPath, SSL_CRT_FILE);
+		const keyFile = path.resolve(paths.appPath, SSL_KEY_FILE);
+		const config = {
+			cert: readEnvFile(crtFile, "SSL_CRT_FILE"),
+			key: readEnvFile(keyFile, "SSL_KEY_FILE"),
+		};
 
-    validateKeyAndCerts({ ...config, keyFile, crtFile });
-    return {
-      server: 'https',
-      options: config,
-    };
-  }
-  return isHttps ? 'https' : 'http';
+		validateKeyAndCerts({ ...config, keyFile, crtFile });
+		return {
+			server: "https",
+			options: config,
+		};
+	}
+	return isHttps ? "https" : "http";
 }
 
 module.exports = getHttpsConfig;

--- a/ui/config/jest/babelTransform.js
+++ b/ui/config/jest/babelTransform.js
@@ -1,29 +1,29 @@
-'use strict';
+"use strict";
 
-const babelJest = require('babel-jest').default;
+const babelJest = require("babel-jest").default;
 
 const hasJsxRuntime = (() => {
-  if (process.env.DISABLE_NEW_JSX_TRANSFORM === 'true') {
-    return false;
-  }
+	if (process.env.DISABLE_NEW_JSX_TRANSFORM === "true") {
+		return false;
+	}
 
-  try {
-    require.resolve('react/jsx-runtime');
-    return true;
-  } catch (e) {
-    return false;
-  }
+	try {
+		require.resolve("react/jsx-runtime");
+		return true;
+	} catch (e) {
+		return false;
+	}
 })();
 
 module.exports = babelJest.createTransformer({
-  presets: [
-    [
-      require.resolve('babel-preset-react-app'),
-      {
-        runtime: hasJsxRuntime ? 'automatic' : 'classic',
-      },
-    ],
-  ],
-  babelrc: false,
-  configFile: false,
+	presets: [
+		[
+			require.resolve("babel-preset-react-app"),
+			{
+				runtime: hasJsxRuntime ? "automatic" : "classic",
+			},
+		],
+	],
+	babelrc: false,
+	configFile: false,
 });

--- a/ui/config/jest/cssTransform.js
+++ b/ui/config/jest/cssTransform.js
@@ -1,16 +1,16 @@
-'use strict';
+"use strict";
 
 // This is a custom Jest transformer turning style imports into empty objects.
 // http://facebook.github.io/jest/docs/en/webpack.html
 
 module.exports = {
-  process() {
-    return {
-      code: 'module.exports = {};',
-    };
-  },
-  getCacheKey() {
-    // The output is always the same.
-    return 'cssTransform';
-  },
+	process() {
+		return {
+			code: "module.exports = {};",
+		};
+	},
+	getCacheKey() {
+		// The output is always the same.
+		return "cssTransform";
+	},
 };

--- a/ui/config/jest/fileTransform.mjs
+++ b/ui/config/jest/fileTransform.mjs
@@ -1,23 +1,23 @@
-'use strict';
+"use strict";
 
-import path from 'path';
-import camelcase from 'camelcase';
+import path from "path";
+import camelcase from "camelcase";
 
 // This is a custom Jest transformer turning file imports into filenames.
 // http://facebook.github.io/jest/docs/en/webpack.html
 
 export default {
-  process(src, filename) {
-    const assetFilename = JSON.stringify(path.basename(filename));
+	process(src, filename) {
+		const assetFilename = JSON.stringify(path.basename(filename));
 
-    if (filename.match(/\.svg$/)) {
-      // Based on how SVGR generates a component name:
-      // https://github.com/smooth-code/svgr/blob/01b194cf967347d43d4cbe6b434404731b87cf27/packages/core/src/state.js#L6
-      const pascalCaseFilename = camelcase(path.parse(filename).name, {
-        pascalCase: true,
-      });
-      const componentName = `Svg${pascalCaseFilename}`;
-      return `const React = require('react');
+		if (filename.match(/\.svg$/)) {
+			// Based on how SVGR generates a component name:
+			// https://github.com/smooth-code/svgr/blob/01b194cf967347d43d4cbe6b434404731b87cf27/packages/core/src/state.js#L6
+			const pascalCaseFilename = camelcase(path.parse(filename).name, {
+				pascalCase: true,
+			});
+			const componentName = `Svg${pascalCaseFilename}`;
+			return `const React = require('react');
       module.exports = {
         __esModule: true,
         default: ${assetFilename},
@@ -33,8 +33,8 @@ export default {
           };
         }),
       };`;
-    }
+		}
 
-    return `module.exports = ${assetFilename};`;
-  },
+		return `module.exports = ${assetFilename};`;
+	},
 };

--- a/ui/config/modules.js
+++ b/ui/config/modules.js
@@ -1,10 +1,10 @@
-'use strict';
+"use strict";
 
-const fs = require('fs');
-const path = require('path');
-const paths = require('./paths');
-const chalk = require('react-dev-utils/chalk');
-const resolve = require('resolve');
+const fs = require("fs");
+const path = require("path");
+const paths = require("./paths");
+const chalk = require("react-dev-utils/chalk");
+const resolve = require("resolve");
 
 /**
  * Get additional module paths based on the baseUrl of a compilerOptions object.
@@ -12,41 +12,41 @@ const resolve = require('resolve');
  * @param {Object} options
  */
 function getAdditionalModulePaths(options = {}) {
-  const baseUrl = options.baseUrl;
+	const baseUrl = options.baseUrl;
 
-  if (!baseUrl) {
-    return '';
-  }
+	if (!baseUrl) {
+		return "";
+	}
 
-  const baseUrlResolved = path.resolve(paths.appPath, baseUrl);
+	const baseUrlResolved = path.resolve(paths.appPath, baseUrl);
 
-  // We don't need to do anything if `baseUrl` is set to `node_modules`. This is
-  // the default behavior.
-  if (path.relative(paths.appNodeModules, baseUrlResolved) === '') {
-    return null;
-  }
+	// We don't need to do anything if `baseUrl` is set to `node_modules`. This is
+	// the default behavior.
+	if (path.relative(paths.appNodeModules, baseUrlResolved) === "") {
+		return null;
+	}
 
-  // Allow the user set the `baseUrl` to `appSrc`.
-  if (path.relative(paths.appSrc, baseUrlResolved) === '') {
-    return [paths.appSrc];
-  }
+	// Allow the user set the `baseUrl` to `appSrc`.
+	if (path.relative(paths.appSrc, baseUrlResolved) === "") {
+		return [paths.appSrc];
+	}
 
-  // If the path is equal to the root directory we ignore it here.
-  // We don't want to allow importing from the root directly as source files are
-  // not transpiled outside of `src`. We do allow importing them with the
-  // absolute path (e.g. `src/Components/Button.js`) but we set that up with
-  // an alias.
-  if (path.relative(paths.appPath, baseUrlResolved) === '') {
-    return null;
-  }
+	// If the path is equal to the root directory we ignore it here.
+	// We don't want to allow importing from the root directly as source files are
+	// not transpiled outside of `src`. We do allow importing them with the
+	// absolute path (e.g. `src/Components/Button.js`) but we set that up with
+	// an alias.
+	if (path.relative(paths.appPath, baseUrlResolved) === "") {
+		return null;
+	}
 
-  // Otherwise, throw an error.
-  throw new Error(
-    chalk.red.bold(
-      "Your project's `baseUrl` can only be set to `src` or `node_modules`." +
-        ' Create React App does not support other values at this time.'
-    )
-  );
+	// Otherwise, throw an error.
+	throw new Error(
+		chalk.red.bold(
+			"Your project's `baseUrl` can only be set to `src` or `node_modules`." +
+				" Create React App does not support other values at this time.",
+		),
+	);
 }
 
 /**
@@ -55,19 +55,19 @@ function getAdditionalModulePaths(options = {}) {
  * @param {*} options
  */
 function getWebpackAliases(options = {}) {
-  const baseUrl = options.baseUrl;
+	const baseUrl = options.baseUrl;
 
-  if (!baseUrl) {
-    return {};
-  }
+	if (!baseUrl) {
+		return {};
+	}
 
-  const baseUrlResolved = path.resolve(paths.appPath, baseUrl);
+	const baseUrlResolved = path.resolve(paths.appPath, baseUrl);
 
-  if (path.relative(paths.appPath, baseUrlResolved) === '') {
-    return {
-      src: paths.appSrc,
-    };
-  }
+	if (path.relative(paths.appPath, baseUrlResolved) === "") {
+		return {
+			src: paths.appSrc,
+		};
+	}
 }
 
 /**
@@ -76,59 +76,61 @@ function getWebpackAliases(options = {}) {
  * @param {*} options
  */
 function getJestAliases(options = {}) {
-  const baseUrl = options.baseUrl;
+	const baseUrl = options.baseUrl;
 
-  if (!baseUrl) {
-    return {};
-  }
+	if (!baseUrl) {
+		return {};
+	}
 
-  const baseUrlResolved = path.resolve(paths.appPath, baseUrl);
+	const baseUrlResolved = path.resolve(paths.appPath, baseUrl);
 
-  if (path.relative(paths.appPath, baseUrlResolved) === '') {
-    return {
-      '^src/(.*)$': '<rootDir>/src/$1',
-    };
-  }
+	if (path.relative(paths.appPath, baseUrlResolved) === "") {
+		return {
+			"^src/(.*)$": "<rootDir>/src/$1",
+		};
+	}
 }
 
 function getModules() {
-  // Check if TypeScript is setup
-  const hasTsConfig = fs.existsSync(paths.appTsConfig);
-  const hasJsConfig = fs.existsSync(paths.appJsConfig);
+	// Check if TypeScript is setup
+	const hasTsConfig = fs.existsSync(paths.appTsConfig);
+	const hasJsConfig = fs.existsSync(paths.appJsConfig);
 
-  if (hasTsConfig && hasJsConfig) {
-    throw new Error(
-      'You have both a tsconfig.json and a jsconfig.json. If you are using TypeScript please remove your jsconfig.json file.'
-    );
-  }
+	if (hasTsConfig && hasJsConfig) {
+		throw new Error(
+			"You have both a tsconfig.json and a jsconfig.json. If you are using TypeScript please remove your jsconfig.json file.",
+		);
+	}
 
-  let config;
+	let config;
 
-  // If there's a tsconfig.json we assume it's a
-  // TypeScript project and set up the config
-  // based on tsconfig.json
-  if (hasTsConfig) {
-    const ts = require(resolve.sync('typescript', {
-      basedir: paths.appNodeModules,
-    }));
-    config = ts.readConfigFile(paths.appTsConfig, ts.sys.readFile).config;
-    // Otherwise we'll check if there is jsconfig.json
-    // for non TS projects.
-  } else if (hasJsConfig) {
-    config = require(paths.appJsConfig);
-  }
+	// If there's a tsconfig.json we assume it's a
+	// TypeScript project and set up the config
+	// based on tsconfig.json
+	if (hasTsConfig) {
+		const ts = require(
+			resolve.sync("typescript", {
+				basedir: paths.appNodeModules,
+			}),
+		);
+		config = ts.readConfigFile(paths.appTsConfig, ts.sys.readFile).config;
+		// Otherwise we'll check if there is jsconfig.json
+		// for non TS projects.
+	} else if (hasJsConfig) {
+		config = require(paths.appJsConfig);
+	}
 
-  config = config || {};
-  const options = config.compilerOptions || {};
+	config = config || {};
+	const options = config.compilerOptions || {};
 
-  const additionalModulePaths = getAdditionalModulePaths(options);
+	const additionalModulePaths = getAdditionalModulePaths(options);
 
-  return {
-    additionalModulePaths: additionalModulePaths,
-    webpackAliases: getWebpackAliases(options),
-    jestAliases: getJestAliases(options),
-    hasTsConfig,
-  };
+	return {
+		additionalModulePaths: additionalModulePaths,
+		webpackAliases: getWebpackAliases(options),
+		jestAliases: getJestAliases(options),
+		hasTsConfig,
+	};
 }
 
 module.exports = getModules();

--- a/ui/config/paths.js
+++ b/ui/config/paths.js
@@ -1,13 +1,13 @@
-'use strict';
+"use strict";
 
-const path = require('path');
-const fs = require('fs');
-const getPublicUrlOrPath = require('react-dev-utils/getPublicUrlOrPath');
+const path = require("path");
+const fs = require("fs");
+const getPublicUrlOrPath = require("react-dev-utils/getPublicUrlOrPath");
 
 // Make sure any symlinks in the project folder are resolved:
 // https://github.com/facebook/create-react-app/issues/637
 const appDirectory = fs.realpathSync(process.cwd());
-const resolveApp = relativePath => path.resolve(appDirectory, relativePath);
+const resolveApp = (relativePath) => path.resolve(appDirectory, relativePath);
 
 // We use `PUBLIC_URL` environment variable or "homepage" field to infer
 // "public path" at which the app is served.
@@ -16,62 +16,60 @@ const resolveApp = relativePath => path.resolve(appDirectory, relativePath);
 // We can't use a relative path in HTML because we don't want to load something
 // like /todos/42/static/js/bundle.7289d.js. We have to know the root.
 const publicUrlOrPath = getPublicUrlOrPath(
-  process.env.NODE_ENV === 'development',
-  require(resolveApp('package.json')).homepage,
-  process.env.PUBLIC_URL
+	process.env.NODE_ENV === "development",
+	require(resolveApp("package.json")).homepage,
+	process.env.PUBLIC_URL,
 );
 
-const buildPath = process.env.BUILD_PATH || 'build';
+const buildPath = process.env.BUILD_PATH || "build";
 
 const moduleFileExtensions = [
-  'web.mjs',
-  'mjs',
-  'web.js',
-  'js',
-  'web.ts',
-  'ts',
-  'web.tsx',
-  'tsx',
-  'json',
-  'web.jsx',
-  'jsx',
+	"web.mjs",
+	"mjs",
+	"web.js",
+	"js",
+	"web.ts",
+	"ts",
+	"web.tsx",
+	"tsx",
+	"json",
+	"web.jsx",
+	"jsx",
 ];
 
 // Resolve file paths in the same order as webpack
 const resolveModule = (resolveFn, filePath) => {
-  const extension = moduleFileExtensions.find(extension =>
-    fs.existsSync(resolveFn(`${filePath}.${extension}`))
-  );
+	const extension = moduleFileExtensions.find((extension) =>
+		fs.existsSync(resolveFn(`${filePath}.${extension}`)),
+	);
 
-  if (extension) {
-    return resolveFn(`${filePath}.${extension}`);
-  }
+	if (extension) {
+		return resolveFn(`${filePath}.${extension}`);
+	}
 
-  return resolveFn(`${filePath}.js`);
+	return resolveFn(`${filePath}.js`);
 };
 
 // config after eject: we're in ./config/
 module.exports = {
-  dotenv: resolveApp('.env'),
-  appPath: resolveApp('.'),
-  appBuild: resolveApp(buildPath),
-  appPublic: resolveApp('public'),
-  appHtml: resolveApp('public/index.html'),
-  appIndexJs: resolveModule(resolveApp, 'src/index'),
-  appPackageJson: resolveApp('package.json'),
-  appSrc: resolveApp('src'),
-  appTsConfig: resolveApp('tsconfig.json'),
-  appJsConfig: resolveApp('jsconfig.json'),
-  yarnLockFile: resolveApp('yarn.lock'),
-  testsSetup: resolveModule(resolveApp, 'src/setupTests'),
-  proxySetup: resolveApp('src/setupProxy.js'),
-  appNodeModules: resolveApp('node_modules'),
-  appWebpackCache: resolveApp('node_modules/.cache'),
-  appTsBuildInfoFile: resolveApp('node_modules/.cache/tsconfig.tsbuildinfo'),
-  swSrc: resolveModule(resolveApp, 'src/service-worker'),
-  publicUrlOrPath,
+	dotenv: resolveApp(".env"),
+	appPath: resolveApp("."),
+	appBuild: resolveApp(buildPath),
+	appPublic: resolveApp("public"),
+	appHtml: resolveApp("public/index.html"),
+	appIndexJs: resolveModule(resolveApp, "src/index"),
+	appPackageJson: resolveApp("package.json"),
+	appSrc: resolveApp("src"),
+	appTsConfig: resolveApp("tsconfig.json"),
+	appJsConfig: resolveApp("jsconfig.json"),
+	yarnLockFile: resolveApp("yarn.lock"),
+	testsSetup: resolveModule(resolveApp, "src/setupTests"),
+	proxySetup: resolveApp("src/setupProxy.js"),
+	appNodeModules: resolveApp("node_modules"),
+	appWebpackCache: resolveApp("node_modules/.cache"),
+	appTsBuildInfoFile: resolveApp("node_modules/.cache/tsconfig.tsbuildinfo"),
+	swSrc: resolveModule(resolveApp, "src/service-worker"),
+	publicUrlOrPath,
 };
-
-
 
 module.exports.moduleFileExtensions = moduleFileExtensions;

--- a/ui/config/webpack.config.js
+++ b/ui/config/webpack.config.js
@@ -1,58 +1,58 @@
-'use strict';
+"use strict";
 
-const fs = require('fs');
-const path = require('path');
-const webpack = require('webpack');
-const resolve = require('resolve');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin');
-const InlineChunkHtmlPlugin = require('react-dev-utils/InlineChunkHtmlPlugin');
-const TerserPlugin = require('terser-webpack-plugin');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
-const { WebpackManifestPlugin } = require('webpack-manifest-plugin');
-const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin');
-const WorkboxWebpackPlugin = require('workbox-webpack-plugin');
-const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin');
-const getCSSModuleLocalIdent = require('react-dev-utils/getCSSModuleLocalIdent');
-const ESLintPlugin = require('eslint-webpack-plugin');
-const paths = require('./paths');
-const modules = require('./modules');
-const getClientEnvironment = require('./env');
-const ModuleNotFoundPlugin = require('react-dev-utils/ModuleNotFoundPlugin');
+const fs = require("fs");
+const path = require("path");
+const webpack = require("webpack");
+const resolve = require("resolve");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
+const CaseSensitivePathsPlugin = require("case-sensitive-paths-webpack-plugin");
+const InlineChunkHtmlPlugin = require("react-dev-utils/InlineChunkHtmlPlugin");
+const TerserPlugin = require("terser-webpack-plugin");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
+const { WebpackManifestPlugin } = require("webpack-manifest-plugin");
+const InterpolateHtmlPlugin = require("react-dev-utils/InterpolateHtmlPlugin");
+const WorkboxWebpackPlugin = require("workbox-webpack-plugin");
+const ModuleScopePlugin = require("react-dev-utils/ModuleScopePlugin");
+const getCSSModuleLocalIdent = require("react-dev-utils/getCSSModuleLocalIdent");
+const ESLintPlugin = require("eslint-webpack-plugin");
+const paths = require("./paths");
+const modules = require("./modules");
+const getClientEnvironment = require("./env");
+const ModuleNotFoundPlugin = require("react-dev-utils/ModuleNotFoundPlugin");
 const ForkTsCheckerWebpackPlugin =
-  process.env.TSC_COMPILE_ON_ERROR === 'true'
-    ? require('react-dev-utils/ForkTsCheckerWarningWebpackPlugin')
-    : require('react-dev-utils/ForkTsCheckerWebpackPlugin');
-const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
+	process.env.TSC_COMPILE_ON_ERROR === "true"
+		? require("react-dev-utils/ForkTsCheckerWarningWebpackPlugin")
+		: require("react-dev-utils/ForkTsCheckerWebpackPlugin");
+const ReactRefreshWebpackPlugin = require("@pmmmwh/react-refresh-webpack-plugin");
 
-const createEnvironmentHash = require('./webpack/persistentCache/createEnvironmentHash');
+const createEnvironmentHash = require("./webpack/persistentCache/createEnvironmentHash");
 
 // Source maps are resource heavy and can cause out of memory issue for large source files.
-const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false';
+const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== "false";
 
-const reactRefreshRuntimeEntry = require.resolve('react-refresh/runtime');
+const reactRefreshRuntimeEntry = require.resolve("react-refresh/runtime");
 const reactRefreshWebpackPluginRuntimeEntry = require.resolve(
-  '@pmmmwh/react-refresh-webpack-plugin'
+	"@pmmmwh/react-refresh-webpack-plugin",
 );
-const babelRuntimeEntry = require.resolve('babel-preset-react-app');
+const babelRuntimeEntry = require.resolve("babel-preset-react-app");
 const babelRuntimeEntryHelpers = require.resolve(
-  '@babel/runtime/helpers/esm/assertThisInitialized',
-  { paths: [babelRuntimeEntry] }
+	"@babel/runtime/helpers/esm/assertThisInitialized",
+	{ paths: [babelRuntimeEntry] },
 );
-const babelRuntimeRegenerator = require.resolve('@babel/runtime/regenerator', {
-  paths: [babelRuntimeEntry],
+const babelRuntimeRegenerator = require.resolve("@babel/runtime/regenerator", {
+	paths: [babelRuntimeEntry],
 });
 
 // Some apps do not need the benefits of saving a web request, so not inlining the chunk
 // makes for a smoother build process.
-const shouldInlineRuntimeChunk = process.env.INLINE_RUNTIME_CHUNK !== 'false';
+const shouldInlineRuntimeChunk = process.env.INLINE_RUNTIME_CHUNK !== "false";
 
-const emitErrorsAsWarnings = process.env.ESLINT_NO_DEV_ERRORS === 'true';
-const disableESLintPlugin = process.env.DISABLE_ESLINT_PLUGIN === 'true';
+const emitErrorsAsWarnings = process.env.ESLINT_NO_DEV_ERRORS === "true";
+const disableESLintPlugin = process.env.DISABLE_ESLINT_PLUGIN === "true";
 
 const imageInlineSizeLimit = parseInt(
-  process.env.IMAGE_INLINE_SIZE_LIMIT || '10000'
+	process.env.IMAGE_INLINE_SIZE_LIMIT || "10000",
 );
 
 // Check if TypeScript is setup
@@ -60,7 +60,7 @@ const useTypeScript = fs.existsSync(paths.appTsConfig);
 
 // Check if Tailwind config exists
 const useTailwind = fs.existsSync(
-  path.join(paths.appPath, 'tailwind.config.js')
+	path.join(paths.appPath, "tailwind.config.js"),
 );
 
 // Get the path to the uncompiled service worker (if it exists).
@@ -73,683 +73,684 @@ const sassRegex = /\.(scss|sass)$/;
 const sassModuleRegex = /\.module\.(scss|sass)$/;
 
 const hasJsxRuntime = (() => {
-  if (process.env.DISABLE_NEW_JSX_TRANSFORM === 'true') {
-    return false;
-  }
+	if (process.env.DISABLE_NEW_JSX_TRANSFORM === "true") {
+		return false;
+	}
 
-  try {
-    require.resolve('react/jsx-runtime');
-    return true;
-  } catch (e) {
-    return false;
-  }
+	try {
+		require.resolve("react/jsx-runtime");
+		return true;
+	} catch (e) {
+		return false;
+	}
 })();
 
 // This is the production and development configuration.
 // It is focused on developer experience, fast rebuilds, and a minimal bundle.
 module.exports = function (webpackEnv) {
-  const isEnvDevelopment = webpackEnv === 'development';
-  const isEnvProduction = webpackEnv === 'production';
+	const isEnvDevelopment = webpackEnv === "development";
+	const isEnvProduction = webpackEnv === "production";
 
-  // Variable used for enabling profiling in Production
-  // passed into alias object. Uses a flag if passed into the build command
-  const isEnvProductionProfile =
-    isEnvProduction && process.argv.includes('--profile');
+	// Variable used for enabling profiling in Production
+	// passed into alias object. Uses a flag if passed into the build command
+	const isEnvProductionProfile =
+		isEnvProduction && process.argv.includes("--profile");
 
-  // We will provide `paths.publicUrlOrPath` to our app
-  // as %PUBLIC_URL% in `index.html` and `process.env.PUBLIC_URL` in JavaScript.
-  // Omit trailing slash as %PUBLIC_URL%/xyz looks better than %PUBLIC_URL%xyz.
-  // Get environment variables to inject into our app.
-  const env = getClientEnvironment(paths.publicUrlOrPath.slice(0, -1));
+	// We will provide `paths.publicUrlOrPath` to our app
+	// as %PUBLIC_URL% in `index.html` and `process.env.PUBLIC_URL` in JavaScript.
+	// Omit trailing slash as %PUBLIC_URL%/xyz looks better than %PUBLIC_URL%xyz.
+	// Get environment variables to inject into our app.
+	const env = getClientEnvironment(paths.publicUrlOrPath.slice(0, -1));
 
-  const shouldUseReactRefresh = env.raw.FAST_REFRESH;
+	const shouldUseReactRefresh = env.raw.FAST_REFRESH;
 
-  // common function to get style loaders
-  const getStyleLoaders = (cssOptions, preProcessor) => {
-    const loaders = [
-      isEnvDevelopment && require.resolve('style-loader'),
-      isEnvProduction && {
-        loader: MiniCssExtractPlugin.loader,
-        // css is located in `static/css`, use '../../' to locate index.html folder
-        // in production `paths.publicUrlOrPath` can be a relative path
-        options: paths.publicUrlOrPath.startsWith('.')
-          ? { publicPath: '../../' }
-          : {},
-      },
-      {
-        loader: require.resolve('css-loader'),
-        options: cssOptions,
-      },
-      {
-        // Options for PostCSS as we reference these options twice
-        // Adds vendor prefixing based on your specified browser support in
-        // package.json
-        loader: require.resolve('postcss-loader'),
-        options: {
-          postcssOptions: {
-            // Necessary for external CSS imports to work
-            // https://github.com/facebook/create-react-app/issues/2677
-            ident: 'postcss',
-            config: false,
-            plugins: !useTailwind
-              ? [
-                  'postcss-flexbugs-fixes',
-                  [
-                    'postcss-preset-env',
-                    {
-                      autoprefixer: {
-                        flexbox: 'no-2009',
-                      },
-                      stage: 3,
-                    },
-                  ],
-                  // Adds PostCSS Normalize as the reset css with default options,
-                  // so that it honors browserslist config in package.json
-                  // which in turn let's users customize the target behavior as per their needs.
-                  'postcss-normalize',
-                ]
-              : [
-                  'tailwindcss',
-                  'postcss-flexbugs-fixes',
-                  [
-                    'postcss-preset-env',
-                    {
-                      autoprefixer: {
-                        flexbox: 'no-2009',
-                      },
-                      stage: 3,
-                    },
-                  ],
-                ],
-          },
-          sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
-        },
-      },
-    ].filter(Boolean);
-    if (preProcessor) {
-      loaders.push(
-        {
-          loader: require.resolve('resolve-url-loader'),
-          options: {
-            sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
-            root: paths.appSrc,
-          },
-        },
-        {
-          loader: require.resolve(preProcessor),
-          options: {
-            sourceMap: true,
-          },
-        }
-      );
-    }
-    return loaders;
-  };
+	// common function to get style loaders
+	const getStyleLoaders = (cssOptions, preProcessor) => {
+		const loaders = [
+			isEnvDevelopment && require.resolve("style-loader"),
+			isEnvProduction && {
+				loader: MiniCssExtractPlugin.loader,
+				// css is located in `static/css`, use '../../' to locate index.html folder
+				// in production `paths.publicUrlOrPath` can be a relative path
+				options: paths.publicUrlOrPath.startsWith(".")
+					? { publicPath: "../../" }
+					: {},
+			},
+			{
+				loader: require.resolve("css-loader"),
+				options: cssOptions,
+			},
+			{
+				// Options for PostCSS as we reference these options twice
+				// Adds vendor prefixing based on your specified browser support in
+				// package.json
+				loader: require.resolve("postcss-loader"),
+				options: {
+					postcssOptions: {
+						// Necessary for external CSS imports to work
+						// https://github.com/facebook/create-react-app/issues/2677
+						ident: "postcss",
+						config: false,
+						plugins: !useTailwind
+							? [
+									"postcss-flexbugs-fixes",
+									[
+										"postcss-preset-env",
+										{
+											autoprefixer: {
+												flexbox: "no-2009",
+											},
+											stage: 3,
+										},
+									],
+									// Adds PostCSS Normalize as the reset css with default options,
+									// so that it honors browserslist config in package.json
+									// which in turn let's users customize the target behavior as per their needs.
+									"postcss-normalize",
+								]
+							: [
+									"tailwindcss",
+									"postcss-flexbugs-fixes",
+									[
+										"postcss-preset-env",
+										{
+											autoprefixer: {
+												flexbox: "no-2009",
+											},
+											stage: 3,
+										},
+									],
+								],
+					},
+					sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
+				},
+			},
+		].filter(Boolean);
+		if (preProcessor) {
+			loaders.push(
+				{
+					loader: require.resolve("resolve-url-loader"),
+					options: {
+						sourceMap: isEnvProduction ? shouldUseSourceMap : isEnvDevelopment,
+						root: paths.appSrc,
+					},
+				},
+				{
+					loader: require.resolve(preProcessor),
+					options: {
+						sourceMap: true,
+					},
+				},
+			);
+		}
+		return loaders;
+	};
 
-  return {
-    target: ['browserslist'],
-    // Webpack noise constrained to errors and warnings
-    stats: 'errors-warnings',
-    mode: isEnvProduction ? 'production' : isEnvDevelopment && 'development',
-    // Stop compilation early in production
-    bail: isEnvProduction,
-    devtool: isEnvProduction
-      ? shouldUseSourceMap
-        ? 'source-map'
-        : false
-      : isEnvDevelopment && 'cheap-module-source-map',
-    // These are the "entry points" to our application.
-    // This means they will be the "root" imports that are included in JS bundle.
-    entry: paths.appIndexJs,
-    output: {
-      // The build folder.
-      path: paths.appBuild,
-      // Add /* filename */ comments to generated require()s in the output.
-      pathinfo: isEnvDevelopment,
-      // There will be one main bundle, and one file per asynchronous chunk.
-      // In development, it does not produce real files.
-      filename: isEnvProduction
-        ? 'static/js/[name].[contenthash:8].js'
-        : isEnvDevelopment && 'static/js/bundle.js',
-      // There are also additional JS chunk files if you use code splitting.
-      chunkFilename: isEnvProduction
-        ? 'static/js/[name].[contenthash:8].chunk.js'
-        : isEnvDevelopment && 'static/js/[name].chunk.js',
-      assetModuleFilename: 'static/media/[name].[hash][ext]',
-      // webpack uses `publicPath` to determine where the app is being served from.
-      // It requires a trailing slash, or the file assets will get an incorrect path.
-      // We inferred the "public path" (such as / or /my-project) from homepage.
-      publicPath: paths.publicUrlOrPath,
-      // Point sourcemap entries to original disk location (format as URL on Windows)
-      devtoolModuleFilenameTemplate: isEnvProduction
-        ? info =>
-            path
-              .relative(paths.appSrc, info.absoluteResourcePath)
-              .replace(/\\/g, '/')
-        : isEnvDevelopment &&
-          (info => path.resolve(info.absoluteResourcePath).replace(/\\/g, '/')),
-    },
-    cache: {
-      type: 'filesystem',
-      version: createEnvironmentHash(env.raw),
-      cacheDirectory: paths.appWebpackCache,
-      store: 'pack',
-      buildDependencies: {
-        defaultWebpack: ['webpack/lib/'],
-        config: [__filename],
-        tsconfig: [paths.appTsConfig, paths.appJsConfig].filter(f =>
-          fs.existsSync(f)
-        ),
-      },
-    },
-    infrastructureLogging: {
-      level: 'none',
-    },
-    optimization: {
-      minimize: isEnvProduction,
-      minimizer: [
-        // This is only used in production mode
-        new TerserPlugin({
-          terserOptions: {
-            parse: {
-              // We want terser to parse ecma 8 code. However, we don't want it
-              // to apply any minification steps that turns valid ecma 5 code
-              // into invalid ecma 5 code. This is why the 'compress' and 'output'
-              // sections only apply transformations that are ecma 5 safe
-              // https://github.com/facebook/create-react-app/pull/4234
-              ecma: 8,
-            },
-            compress: {
-              ecma: 5,
-              warnings: false,
-              // Disabled because of an issue with Uglify breaking seemingly valid code:
-              // https://github.com/facebook/create-react-app/issues/2376
-              // Pending further investigation:
-              // https://github.com/mishoo/UglifyJS2/issues/2011
-              comparisons: false,
-              // Disabled because of an issue with Terser breaking valid code:
-              // https://github.com/facebook/create-react-app/issues/5250
-              // Pending further investigation:
-              // https://github.com/terser-js/terser/issues/120
-              inline: 2,
-            },
-            mangle: {
-              safari10: true,
-            },
-            // Added for profiling in devtools
-            keep_classnames: isEnvProductionProfile,
-            keep_fnames: isEnvProductionProfile,
-            output: {
-              ecma: 5,
-              comments: false,
-              // Turned on because emoji and regex is not minified properly using default
-              // https://github.com/facebook/create-react-app/issues/2488
-              ascii_only: true,
-            },
-          },
-        }),
-        // This is only used in production mode
-        new CssMinimizerPlugin(),
-      ],
-    },
-    resolve: {
-      // This allows you to set a fallback for where webpack should look for modules.
-      // We placed these paths second because we want `node_modules` to "win"
-      // if there are any conflicts. This matches Node resolution mechanism.
-      // https://github.com/facebook/create-react-app/issues/253
-      modules: ['node_modules', paths.appNodeModules].concat(
-        modules.additionalModulePaths || []
-      ),
-      // These are the reasonable defaults supported by the Node ecosystem.
-      // We also include JSX as a common component filename extension to support
-      // some tools, although we do not recommend using it, see:
-      // https://github.com/facebook/create-react-app/issues/290
-      // `web` extension prefixes have been added for better support
-      // for React Native Web.
-      extensions: paths.moduleFileExtensions
-        .map(ext => `.${ext}`)
-        .filter(ext => useTypeScript || !ext.includes('ts')),
-      alias: {
-        // Support React Native Web
-        // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
-        'react-native': 'react-native-web',
-        // Allows for better profiling with ReactDevTools
-        ...(isEnvProductionProfile && {
-          'react-dom$': 'react-dom/profiling',
-          'scheduler/tracing': 'scheduler/tracing-profiling',
-        }),
-        ...(modules.webpackAliases || {}),
-      },
-      plugins: [
-        // Prevents users from importing files from outside of src/ (or node_modules/).
-        // This often causes confusion because we only process files within src/ with babel.
-        // To fix this, we prevent you from importing files out of src/ -- if you'd like to,
-        // please link the files into your node_modules/ and let module-resolution kick in.
-        // Make sure your source files are compiled, as they will not be processed in any way.
-        new ModuleScopePlugin(paths.appSrc, [
-          paths.appPackageJson,
-          reactRefreshRuntimeEntry,
-          reactRefreshWebpackPluginRuntimeEntry,
-          babelRuntimeEntry,
-          babelRuntimeEntryHelpers,
-          babelRuntimeRegenerator,
-        ]),
-      ],
-    },
-    module: {
-      strictExportPresence: true,
-      rules: [
-        // Handle node_modules packages that contain sourcemaps
-        shouldUseSourceMap && {
-          enforce: 'pre',
-          exclude: /@babel(?:\/|\\{1,2})runtime/,
-          test: /\.(js|mjs|jsx|ts|tsx|css)$/,
-          loader: require.resolve('source-map-loader'),
-        },
-        {
-          // "oneOf" will traverse all following loaders until one will
-          // match the requirements. When no loader matches it will fall
-          // back to the "file" loader at the end of the loader list.
-          oneOf: [
-            // TODO: Merge this config once `image/avif` is in the mime-db
-            // https://github.com/jshttp/mime-db
-            {
-              test: [/\.avif$/],
-              type: 'asset',
-              mimetype: 'image/avif',
-              parser: {
-                dataUrlCondition: {
-                  maxSize: imageInlineSizeLimit,
-                },
-              },
-            },
-            // "url" loader works like "file" loader except that it embeds assets
-            // smaller than specified limit in bytes as data URLs to avoid requests.
-            // A missing `test` is equivalent to a match.
-            {
-              test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],
-              type: 'asset',
-              parser: {
-                dataUrlCondition: {
-                  maxSize: imageInlineSizeLimit,
-                },
-              },
-            },
-            {
-              test: /\.svg$/,
-              use: [
-                {
-                  loader: require.resolve('@svgr/webpack'),
-                  options: {
-                    prettier: false,
-                    svgo: false,
-                    svgoConfig: {
-                      plugins: [{ removeViewBox: false }],
-                    },
-                    titleProp: true,
-                    ref: true,
-                  },
-                },
-                {
-                  loader: require.resolve('file-loader'),
-                  options: {
-                    name: 'static/media/[name].[hash].[ext]',
-                  },
-                },
-              ],
-              issuer: {
-                and: [/\.(ts|tsx|js|jsx|md|mdx)$/],
-              },
-            },
-            // Process application JS with Babel.
-            // The preset includes JSX, Flow, TypeScript, and some ESnext features.
-            {
-              test: /\.(js|mjs|jsx|ts|tsx)$/,
-              include: paths.appSrc,
-              loader: require.resolve('babel-loader'),
-              options: {
-                customize: require.resolve(
-                  'babel-preset-react-app/webpack-overrides'
-                ),
-                presets: [
-                  [
-                    require.resolve('babel-preset-react-app'),
-                    {
-                      runtime: hasJsxRuntime ? 'automatic' : 'classic',
-                    },
-                  ],
-                ],
-                
-                plugins: [
-                  isEnvDevelopment &&
-                    shouldUseReactRefresh &&
-                    require.resolve('react-refresh/babel'),
-                ].filter(Boolean),
-                // This is a feature of `babel-loader` for webpack (not Babel itself).
-                // It enables caching results in ./node_modules/.cache/babel-loader/
-                // directory for faster rebuilds.
-                cacheDirectory: true,
-                // See #6846 for context on why cacheCompression is disabled
-                cacheCompression: false,
-                compact: isEnvProduction,
-              },
-            },
-            // Process any JS outside of the app with Babel.
-            // Unlike the application JS, we only compile the standard ES features.
-            {
-              test: /\.(js|mjs)$/,
-              exclude: /@babel(?:\/|\\{1,2})runtime/,
-              loader: require.resolve('babel-loader'),
-              options: {
-                babelrc: false,
-                configFile: false,
-                compact: false,
-                presets: [
-                  [
-                    require.resolve('babel-preset-react-app/dependencies'),
-                    { helpers: true },
-                  ],
-                ],
-                cacheDirectory: true,
-                // See #6846 for context on why cacheCompression is disabled
-                cacheCompression: false,
-                
-                // Babel sourcemaps are needed for debugging into node_modules
-                // code.  Without the options below, debuggers like VSCode
-                // show incorrect code and set breakpoints on the wrong lines.
-                sourceMaps: shouldUseSourceMap,
-                inputSourceMap: shouldUseSourceMap,
-              },
-            },
-            // "postcss" loader applies autoprefixer to our CSS.
-            // "css" loader resolves paths in CSS and adds assets as dependencies.
-            // "style" loader turns CSS into JS modules that inject <style> tags.
-            // In production, we use MiniCSSExtractPlugin to extract that CSS
-            // to a file, but in development "style" loader enables hot editing
-            // of CSS.
-            // By default we support CSS Modules with the extension .module.css
-            {
-              test: cssRegex,
-              exclude: cssModuleRegex,
-              use: getStyleLoaders({
-                importLoaders: 1,
-                sourceMap: isEnvProduction
-                  ? shouldUseSourceMap
-                  : isEnvDevelopment,
-                modules: {
-                  mode: 'icss',
-                },
-              }),
-              // Don't consider CSS imports dead code even if the
-              // containing package claims to have no side effects.
-              // Remove this when webpack adds a warning or an error for this.
-              // See https://github.com/webpack/webpack/issues/6571
-              sideEffects: true,
-            },
-            // Adds support for CSS Modules (https://github.com/css-modules/css-modules)
-            // using the extension .module.css
-            {
-              test: cssModuleRegex,
-              use: getStyleLoaders({
-                importLoaders: 1,
-                sourceMap: isEnvProduction
-                  ? shouldUseSourceMap
-                  : isEnvDevelopment,
-                modules: {
-                  mode: 'local',
-                  getLocalIdent: getCSSModuleLocalIdent,
-                },
-              }),
-            },
-            // Opt-in support for SASS (using .scss or .sass extensions).
-            // By default we support SASS Modules with the
-            // extensions .module.scss or .module.sass
-            {
-              test: sassRegex,
-              exclude: sassModuleRegex,
-              use: getStyleLoaders(
-                {
-                  importLoaders: 3,
-                  sourceMap: isEnvProduction
-                    ? shouldUseSourceMap
-                    : isEnvDevelopment,
-                  modules: {
-                    mode: 'icss',
-                  },
-                },
-                'sass-loader'
-              ),
-              // Don't consider CSS imports dead code even if the
-              // containing package claims to have no side effects.
-              // Remove this when webpack adds a warning or an error for this.
-              // See https://github.com/webpack/webpack/issues/6571
-              sideEffects: true,
-            },
-            // Adds support for CSS Modules, but using SASS
-            // using the extension .module.scss or .module.sass
-            {
-              test: sassModuleRegex,
-              use: getStyleLoaders(
-                {
-                  importLoaders: 3,
-                  sourceMap: isEnvProduction
-                    ? shouldUseSourceMap
-                    : isEnvDevelopment,
-                  modules: {
-                    mode: 'local',
-                    getLocalIdent: getCSSModuleLocalIdent,
-                  },
-                },
-                'sass-loader'
-              ),
-            },
-            // "file" loader makes sure those assets get served by WebpackDevServer.
-            // When you `import` an asset, you get its (virtual) filename.
-            // In production, they would get copied to the `build` folder.
-            // This loader doesn't use a "test" so it will catch all modules
-            // that fall through the other loaders.
-            {
-              // Exclude `js` files to keep "css" loader working as it injects
-              // its runtime that would otherwise be processed through "file" loader.
-              // Also exclude `html` and `json` extensions so they get processed
-              // by webpacks internal loaders.
-              exclude: [/^$/, /\.(js|mjs|jsx|ts|tsx)$/, /\.html$/, /\.json$/],
-              type: 'asset/resource',
-            },
-            // ** STOP ** Are you adding a new loader?
-            // Make sure to add the new loader(s) before the "file" loader.
-          ],
-        },
-      ].filter(Boolean),
-    },
-    plugins: [
-      // Generates an `index.html` file with the <script> injected.
-      new HtmlWebpackPlugin(
-        Object.assign(
-          {},
-          {
-            inject: true,
-            template: paths.appHtml,
-          },
-          isEnvProduction
-            ? {
-                minify: {
-                  removeComments: true,
-                  collapseWhitespace: true,
-                  removeRedundantAttributes: true,
-                  useShortDoctype: true,
-                  removeEmptyAttributes: true,
-                  removeStyleLinkTypeAttributes: true,
-                  keepClosingSlash: true,
-                  minifyJS: true,
-                  minifyCSS: true,
-                  minifyURLs: true,
-                },
-              }
-            : undefined
-        )
-      ),
-      // Inlines the webpack runtime script. This script is too small to warrant
-      // a network request.
-      // https://github.com/facebook/create-react-app/issues/5358
-      isEnvProduction &&
-        shouldInlineRuntimeChunk &&
-        new InlineChunkHtmlPlugin(HtmlWebpackPlugin, [/runtime-.+[.]js/]),
-      // Makes some environment variables available in index.html.
-      // The public URL is available as %PUBLIC_URL% in index.html, e.g.:
-      // <link rel="icon" href="%PUBLIC_URL%/favicon.ico">
-      // It will be an empty string unless you specify "homepage"
-      // in `package.json`, in which case it will be the pathname of that URL.
-      new InterpolateHtmlPlugin(HtmlWebpackPlugin, env.raw),
-      // This gives some necessary context to module not found errors, such as
-      // the requesting resource.
-      new ModuleNotFoundPlugin(paths.appPath),
-      // Makes some environment variables available to the JS code, for example:
-      // if (process.env.NODE_ENV === 'production') { ... }. See `./env.js`.
-      // It is absolutely essential that NODE_ENV is set to production
-      // during a production build.
-      // Otherwise React will be compiled in the very slow development mode.
-      new webpack.DefinePlugin(env.stringified),
-      // Experimental hot reloading for React .
-      // https://github.com/facebook/react/tree/main/packages/react-refresh
-      isEnvDevelopment &&
-        shouldUseReactRefresh &&
-        new ReactRefreshWebpackPlugin({
-          overlay: false,
-        }),
-      // Watcher doesn't work well if you mistype casing in a path so we use
-      // a plugin that prints an error when you attempt to do this.
-      // See https://github.com/facebook/create-react-app/issues/240
-      isEnvDevelopment && new CaseSensitivePathsPlugin(),
-      isEnvProduction &&
-        new MiniCssExtractPlugin({
-          // Options similar to the same options in webpackOptions.output
-          // both options are optional
-          filename: 'static/css/[name].[contenthash:8].css',
-          chunkFilename: 'static/css/[name].[contenthash:8].chunk.css',
-        }),
-      // Generate an asset manifest file with the following content:
-      // - "files" key: Mapping of all asset filenames to their corresponding
-      //   output file so that tools can pick it up without having to parse
-      //   `index.html`
-      // - "entrypoints" key: Array of files which are included in `index.html`,
-      //   can be used to reconstruct the HTML if necessary
-      new WebpackManifestPlugin({
-        fileName: 'asset-manifest.json',
-        publicPath: paths.publicUrlOrPath,
-        generate: (seed, files, entrypoints) => {
-          const manifestFiles = files.reduce((manifest, file) => {
-            manifest[file.name] = file.path;
-            return manifest;
-          }, seed);
-          const entrypointFiles = entrypoints.main.filter(
-            fileName => !fileName.endsWith('.map')
-          );
+	return {
+		target: ["browserslist"],
+		// Webpack noise constrained to errors and warnings
+		stats: "errors-warnings",
+		mode: isEnvProduction ? "production" : isEnvDevelopment && "development",
+		// Stop compilation early in production
+		bail: isEnvProduction,
+		devtool: isEnvProduction
+			? shouldUseSourceMap
+				? "source-map"
+				: false
+			: isEnvDevelopment && "cheap-module-source-map",
+		// These are the "entry points" to our application.
+		// This means they will be the "root" imports that are included in JS bundle.
+		entry: paths.appIndexJs,
+		output: {
+			// The build folder.
+			path: paths.appBuild,
+			// Add /* filename */ comments to generated require()s in the output.
+			pathinfo: isEnvDevelopment,
+			// There will be one main bundle, and one file per asynchronous chunk.
+			// In development, it does not produce real files.
+			filename: isEnvProduction
+				? "static/js/[name].[contenthash:8].js"
+				: isEnvDevelopment && "static/js/bundle.js",
+			// There are also additional JS chunk files if you use code splitting.
+			chunkFilename: isEnvProduction
+				? "static/js/[name].[contenthash:8].chunk.js"
+				: isEnvDevelopment && "static/js/[name].chunk.js",
+			assetModuleFilename: "static/media/[name].[hash][ext]",
+			// webpack uses `publicPath` to determine where the app is being served from.
+			// It requires a trailing slash, or the file assets will get an incorrect path.
+			// We inferred the "public path" (such as / or /my-project) from homepage.
+			publicPath: paths.publicUrlOrPath,
+			// Point sourcemap entries to original disk location (format as URL on Windows)
+			devtoolModuleFilenameTemplate: isEnvProduction
+				? (info) =>
+						path
+							.relative(paths.appSrc, info.absoluteResourcePath)
+							.replace(/\\/g, "/")
+				: isEnvDevelopment &&
+					((info) =>
+						path.resolve(info.absoluteResourcePath).replace(/\\/g, "/")),
+		},
+		cache: {
+			type: "filesystem",
+			version: createEnvironmentHash(env.raw),
+			cacheDirectory: paths.appWebpackCache,
+			store: "pack",
+			buildDependencies: {
+				defaultWebpack: ["webpack/lib/"],
+				config: [__filename],
+				tsconfig: [paths.appTsConfig, paths.appJsConfig].filter((f) =>
+					fs.existsSync(f),
+				),
+			},
+		},
+		infrastructureLogging: {
+			level: "none",
+		},
+		optimization: {
+			minimize: isEnvProduction,
+			minimizer: [
+				// This is only used in production mode
+				new TerserPlugin({
+					terserOptions: {
+						parse: {
+							// We want terser to parse ecma 8 code. However, we don't want it
+							// to apply any minification steps that turns valid ecma 5 code
+							// into invalid ecma 5 code. This is why the 'compress' and 'output'
+							// sections only apply transformations that are ecma 5 safe
+							// https://github.com/facebook/create-react-app/pull/4234
+							ecma: 8,
+						},
+						compress: {
+							ecma: 5,
+							warnings: false,
+							// Disabled because of an issue with Uglify breaking seemingly valid code:
+							// https://github.com/facebook/create-react-app/issues/2376
+							// Pending further investigation:
+							// https://github.com/mishoo/UglifyJS2/issues/2011
+							comparisons: false,
+							// Disabled because of an issue with Terser breaking valid code:
+							// https://github.com/facebook/create-react-app/issues/5250
+							// Pending further investigation:
+							// https://github.com/terser-js/terser/issues/120
+							inline: 2,
+						},
+						mangle: {
+							safari10: true,
+						},
+						// Added for profiling in devtools
+						keep_classnames: isEnvProductionProfile,
+						keep_fnames: isEnvProductionProfile,
+						output: {
+							ecma: 5,
+							comments: false,
+							// Turned on because emoji and regex is not minified properly using default
+							// https://github.com/facebook/create-react-app/issues/2488
+							ascii_only: true,
+						},
+					},
+				}),
+				// This is only used in production mode
+				new CssMinimizerPlugin(),
+			],
+		},
+		resolve: {
+			// This allows you to set a fallback for where webpack should look for modules.
+			// We placed these paths second because we want `node_modules` to "win"
+			// if there are any conflicts. This matches Node resolution mechanism.
+			// https://github.com/facebook/create-react-app/issues/253
+			modules: ["node_modules", paths.appNodeModules].concat(
+				modules.additionalModulePaths || [],
+			),
+			// These are the reasonable defaults supported by the Node ecosystem.
+			// We also include JSX as a common component filename extension to support
+			// some tools, although we do not recommend using it, see:
+			// https://github.com/facebook/create-react-app/issues/290
+			// `web` extension prefixes have been added for better support
+			// for React Native Web.
+			extensions: paths.moduleFileExtensions
+				.map((ext) => `.${ext}`)
+				.filter((ext) => useTypeScript || !ext.includes("ts")),
+			alias: {
+				// Support React Native Web
+				// https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
+				"react-native": "react-native-web",
+				// Allows for better profiling with ReactDevTools
+				...(isEnvProductionProfile && {
+					"react-dom$": "react-dom/profiling",
+					"scheduler/tracing": "scheduler/tracing-profiling",
+				}),
+				...(modules.webpackAliases || {}),
+			},
+			plugins: [
+				// Prevents users from importing files from outside of src/ (or node_modules/).
+				// This often causes confusion because we only process files within src/ with babel.
+				// To fix this, we prevent you from importing files out of src/ -- if you'd like to,
+				// please link the files into your node_modules/ and let module-resolution kick in.
+				// Make sure your source files are compiled, as they will not be processed in any way.
+				new ModuleScopePlugin(paths.appSrc, [
+					paths.appPackageJson,
+					reactRefreshRuntimeEntry,
+					reactRefreshWebpackPluginRuntimeEntry,
+					babelRuntimeEntry,
+					babelRuntimeEntryHelpers,
+					babelRuntimeRegenerator,
+				]),
+			],
+		},
+		module: {
+			strictExportPresence: true,
+			rules: [
+				// Handle node_modules packages that contain sourcemaps
+				shouldUseSourceMap && {
+					enforce: "pre",
+					exclude: /@babel(?:\/|\\{1,2})runtime/,
+					test: /\.(js|mjs|jsx|ts|tsx|css)$/,
+					loader: require.resolve("source-map-loader"),
+				},
+				{
+					// "oneOf" will traverse all following loaders until one will
+					// match the requirements. When no loader matches it will fall
+					// back to the "file" loader at the end of the loader list.
+					oneOf: [
+						// TODO: Merge this config once `image/avif` is in the mime-db
+						// https://github.com/jshttp/mime-db
+						{
+							test: [/\.avif$/],
+							type: "asset",
+							mimetype: "image/avif",
+							parser: {
+								dataUrlCondition: {
+									maxSize: imageInlineSizeLimit,
+								},
+							},
+						},
+						// "url" loader works like "file" loader except that it embeds assets
+						// smaller than specified limit in bytes as data URLs to avoid requests.
+						// A missing `test` is equivalent to a match.
+						{
+							test: [/\.bmp$/, /\.gif$/, /\.jpe?g$/, /\.png$/],
+							type: "asset",
+							parser: {
+								dataUrlCondition: {
+									maxSize: imageInlineSizeLimit,
+								},
+							},
+						},
+						{
+							test: /\.svg$/,
+							use: [
+								{
+									loader: require.resolve("@svgr/webpack"),
+									options: {
+										prettier: false,
+										svgo: false,
+										svgoConfig: {
+											plugins: [{ removeViewBox: false }],
+										},
+										titleProp: true,
+										ref: true,
+									},
+								},
+								{
+									loader: require.resolve("file-loader"),
+									options: {
+										name: "static/media/[name].[hash].[ext]",
+									},
+								},
+							],
+							issuer: {
+								and: [/\.(ts|tsx|js|jsx|md|mdx)$/],
+							},
+						},
+						// Process application JS with Babel.
+						// The preset includes JSX, Flow, TypeScript, and some ESnext features.
+						{
+							test: /\.(js|mjs|jsx|ts|tsx)$/,
+							include: paths.appSrc,
+							loader: require.resolve("babel-loader"),
+							options: {
+								customize: require.resolve(
+									"babel-preset-react-app/webpack-overrides",
+								),
+								presets: [
+									[
+										require.resolve("babel-preset-react-app"),
+										{
+											runtime: hasJsxRuntime ? "automatic" : "classic",
+										},
+									],
+								],
 
-          return {
-            files: manifestFiles,
-            entrypoints: entrypointFiles,
-          };
-        },
-      }),
-      // Moment.js is an extremely popular library that bundles large locale files
-      // by default due to how webpack interprets its code. This is a practical
-      // solution that requires the user to opt into importing specific locales.
-      // https://github.com/jmblog/how-to-optimize-momentjs-with-webpack
-      // You can remove this if you don't use Moment.js:
-      new webpack.IgnorePlugin({
-        resourceRegExp: /^\.\/locale$/,
-        contextRegExp: /moment$/,
-      }),
-      // Generate a service worker script that will precache, and keep up to date,
-      // the HTML & assets that are part of the webpack build.
-      isEnvProduction &&
-        fs.existsSync(swSrc) &&
-        new WorkboxWebpackPlugin.InjectManifest({
-          swSrc,
-          dontCacheBustURLsMatching: /\.[0-9a-f]{8}\./,
-          exclude: [/\.map$/, /asset-manifest\.json$/, /LICENSE/],
-          // Bump up the default maximum size (2mb) that's precached,
-          // to make lazy-loading failure scenarios less likely.
-          // See https://github.com/cra-template/pwa/issues/13#issuecomment-722667270
-          maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
-        }),
-      // TypeScript type checking
-      useTypeScript &&
-        new ForkTsCheckerWebpackPlugin({
-          async: isEnvDevelopment,
-          typescript: {
-            typescriptPath: resolve.sync('typescript', {
-              basedir: paths.appNodeModules,
-            }),
-            configOverwrite: {
-              compilerOptions: {
-                sourceMap: isEnvProduction
-                  ? shouldUseSourceMap
-                  : isEnvDevelopment,
-                skipLibCheck: true,
-                inlineSourceMap: false,
-                declarationMap: false,
-                noEmit: true,
-                incremental: true,
-                tsBuildInfoFile: paths.appTsBuildInfoFile,
-              },
-            },
-            context: paths.appPath,
-            diagnosticOptions: {
-              syntactic: true,
-            },
-            mode: 'write-references',
-            // profile: true,
-          },
-          issue: {
-            // This one is specifically to match during CI tests,
-            // as micromatch doesn't match
-            // '../cra-template-typescript/template/src/App.tsx'
-            // otherwise.
-            include: [
-              { file: '../**/src/**/*.{ts,tsx}' },
-              { file: '**/src/**/*.{ts,tsx}' },
-            ],
-            exclude: [
-              { file: '**/src/**/__tests__/**' },
-              { file: '**/src/**/?(*.){spec|test}.*' },
-              { file: '**/src/setupProxy.*' },
-              { file: '**/src/setupTests.*' },
-            ],
-          },
-          logger: {
-            infrastructure: 'silent',
-          },
-        }),
-      !disableESLintPlugin &&
-        new ESLintPlugin({
-          // Plugin options
-          extensions: ['js', 'mjs', 'jsx', 'ts', 'tsx'],
-          formatter: require.resolve('react-dev-utils/eslintFormatter'),
-          eslintPath: require.resolve('eslint'),
-          failOnError: !(isEnvDevelopment && emitErrorsAsWarnings),
-          context: paths.appSrc,
-          cache: true,
-          cacheLocation: path.resolve(
-            paths.appNodeModules,
-            '.cache/.eslintcache'
-          ),
-          // ESLint class options
-          cwd: paths.appPath,
-          resolvePluginsRelativeTo: __dirname,
-          baseConfig: {
-            extends: [require.resolve('eslint-config-react-app/base')],
-            rules: {
-              ...(!hasJsxRuntime && {
-                'react/react-in-jsx-scope': 'error',
-              }),
-            },
-          },
-        }),
-    ].filter(Boolean),
-    // Turn off performance processing because we utilize
-    // our own hints via the FileSizeReporter
-    performance: false,
-  };
+								plugins: [
+									isEnvDevelopment &&
+										shouldUseReactRefresh &&
+										require.resolve("react-refresh/babel"),
+								].filter(Boolean),
+								// This is a feature of `babel-loader` for webpack (not Babel itself).
+								// It enables caching results in ./node_modules/.cache/babel-loader/
+								// directory for faster rebuilds.
+								cacheDirectory: true,
+								// See #6846 for context on why cacheCompression is disabled
+								cacheCompression: false,
+								compact: isEnvProduction,
+							},
+						},
+						// Process any JS outside of the app with Babel.
+						// Unlike the application JS, we only compile the standard ES features.
+						{
+							test: /\.(js|mjs)$/,
+							exclude: /@babel(?:\/|\\{1,2})runtime/,
+							loader: require.resolve("babel-loader"),
+							options: {
+								babelrc: false,
+								configFile: false,
+								compact: false,
+								presets: [
+									[
+										require.resolve("babel-preset-react-app/dependencies"),
+										{ helpers: true },
+									],
+								],
+								cacheDirectory: true,
+								// See #6846 for context on why cacheCompression is disabled
+								cacheCompression: false,
+
+								// Babel sourcemaps are needed for debugging into node_modules
+								// code.  Without the options below, debuggers like VSCode
+								// show incorrect code and set breakpoints on the wrong lines.
+								sourceMaps: shouldUseSourceMap,
+								inputSourceMap: shouldUseSourceMap,
+							},
+						},
+						// "postcss" loader applies autoprefixer to our CSS.
+						// "css" loader resolves paths in CSS and adds assets as dependencies.
+						// "style" loader turns CSS into JS modules that inject <style> tags.
+						// In production, we use MiniCSSExtractPlugin to extract that CSS
+						// to a file, but in development "style" loader enables hot editing
+						// of CSS.
+						// By default we support CSS Modules with the extension .module.css
+						{
+							test: cssRegex,
+							exclude: cssModuleRegex,
+							use: getStyleLoaders({
+								importLoaders: 1,
+								sourceMap: isEnvProduction
+									? shouldUseSourceMap
+									: isEnvDevelopment,
+								modules: {
+									mode: "icss",
+								},
+							}),
+							// Don't consider CSS imports dead code even if the
+							// containing package claims to have no side effects.
+							// Remove this when webpack adds a warning or an error for this.
+							// See https://github.com/webpack/webpack/issues/6571
+							sideEffects: true,
+						},
+						// Adds support for CSS Modules (https://github.com/css-modules/css-modules)
+						// using the extension .module.css
+						{
+							test: cssModuleRegex,
+							use: getStyleLoaders({
+								importLoaders: 1,
+								sourceMap: isEnvProduction
+									? shouldUseSourceMap
+									: isEnvDevelopment,
+								modules: {
+									mode: "local",
+									getLocalIdent: getCSSModuleLocalIdent,
+								},
+							}),
+						},
+						// Opt-in support for SASS (using .scss or .sass extensions).
+						// By default we support SASS Modules with the
+						// extensions .module.scss or .module.sass
+						{
+							test: sassRegex,
+							exclude: sassModuleRegex,
+							use: getStyleLoaders(
+								{
+									importLoaders: 3,
+									sourceMap: isEnvProduction
+										? shouldUseSourceMap
+										: isEnvDevelopment,
+									modules: {
+										mode: "icss",
+									},
+								},
+								"sass-loader",
+							),
+							// Don't consider CSS imports dead code even if the
+							// containing package claims to have no side effects.
+							// Remove this when webpack adds a warning or an error for this.
+							// See https://github.com/webpack/webpack/issues/6571
+							sideEffects: true,
+						},
+						// Adds support for CSS Modules, but using SASS
+						// using the extension .module.scss or .module.sass
+						{
+							test: sassModuleRegex,
+							use: getStyleLoaders(
+								{
+									importLoaders: 3,
+									sourceMap: isEnvProduction
+										? shouldUseSourceMap
+										: isEnvDevelopment,
+									modules: {
+										mode: "local",
+										getLocalIdent: getCSSModuleLocalIdent,
+									},
+								},
+								"sass-loader",
+							),
+						},
+						// "file" loader makes sure those assets get served by WebpackDevServer.
+						// When you `import` an asset, you get its (virtual) filename.
+						// In production, they would get copied to the `build` folder.
+						// This loader doesn't use a "test" so it will catch all modules
+						// that fall through the other loaders.
+						{
+							// Exclude `js` files to keep "css" loader working as it injects
+							// its runtime that would otherwise be processed through "file" loader.
+							// Also exclude `html` and `json` extensions so they get processed
+							// by webpacks internal loaders.
+							exclude: [/^$/, /\.(js|mjs|jsx|ts|tsx)$/, /\.html$/, /\.json$/],
+							type: "asset/resource",
+						},
+						// ** STOP ** Are you adding a new loader?
+						// Make sure to add the new loader(s) before the "file" loader.
+					],
+				},
+			].filter(Boolean),
+		},
+		plugins: [
+			// Generates an `index.html` file with the <script> injected.
+			new HtmlWebpackPlugin(
+				Object.assign(
+					{},
+					{
+						inject: true,
+						template: paths.appHtml,
+					},
+					isEnvProduction
+						? {
+								minify: {
+									removeComments: true,
+									collapseWhitespace: true,
+									removeRedundantAttributes: true,
+									useShortDoctype: true,
+									removeEmptyAttributes: true,
+									removeStyleLinkTypeAttributes: true,
+									keepClosingSlash: true,
+									minifyJS: true,
+									minifyCSS: true,
+									minifyURLs: true,
+								},
+							}
+						: undefined,
+				),
+			),
+			// Inlines the webpack runtime script. This script is too small to warrant
+			// a network request.
+			// https://github.com/facebook/create-react-app/issues/5358
+			isEnvProduction &&
+				shouldInlineRuntimeChunk &&
+				new InlineChunkHtmlPlugin(HtmlWebpackPlugin, [/runtime-.+[.]js/]),
+			// Makes some environment variables available in index.html.
+			// The public URL is available as %PUBLIC_URL% in index.html, e.g.:
+			// <link rel="icon" href="%PUBLIC_URL%/favicon.ico">
+			// It will be an empty string unless you specify "homepage"
+			// in `package.json`, in which case it will be the pathname of that URL.
+			new InterpolateHtmlPlugin(HtmlWebpackPlugin, env.raw),
+			// This gives some necessary context to module not found errors, such as
+			// the requesting resource.
+			new ModuleNotFoundPlugin(paths.appPath),
+			// Makes some environment variables available to the JS code, for example:
+			// if (process.env.NODE_ENV === 'production') { ... }. See `./env.js`.
+			// It is absolutely essential that NODE_ENV is set to production
+			// during a production build.
+			// Otherwise React will be compiled in the very slow development mode.
+			new webpack.DefinePlugin(env.stringified),
+			// Experimental hot reloading for React .
+			// https://github.com/facebook/react/tree/main/packages/react-refresh
+			isEnvDevelopment &&
+				shouldUseReactRefresh &&
+				new ReactRefreshWebpackPlugin({
+					overlay: false,
+				}),
+			// Watcher doesn't work well if you mistype casing in a path so we use
+			// a plugin that prints an error when you attempt to do this.
+			// See https://github.com/facebook/create-react-app/issues/240
+			isEnvDevelopment && new CaseSensitivePathsPlugin(),
+			isEnvProduction &&
+				new MiniCssExtractPlugin({
+					// Options similar to the same options in webpackOptions.output
+					// both options are optional
+					filename: "static/css/[name].[contenthash:8].css",
+					chunkFilename: "static/css/[name].[contenthash:8].chunk.css",
+				}),
+			// Generate an asset manifest file with the following content:
+			// - "files" key: Mapping of all asset filenames to their corresponding
+			//   output file so that tools can pick it up without having to parse
+			//   `index.html`
+			// - "entrypoints" key: Array of files which are included in `index.html`,
+			//   can be used to reconstruct the HTML if necessary
+			new WebpackManifestPlugin({
+				fileName: "asset-manifest.json",
+				publicPath: paths.publicUrlOrPath,
+				generate: (seed, files, entrypoints) => {
+					const manifestFiles = files.reduce((manifest, file) => {
+						manifest[file.name] = file.path;
+						return manifest;
+					}, seed);
+					const entrypointFiles = entrypoints.main.filter(
+						(fileName) => !fileName.endsWith(".map"),
+					);
+
+					return {
+						files: manifestFiles,
+						entrypoints: entrypointFiles,
+					};
+				},
+			}),
+			// Moment.js is an extremely popular library that bundles large locale files
+			// by default due to how webpack interprets its code. This is a practical
+			// solution that requires the user to opt into importing specific locales.
+			// https://github.com/jmblog/how-to-optimize-momentjs-with-webpack
+			// You can remove this if you don't use Moment.js:
+			new webpack.IgnorePlugin({
+				resourceRegExp: /^\.\/locale$/,
+				contextRegExp: /moment$/,
+			}),
+			// Generate a service worker script that will precache, and keep up to date,
+			// the HTML & assets that are part of the webpack build.
+			isEnvProduction &&
+				fs.existsSync(swSrc) &&
+				new WorkboxWebpackPlugin.InjectManifest({
+					swSrc,
+					dontCacheBustURLsMatching: /\.[0-9a-f]{8}\./,
+					exclude: [/\.map$/, /asset-manifest\.json$/, /LICENSE/],
+					// Bump up the default maximum size (2mb) that's precached,
+					// to make lazy-loading failure scenarios less likely.
+					// See https://github.com/cra-template/pwa/issues/13#issuecomment-722667270
+					maximumFileSizeToCacheInBytes: 5 * 1024 * 1024,
+				}),
+			// TypeScript type checking
+			useTypeScript &&
+				new ForkTsCheckerWebpackPlugin({
+					async: isEnvDevelopment,
+					typescript: {
+						typescriptPath: resolve.sync("typescript", {
+							basedir: paths.appNodeModules,
+						}),
+						configOverwrite: {
+							compilerOptions: {
+								sourceMap: isEnvProduction
+									? shouldUseSourceMap
+									: isEnvDevelopment,
+								skipLibCheck: true,
+								inlineSourceMap: false,
+								declarationMap: false,
+								noEmit: true,
+								incremental: true,
+								tsBuildInfoFile: paths.appTsBuildInfoFile,
+							},
+						},
+						context: paths.appPath,
+						diagnosticOptions: {
+							syntactic: true,
+						},
+						mode: "write-references",
+						// profile: true,
+					},
+					issue: {
+						// This one is specifically to match during CI tests,
+						// as micromatch doesn't match
+						// '../cra-template-typescript/template/src/App.tsx'
+						// otherwise.
+						include: [
+							{ file: "../**/src/**/*.{ts,tsx}" },
+							{ file: "**/src/**/*.{ts,tsx}" },
+						],
+						exclude: [
+							{ file: "**/src/**/__tests__/**" },
+							{ file: "**/src/**/?(*.){spec|test}.*" },
+							{ file: "**/src/setupProxy.*" },
+							{ file: "**/src/setupTests.*" },
+						],
+					},
+					logger: {
+						infrastructure: "silent",
+					},
+				}),
+			!disableESLintPlugin &&
+				new ESLintPlugin({
+					// Plugin options
+					extensions: ["js", "mjs", "jsx", "ts", "tsx"],
+					formatter: require.resolve("react-dev-utils/eslintFormatter"),
+					eslintPath: require.resolve("eslint"),
+					failOnError: !(isEnvDevelopment && emitErrorsAsWarnings),
+					context: paths.appSrc,
+					cache: true,
+					cacheLocation: path.resolve(
+						paths.appNodeModules,
+						".cache/.eslintcache",
+					),
+					// ESLint class options
+					cwd: paths.appPath,
+					resolvePluginsRelativeTo: __dirname,
+					baseConfig: {
+						extends: [require.resolve("eslint-config-react-app/base")],
+						rules: {
+							...(!hasJsxRuntime && {
+								"react/react-in-jsx-scope": "error",
+							}),
+						},
+					},
+				}),
+		].filter(Boolean),
+		// Turn off performance processing because we utilize
+		// our own hints via the FileSizeReporter
+		performance: false,
+	};
 };

--- a/ui/config/webpack/persistentCache/createEnvironmentHash.js
+++ b/ui/config/webpack/persistentCache/createEnvironmentHash.js
@@ -1,9 +1,9 @@
-'use strict';
-const { createHash } = require('crypto');
+"use strict";
+const { createHash } = require("crypto");
 
-module.exports = env => {
-  const hash = createHash('md5');
-  hash.update(JSON.stringify(env));
+module.exports = (env) => {
+	const hash = createHash("md5");
+	hash.update(JSON.stringify(env));
 
-  return hash.digest('hex');
+	return hash.digest("hex");
 };

--- a/ui/config/webpackDevServer.config.js
+++ b/ui/config/webpackDevServer.config.js
@@ -1,138 +1,138 @@
-'use strict';
+"use strict";
 
-const fs = require('fs');
-const evalSourceMapMiddleware = require('react-dev-utils/evalSourceMapMiddleware');
-const noopServiceWorkerMiddleware = require('react-dev-utils/noopServiceWorkerMiddleware');
-const ignoredFiles = require('react-dev-utils/ignoredFiles');
-const redirectServedPath = require('react-dev-utils/redirectServedPathMiddleware');
-const paths = require('./paths');
-const getHttpsConfig = require('./getHttpsConfig');
+const fs = require("fs");
+const evalSourceMapMiddleware = require("react-dev-utils/evalSourceMapMiddleware");
+const noopServiceWorkerMiddleware = require("react-dev-utils/noopServiceWorkerMiddleware");
+const ignoredFiles = require("react-dev-utils/ignoredFiles");
+const redirectServedPath = require("react-dev-utils/redirectServedPathMiddleware");
+const paths = require("./paths");
+const getHttpsConfig = require("./getHttpsConfig");
 
-const host = process.env.HOST || '0.0.0.0';
+const host = process.env.HOST || "0.0.0.0";
 const sockHost = process.env.WDS_SOCKET_HOST;
 const sockPath = process.env.WDS_SOCKET_PATH; // default: '/ws'
 const sockPort = process.env.WDS_SOCKET_PORT;
 
 module.exports = function (proxy, allowedHost) {
-  const disableFirewall =
-    !proxy || process.env.DANGEROUSLY_DISABLE_HOST_CHECK === 'true';
-  return {
-    // WebpackDevServer 2.4.3 introduced a security fix that prevents remote
-    // websites from potentially accessing local content through DNS rebinding:
-    // https://github.com/webpack/webpack-dev-server/issues/887
-    // https://medium.com/webpack/webpack-dev-server-middleware-security-issues-1489d950874a
-    // However, it made several existing use cases such as development in cloud
-    // environment or subdomains in development significantly more complicated:
-    // https://github.com/facebook/create-react-app/issues/2271
-    // https://github.com/facebook/create-react-app/issues/2233
-    // While we're investigating better solutions, for now we will take a
-    // compromise. Since our WDS configuration only serves files in the `public`
-    // folder we won't consider accessing them a vulnerability. However, if you
-    // use the `proxy` feature, it gets more dangerous because it can expose
-    // remote code execution vulnerabilities in backends like Django and Rails.
-    // So we will disable the host check normally, but enable it if you have
-    // specified the `proxy` setting. Finally, we let you override it if you
-    // really know what you're doing with a special environment variable.
-    // Note: ["localhost", ".localhost"] will support subdomains - but we might
-    // want to allow setting the allowedHosts manually for more complex setups
-    allowedHosts: disableFirewall ? 'all' : [allowedHost],
-    headers: {
-      'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Methods': '*',
-      'Access-Control-Allow-Headers': '*',
-    },
-    // Enable gzip compression of generated files.
-    compress: true,
-    static: {
-      // By default WebpackDevServer serves physical files from current directory
-      // in addition to all the virtual build products that it serves from memory.
-      // This is confusing because those files won’t automatically be available in
-      // production build folder unless we copy them. However, copying the whole
-      // project directory is dangerous because we may expose sensitive files.
-      // Instead, we establish a convention that only files in `public` directory
-      // get served. Our build script will copy `public` into the `build` folder.
-      // In `index.html`, you can get URL of `public` folder with %PUBLIC_URL%:
-      // <link rel="icon" href="%PUBLIC_URL%/favicon.ico">
-      // In JavaScript code, you can access it with `process.env.PUBLIC_URL`.
-      // Note that we only recommend to use `public` folder as an escape hatch
-      // for files like `favicon.ico`, `manifest.json`, and libraries that are
-      // for some reason broken when imported through webpack. If you just want to
-      // use an image, put it in `src` and `import` it from JavaScript instead.
-      directory: paths.appPublic,
-      publicPath: [paths.publicUrlOrPath],
-      // By default files from `contentBase` will not trigger a page reload.
-      watch: {
-        // Reportedly, this avoids CPU overload on some systems.
-        // https://github.com/facebook/create-react-app/issues/293
-        // src/node_modules is not ignored to support absolute imports
-        // https://github.com/facebook/create-react-app/issues/1065
-        ignored: ignoredFiles(paths.appSrc),
-      },
-    },
-    client: {
-      webSocketURL: {
-        // Enable custom sockjs pathname for websocket connection to hot reloading server.
-        // Enable custom sockjs hostname, pathname and port for websocket connection
-        // to hot reloading server.
-        hostname: sockHost,
-        pathname: sockPath,
-        port: sockPort,
-      },
-      overlay: {
-        errors: true,
-        warnings: false,
-      },
-    },
-    devMiddleware: {
-      // It is important to tell WebpackDevServer to use the same "publicPath" path as
-      // we specified in the webpack config. When homepage is '.', default to serving
-      // from the root.
-      // remove last slash so user can land on `/test` instead of `/test/`
-      publicPath: paths.publicUrlOrPath.slice(0, -1),
-    },
+	const disableFirewall =
+		!proxy || process.env.DANGEROUSLY_DISABLE_HOST_CHECK === "true";
+	return {
+		// WebpackDevServer 2.4.3 introduced a security fix that prevents remote
+		// websites from potentially accessing local content through DNS rebinding:
+		// https://github.com/webpack/webpack-dev-server/issues/887
+		// https://medium.com/webpack/webpack-dev-server-middleware-security-issues-1489d950874a
+		// However, it made several existing use cases such as development in cloud
+		// environment or subdomains in development significantly more complicated:
+		// https://github.com/facebook/create-react-app/issues/2271
+		// https://github.com/facebook/create-react-app/issues/2233
+		// While we're investigating better solutions, for now we will take a
+		// compromise. Since our WDS configuration only serves files in the `public`
+		// folder we won't consider accessing them a vulnerability. However, if you
+		// use the `proxy` feature, it gets more dangerous because it can expose
+		// remote code execution vulnerabilities in backends like Django and Rails.
+		// So we will disable the host check normally, but enable it if you have
+		// specified the `proxy` setting. Finally, we let you override it if you
+		// really know what you're doing with a special environment variable.
+		// Note: ["localhost", ".localhost"] will support subdomains - but we might
+		// want to allow setting the allowedHosts manually for more complex setups
+		allowedHosts: disableFirewall ? "all" : [allowedHost],
+		headers: {
+			"Access-Control-Allow-Origin": "*",
+			"Access-Control-Allow-Methods": "*",
+			"Access-Control-Allow-Headers": "*",
+		},
+		// Enable gzip compression of generated files.
+		compress: true,
+		static: {
+			// By default WebpackDevServer serves physical files from current directory
+			// in addition to all the virtual build products that it serves from memory.
+			// This is confusing because those files won’t automatically be available in
+			// production build folder unless we copy them. However, copying the whole
+			// project directory is dangerous because we may expose sensitive files.
+			// Instead, we establish a convention that only files in `public` directory
+			// get served. Our build script will copy `public` into the `build` folder.
+			// In `index.html`, you can get URL of `public` folder with %PUBLIC_URL%:
+			// <link rel="icon" href="%PUBLIC_URL%/favicon.ico">
+			// In JavaScript code, you can access it with `process.env.PUBLIC_URL`.
+			// Note that we only recommend to use `public` folder as an escape hatch
+			// for files like `favicon.ico`, `manifest.json`, and libraries that are
+			// for some reason broken when imported through webpack. If you just want to
+			// use an image, put it in `src` and `import` it from JavaScript instead.
+			directory: paths.appPublic,
+			publicPath: [paths.publicUrlOrPath],
+			// By default files from `contentBase` will not trigger a page reload.
+			watch: {
+				// Reportedly, this avoids CPU overload on some systems.
+				// https://github.com/facebook/create-react-app/issues/293
+				// src/node_modules is not ignored to support absolute imports
+				// https://github.com/facebook/create-react-app/issues/1065
+				ignored: ignoredFiles(paths.appSrc),
+			},
+		},
+		client: {
+			webSocketURL: {
+				// Enable custom sockjs pathname for websocket connection to hot reloading server.
+				// Enable custom sockjs hostname, pathname and port for websocket connection
+				// to hot reloading server.
+				hostname: sockHost,
+				pathname: sockPath,
+				port: sockPort,
+			},
+			overlay: {
+				errors: true,
+				warnings: false,
+			},
+		},
+		devMiddleware: {
+			// It is important to tell WebpackDevServer to use the same "publicPath" path as
+			// we specified in the webpack config. When homepage is '.', default to serving
+			// from the root.
+			// remove last slash so user can land on `/test` instead of `/test/`
+			publicPath: paths.publicUrlOrPath.slice(0, -1),
+		},
 
-    host,
-    historyApiFallback: {
-      // Paths with dots should still use the history fallback.
-      // See https://github.com/facebook/create-react-app/issues/387.
-      disableDotRule: true,
-      index: paths.publicUrlOrPath,
-    },
-    // `proxy` is run between `before` and `after` `webpack-dev-server` hooks
-    proxy,
+		host,
+		historyApiFallback: {
+			// Paths with dots should still use the history fallback.
+			// See https://github.com/facebook/create-react-app/issues/387.
+			disableDotRule: true,
+			index: paths.publicUrlOrPath,
+		},
+		// `proxy` is run between `before` and `after` `webpack-dev-server` hooks
+		proxy,
 
-    server: getHttpsConfig(),
+		server: getHttpsConfig(),
 
-    setupMiddlewares: (middlewares, devServer) => {
-      if (!devServer) {
-        throw new Error("webpack-dev-server is not defined");
-      }
+		setupMiddlewares: (middlewares, devServer) => {
+			if (!devServer) {
+				throw new Error("webpack-dev-server is not defined");
+			}
 
-      if (fs.existsSync(paths.proxySetup)) {
-        // This registers user provided middleware for proxy reasons
-        require(paths.proxySetup)(devServer.app);
-      }
+			if (fs.existsSync(paths.proxySetup)) {
+				// This registers user provided middleware for proxy reasons
+				require(paths.proxySetup)(devServer.app);
+			}
 
-      middlewares.unshift(
-        // Keep `evalSourceMapMiddleware`
-        // middlewares before `redirectServedPath` otherwise will not have any effect
-        // This lets us fetch source contents from webpack for the error overlay
-        evalSourceMapMiddleware(devServer),
-      );
+			middlewares.unshift(
+				// Keep `evalSourceMapMiddleware`
+				// middlewares before `redirectServedPath` otherwise will not have any effect
+				// This lets us fetch source contents from webpack for the error overlay
+				evalSourceMapMiddleware(devServer),
+			);
 
-      middlewares.push(
-        // Redirect to `PUBLIC_URL` or `homepage` from `package.json` if url not match
-        redirectServedPath(paths.publicUrlOrPath),
+			middlewares.push(
+				// Redirect to `PUBLIC_URL` or `homepage` from `package.json` if url not match
+				redirectServedPath(paths.publicUrlOrPath),
 
-        // This service worker file is effectively a 'no-op' that will reset any
-        // previous service worker registered for the same host:port combination.
-        // We do this in development to avoid hitting the production cache if
-        // it used the same host and port.
-        // https://github.com/facebook/create-react-app/issues/2272#issuecomment-302832432
-        noopServiceWorkerMiddleware(paths.publicUrlOrPath),
-      );
+				// This service worker file is effectively a 'no-op' that will reset any
+				// previous service worker registered for the same host:port combination.
+				// We do this in development to avoid hitting the production cache if
+				// it used the same host and port.
+				// https://github.com/facebook/create-react-app/issues/2272#issuecomment-302832432
+				noopServiceWorkerMiddleware(paths.publicUrlOrPath),
+			);
 
-      return middlewares;
-    },
-  };
+			return middlewares;
+		},
+	};
 };

--- a/ui/package.json
+++ b/ui/package.json
@@ -136,8 +136,8 @@
     "redocly": "env-cmd -f ./redocly.env redocly build-docs --output public/api/index.html",
     "redocly-lint": "env-cmd -f ./redocly.env redocly lint",
     "lint": "npm run eslint && npm run dockerlint && npm run mdlint && npm run redocly-lint",
-    "prettier-check": "prettier --check \"src/**/*.ts\" \"src/**/*.tsx\"",
-    "prettier-write": "prettier --write \"src/**/*.ts\" \"src/**/*.tsx\"",
+    "prettier-check": "prettier . --check",
+    "prettier-write": "prettier . --write",
     "precommit": "npm run lint && npm audit --omit=dev --audit-level=high && npm run prettier-write && npm run extract && npm run compile",
     "typescript-check": "npx tsc"
   },

--- a/ui/scripts/build.js
+++ b/ui/scripts/build.js
@@ -1,34 +1,34 @@
-'use strict';
+"use strict";
 
 // Do this as the first thing so that any code reading it knows the right env.
-process.env.BABEL_ENV = 'production';
-process.env.NODE_ENV = 'production';
+process.env.BABEL_ENV = "production";
+process.env.NODE_ENV = "production";
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
 // terminate the Node.js process with a non-zero exit code.
-process.on('unhandledRejection', err => {
-  throw err;
+process.on("unhandledRejection", (err) => {
+	throw err;
 });
 
 // Ensure environment variables are read.
-require('../config/env');
+require("../config/env");
 
-const path = require('path');
-const chalk = require('react-dev-utils/chalk');
-const fs = require('fs-extra');
-const bfj = require('bfj');
-const webpack = require('webpack');
-const configFactory = require('../config/webpack.config');
-const paths = require('../config/paths');
-const checkRequiredFiles = require('react-dev-utils/checkRequiredFiles');
-const formatWebpackMessages = require('react-dev-utils/formatWebpackMessages');
-const printHostingInstructions = require('react-dev-utils/printHostingInstructions');
-const FileSizeReporter = require('react-dev-utils/FileSizeReporter');
-const printBuildError = require('react-dev-utils/printBuildError');
+const path = require("path");
+const chalk = require("react-dev-utils/chalk");
+const fs = require("fs-extra");
+const bfj = require("bfj");
+const webpack = require("webpack");
+const configFactory = require("../config/webpack.config");
+const paths = require("../config/paths");
+const checkRequiredFiles = require("react-dev-utils/checkRequiredFiles");
+const formatWebpackMessages = require("react-dev-utils/formatWebpackMessages");
+const printHostingInstructions = require("react-dev-utils/printHostingInstructions");
+const FileSizeReporter = require("react-dev-utils/FileSizeReporter");
+const printBuildError = require("react-dev-utils/printBuildError");
 
 const measureFileSizesBeforeBuild =
-  FileSizeReporter.measureFileSizesBeforeBuild;
+	FileSizeReporter.measureFileSizesBeforeBuild;
 const printFileSizesAfterBuild = FileSizeReporter.printFileSizesAfterBuild;
 const useYarn = fs.existsSync(paths.yarnLockFile);
 
@@ -40,178 +40,178 @@ const isInteractive = process.stdout.isTTY;
 
 // Warn and crash if required files are missing
 if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {
-  process.exit(1);
+	process.exit(1);
 }
 
 const argv = process.argv.slice(2);
-const writeStatsJson = argv.indexOf('--stats') !== -1;
+const writeStatsJson = argv.indexOf("--stats") !== -1;
 
 // Generate configuration
-const config = configFactory('production');
+const config = configFactory("production");
 
 // We require that you explicitly set browsers and do not fall back to
 // browserslist defaults.
-const { checkBrowsers } = require('react-dev-utils/browsersHelper');
+const { checkBrowsers } = require("react-dev-utils/browsersHelper");
 checkBrowsers(paths.appPath, isInteractive)
-  .then(() => {
-    // First, read the current file sizes in build directory.
-    // This lets us display how much they changed later.
-    return measureFileSizesBeforeBuild(paths.appBuild);
-  })
-  .then(previousFileSizes => {
-    // Remove all content but keep the directory so that
-    // if you're in it, you don't end up in Trash
-    fs.emptyDirSync(paths.appBuild);
-    // Merge with the public folder
-    copyPublicFolder();
-    // Start the webpack build
-    return build(previousFileSizes);
-  })
-  .then(
-    ({ stats, previousFileSizes, warnings }) => {
-      if (warnings.length) {
-        console.log(chalk.yellow('Compiled with warnings.\n'));
-        console.log(warnings.join('\n\n'));
-        console.log(
-          '\nSearch for the ' +
-            chalk.underline(chalk.yellow('keywords')) +
-            ' to learn more about each warning.'
-        );
-        console.log(
-          'To ignore, add ' +
-            chalk.cyan('// eslint-disable-next-line') +
-            ' to the line before.\n'
-        );
-      } else {
-        console.log(chalk.green('Compiled successfully.\n'));
-      }
+	.then(() => {
+		// First, read the current file sizes in build directory.
+		// This lets us display how much they changed later.
+		return measureFileSizesBeforeBuild(paths.appBuild);
+	})
+	.then((previousFileSizes) => {
+		// Remove all content but keep the directory so that
+		// if you're in it, you don't end up in Trash
+		fs.emptyDirSync(paths.appBuild);
+		// Merge with the public folder
+		copyPublicFolder();
+		// Start the webpack build
+		return build(previousFileSizes);
+	})
+	.then(
+		({ stats, previousFileSizes, warnings }) => {
+			if (warnings.length) {
+				console.log(chalk.yellow("Compiled with warnings.\n"));
+				console.log(warnings.join("\n\n"));
+				console.log(
+					"\nSearch for the " +
+						chalk.underline(chalk.yellow("keywords")) +
+						" to learn more about each warning.",
+				);
+				console.log(
+					"To ignore, add " +
+						chalk.cyan("// eslint-disable-next-line") +
+						" to the line before.\n",
+				);
+			} else {
+				console.log(chalk.green("Compiled successfully.\n"));
+			}
 
-      console.log('File sizes after gzip:\n');
-      printFileSizesAfterBuild(
-        stats,
-        previousFileSizes,
-        paths.appBuild,
-        WARN_AFTER_BUNDLE_GZIP_SIZE,
-        WARN_AFTER_CHUNK_GZIP_SIZE
-      );
-      console.log();
+			console.log("File sizes after gzip:\n");
+			printFileSizesAfterBuild(
+				stats,
+				previousFileSizes,
+				paths.appBuild,
+				WARN_AFTER_BUNDLE_GZIP_SIZE,
+				WARN_AFTER_CHUNK_GZIP_SIZE,
+			);
+			console.log();
 
-      const appPackage = require(paths.appPackageJson);
-      const publicUrl = paths.publicUrlOrPath;
-      const publicPath = config.output.publicPath;
-      const buildFolder = path.relative(process.cwd(), paths.appBuild);
-      printHostingInstructions(
-        appPackage,
-        publicUrl,
-        publicPath,
-        buildFolder,
-        useYarn
-      );
-    },
-    err => {
-      const tscCompileOnError = process.env.TSC_COMPILE_ON_ERROR === 'true';
-      if (tscCompileOnError) {
-        console.log(
-          chalk.yellow(
-            'Compiled with the following type errors (you may want to check these before deploying your app):\n'
-          )
-        );
-        printBuildError(err);
-      } else {
-        console.log(chalk.red('Failed to compile.\n'));
-        printBuildError(err);
-        process.exit(1);
-      }
-    }
-  )
-  .catch(err => {
-    if (err && err.message) {
-      console.log(err.message);
-    }
-    process.exit(1);
-  });
+			const appPackage = require(paths.appPackageJson);
+			const publicUrl = paths.publicUrlOrPath;
+			const publicPath = config.output.publicPath;
+			const buildFolder = path.relative(process.cwd(), paths.appBuild);
+			printHostingInstructions(
+				appPackage,
+				publicUrl,
+				publicPath,
+				buildFolder,
+				useYarn,
+			);
+		},
+		(err) => {
+			const tscCompileOnError = process.env.TSC_COMPILE_ON_ERROR === "true";
+			if (tscCompileOnError) {
+				console.log(
+					chalk.yellow(
+						"Compiled with the following type errors (you may want to check these before deploying your app):\n",
+					),
+				);
+				printBuildError(err);
+			} else {
+				console.log(chalk.red("Failed to compile.\n"));
+				printBuildError(err);
+				process.exit(1);
+			}
+		},
+	)
+	.catch((err) => {
+		if (err && err.message) {
+			console.log(err.message);
+		}
+		process.exit(1);
+	});
 
 // Create the production build and print the deployment instructions.
 function build(previousFileSizes) {
-  console.log('Creating an optimized production build...');
+	console.log("Creating an optimized production build...");
 
-  const compiler = webpack(config);
-  return new Promise((resolve, reject) => {
-    compiler.run((err, stats) => {
-      let messages;
-      if (err) {
-        if (!err.message) {
-          return reject(err);
-        }
+	const compiler = webpack(config);
+	return new Promise((resolve, reject) => {
+		compiler.run((err, stats) => {
+			let messages;
+			if (err) {
+				if (!err.message) {
+					return reject(err);
+				}
 
-        let errMessage = err.message;
+				let errMessage = err.message;
 
-        // Add additional information for postcss errors
-        if (Object.prototype.hasOwnProperty.call(err, 'postcssNode')) {
-          errMessage +=
-            '\nCompileError: Begins at CSS selector ' +
-            err['postcssNode'].selector;
-        }
+				// Add additional information for postcss errors
+				if (Object.prototype.hasOwnProperty.call(err, "postcssNode")) {
+					errMessage +=
+						"\nCompileError: Begins at CSS selector " +
+						err["postcssNode"].selector;
+				}
 
-        messages = formatWebpackMessages({
-          errors: [errMessage],
-          warnings: [],
-        });
-      } else {
-        messages = formatWebpackMessages(
-          stats.toJson({ all: false, warnings: true, errors: true })
-        );
-      }
-      if (messages.errors.length) {
-        // Only keep the first error. Others are often indicative
-        // of the same problem, but confuse the reader with noise.
-        if (messages.errors.length > 1) {
-          messages.errors.length = 1;
-        }
-        return reject(new Error(messages.errors.join('\n\n')));
-      }
-      if (
-        process.env.CI &&
-        (typeof process.env.CI !== 'string' ||
-          process.env.CI.toLowerCase() !== 'false') &&
-        messages.warnings.length
-      ) {
-        // Ignore sourcemap warnings in CI builds. See #8227 for more info.
-        const filteredWarnings = messages.warnings.filter(
-          w => !/Failed to parse source map/.test(w)
-        );
-        if (filteredWarnings.length) {
-          console.log(
-            chalk.yellow(
-              '\nTreating warnings as errors because process.env.CI = true.\n' +
-                'Most CI servers set it automatically.\n'
-            )
-          );
-          return reject(new Error(filteredWarnings.join('\n\n')));
-        }
-      }
+				messages = formatWebpackMessages({
+					errors: [errMessage],
+					warnings: [],
+				});
+			} else {
+				messages = formatWebpackMessages(
+					stats.toJson({ all: false, warnings: true, errors: true }),
+				);
+			}
+			if (messages.errors.length) {
+				// Only keep the first error. Others are often indicative
+				// of the same problem, but confuse the reader with noise.
+				if (messages.errors.length > 1) {
+					messages.errors.length = 1;
+				}
+				return reject(new Error(messages.errors.join("\n\n")));
+			}
+			if (
+				process.env.CI &&
+				(typeof process.env.CI !== "string" ||
+					process.env.CI.toLowerCase() !== "false") &&
+				messages.warnings.length
+			) {
+				// Ignore sourcemap warnings in CI builds. See #8227 for more info.
+				const filteredWarnings = messages.warnings.filter(
+					(w) => !/Failed to parse source map/.test(w),
+				);
+				if (filteredWarnings.length) {
+					console.log(
+						chalk.yellow(
+							"\nTreating warnings as errors because process.env.CI = true.\n" +
+								"Most CI servers set it automatically.\n",
+						),
+					);
+					return reject(new Error(filteredWarnings.join("\n\n")));
+				}
+			}
 
-      const resolveArgs = {
-        stats,
-        previousFileSizes,
-        warnings: messages.warnings,
-      };
+			const resolveArgs = {
+				stats,
+				previousFileSizes,
+				warnings: messages.warnings,
+			};
 
-      if (writeStatsJson) {
-        return bfj
-          .write(paths.appBuild + '/bundle-stats.json', stats.toJson())
-          .then(() => resolve(resolveArgs))
-          .catch(error => reject(new Error(error)));
-      }
+			if (writeStatsJson) {
+				return bfj
+					.write(paths.appBuild + "/bundle-stats.json", stats.toJson())
+					.then(() => resolve(resolveArgs))
+					.catch((error) => reject(new Error(error)));
+			}
 
-      return resolve(resolveArgs);
-    });
-  });
+			return resolve(resolveArgs);
+		});
+	});
 }
 
 function copyPublicFolder() {
-  fs.copySync(paths.appPublic, paths.appBuild, {
-    dereference: true,
-    filter: file => file !== paths.appHtml,
-  });
+	fs.copySync(paths.appPublic, paths.appBuild, {
+		dereference: true,
+		filter: (file) => file !== paths.appHtml,
+	});
 }

--- a/ui/scripts/start.js
+++ b/ui/scripts/start.js
@@ -1,38 +1,38 @@
-'use strict';
+"use strict";
 
 // Do this as the first thing so that any code reading it knows the right env.
-process.env.BABEL_ENV = 'development';
-process.env.NODE_ENV = 'development';
+process.env.BABEL_ENV = "development";
+process.env.NODE_ENV = "development";
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
 // terminate the Node.js process with a non-zero exit code.
-process.on('unhandledRejection', err => {
-  throw err;
+process.on("unhandledRejection", (err) => {
+	throw err;
 });
 
 // Ensure environment variables are read.
-require('../config/env');
+require("../config/env");
 
-const fs = require('fs');
-const chalk = require('react-dev-utils/chalk');
-const webpack = require('webpack');
-const WebpackDevServer = require('webpack-dev-server');
-const clearConsole = require('react-dev-utils/clearConsole');
-const checkRequiredFiles = require('react-dev-utils/checkRequiredFiles');
+const fs = require("fs");
+const chalk = require("react-dev-utils/chalk");
+const webpack = require("webpack");
+const WebpackDevServer = require("webpack-dev-server");
+const clearConsole = require("react-dev-utils/clearConsole");
+const checkRequiredFiles = require("react-dev-utils/checkRequiredFiles");
 const {
-  choosePort,
-  createCompiler,
-  prepareProxy,
-  prepareUrls,
-} = require('react-dev-utils/WebpackDevServerUtils');
-const openBrowser = require('react-dev-utils/openBrowser');
-const semver = require('semver');
-const paths = require('../config/paths');
-const configFactory = require('../config/webpack.config');
-const createDevServerConfig = require('../config/webpackDevServer.config');
-const getClientEnvironment = require('../config/env');
-const react = require(require.resolve('react', { paths: [paths.appPath] }));
+	choosePort,
+	createCompiler,
+	prepareProxy,
+	prepareUrls,
+} = require("react-dev-utils/WebpackDevServerUtils");
+const openBrowser = require("react-dev-utils/openBrowser");
+const semver = require("semver");
+const paths = require("../config/paths");
+const configFactory = require("../config/webpack.config");
+const createDevServerConfig = require("../config/webpackDevServer.config");
+const getClientEnvironment = require("../config/env");
+const react = require(require.resolve("react", { paths: [paths.appPath] }));
 
 const env = getClientEnvironment(paths.publicUrlOrPath.slice(0, -1));
 const useYarn = fs.existsSync(paths.yarnLockFile);
@@ -40,115 +40,115 @@ const isInteractive = process.stdout.isTTY;
 
 // Warn and crash if required files are missing
 if (!checkRequiredFiles([paths.appHtml, paths.appIndexJs])) {
-  process.exit(1);
+	process.exit(1);
 }
 
 // Tools like Cloud9 rely on this.
 const DEFAULT_PORT = parseInt(process.env.PORT, 10) || 3000;
-const HOST = process.env.HOST || '0.0.0.0';
+const HOST = process.env.HOST || "0.0.0.0";
 
 if (process.env.HOST) {
-  console.log(
-    chalk.cyan(
-      `Attempting to bind to HOST environment variable: ${chalk.yellow(
-        chalk.bold(process.env.HOST)
-      )}`
-    )
-  );
-  console.log(
-    `If this was unintentional, check that you haven't mistakenly set it in your shell.`
-  );
-  console.log(
-    `Learn more here: ${chalk.yellow('https://cra.link/advanced-config')}`
-  );
-  console.log();
+	console.log(
+		chalk.cyan(
+			`Attempting to bind to HOST environment variable: ${chalk.yellow(
+				chalk.bold(process.env.HOST),
+			)}`,
+		),
+	);
+	console.log(
+		`If this was unintentional, check that you haven't mistakenly set it in your shell.`,
+	);
+	console.log(
+		`Learn more here: ${chalk.yellow("https://cra.link/advanced-config")}`,
+	);
+	console.log();
 }
 
 // We require that you explicitly set browsers and do not fall back to
 // browserslist defaults.
-const { checkBrowsers } = require('react-dev-utils/browsersHelper');
+const { checkBrowsers } = require("react-dev-utils/browsersHelper");
 checkBrowsers(paths.appPath, isInteractive)
-  .then(() => {
-    // We attempt to use the default port but if it is busy, we offer the user to
-    // run on a different port. `choosePort()` Promise resolves to the next free port.
-    return choosePort(HOST, DEFAULT_PORT);
-  })
-  .then(port => {
-    if (port == null) {
-      // We have not found a port.
-      return;
-    }
+	.then(() => {
+		// We attempt to use the default port but if it is busy, we offer the user to
+		// run on a different port. `choosePort()` Promise resolves to the next free port.
+		return choosePort(HOST, DEFAULT_PORT);
+	})
+	.then((port) => {
+		if (port == null) {
+			// We have not found a port.
+			return;
+		}
 
-    const config = configFactory('development');
-    const protocol = process.env.HTTPS === 'true' ? 'https' : 'http';
-    const appName = require(paths.appPackageJson).name;
+		const config = configFactory("development");
+		const protocol = process.env.HTTPS === "true" ? "https" : "http";
+		const appName = require(paths.appPackageJson).name;
 
-    const useTypeScript = fs.existsSync(paths.appTsConfig);
-    const urls = prepareUrls(
-      protocol,
-      HOST,
-      port,
-      paths.publicUrlOrPath.slice(0, -1)
-    );
-    // Create a webpack compiler that is configured with custom messages.
-    const compiler = createCompiler({
-      appName,
-      config,
-      urls,
-      useYarn,
-      useTypeScript,
-      webpack,
-    });
-    // Load proxy config
-    const proxySetting = require(paths.appPackageJson).proxy;
-    const proxyConfig = prepareProxy(
-      proxySetting,
-      paths.appPublic,
-      paths.publicUrlOrPath
-    );
-    // Serve webpack assets generated by the compiler over a web server.
-    const serverConfig = {
-      ...createDevServerConfig(proxyConfig, urls.lanUrlForConfig),
-      host: HOST,
-      port,
-    };
-    const devServer = new WebpackDevServer(serverConfig, compiler);
-    // Launch WebpackDevServer.
-    devServer.startCallback(() => {
-      if (isInteractive) {
-        clearConsole();
-      }
+		const useTypeScript = fs.existsSync(paths.appTsConfig);
+		const urls = prepareUrls(
+			protocol,
+			HOST,
+			port,
+			paths.publicUrlOrPath.slice(0, -1),
+		);
+		// Create a webpack compiler that is configured with custom messages.
+		const compiler = createCompiler({
+			appName,
+			config,
+			urls,
+			useYarn,
+			useTypeScript,
+			webpack,
+		});
+		// Load proxy config
+		const proxySetting = require(paths.appPackageJson).proxy;
+		const proxyConfig = prepareProxy(
+			proxySetting,
+			paths.appPublic,
+			paths.publicUrlOrPath,
+		);
+		// Serve webpack assets generated by the compiler over a web server.
+		const serverConfig = {
+			...createDevServerConfig(proxyConfig, urls.lanUrlForConfig),
+			host: HOST,
+			port,
+		};
+		const devServer = new WebpackDevServer(serverConfig, compiler);
+		// Launch WebpackDevServer.
+		devServer.startCallback(() => {
+			if (isInteractive) {
+				clearConsole();
+			}
 
-      if (env.raw.FAST_REFRESH && semver.lt(react.version, '16.10.0')) {
-        console.log(
-          chalk.yellow(
-            `Fast Refresh requires React 16.10 or higher. You are using React ${react.version}.`
-          )
-        );
-      }
+			if (env.raw.FAST_REFRESH && semver.lt(react.version, "16.10.0")) {
+				console.log(
+					chalk.yellow(
+						`Fast Refresh requires React 16.10 or higher. You are using React ${react.version}.`,
+					),
+				);
+			}
 
-      console.log(chalk.cyan('Starting the development server...\n'));
-      openBrowser(urls.localUrlForBrowser);
-    });
+			console.log(chalk.cyan("Starting the development server...\n"));
+			openBrowser(urls.localUrlForBrowser);
+		});
 
-    ['SIGINT', 'SIGTERM'].forEach(function (sig) {
-      process.on(sig, function () {
-        devServer.close();
-        process.exit();
-      });
-    });
+		["SIGINT", "SIGTERM"].forEach(function (sig) {
+			process.on(sig, function () {
+				devServer.close();
+				process.exit();
+			});
+		});
 
-    if (process.env.CI !== 'true') {
-      // Gracefully exit when stdin ends
-      process.stdin.on('end', function () {
-        devServer.close();
-        process.exit();
-      });
-    }
-  })
-  .catch(err => {
-    if (err && err.message) {
-      console.log(err.message);
-    }
-    process.exit(1);
-  });
+		if (process.env.CI !== "true") {
+			// Gracefully exit when stdin ends
+			process.stdin.on("end", function () {
+				devServer.close();
+				process.exit();
+			});
+		}
+	})
+	.catch((err) => {
+		if (err && err.message) {
+			console.log(err.message);
+		}
+		process.exit(1);
+	});

--- a/ui/scripts/test.js
+++ b/ui/scripts/test.js
@@ -1,52 +1,51 @@
-'use strict';
+"use strict";
 
 // Do this as the first thing so that any code reading it knows the right env.
-process.env.BABEL_ENV = 'test';
-process.env.NODE_ENV = 'test';
-process.env.PUBLIC_URL = '';
+process.env.BABEL_ENV = "test";
+process.env.NODE_ENV = "test";
+process.env.PUBLIC_URL = "";
 
 // Makes the script crash on unhandled rejections instead of silently
 // ignoring them. In the future, promise rejections that are not handled will
 // terminate the Node.js process with a non-zero exit code.
-process.on('unhandledRejection', err => {
-  throw err;
+process.on("unhandledRejection", (err) => {
+	throw err;
 });
 
 // Ensure environment variables are read.
-require('../config/env');
+require("../config/env");
 
-const jest = require('jest');
-const execSync = require('child_process').execSync;
+const jest = require("jest");
+const execSync = require("child_process").execSync;
 let argv = process.argv.slice(2);
 
 function isInGitRepository() {
-  try {
-    execSync('git rev-parse --is-inside-work-tree', { stdio: 'ignore' });
-    return true;
-  } catch (e) {
-    return false;
-  }
+	try {
+		execSync("git rev-parse --is-inside-work-tree", { stdio: "ignore" });
+		return true;
+	} catch (e) {
+		return false;
+	}
 }
 
 function isInMercurialRepository() {
-  try {
-    execSync('hg --cwd . root', { stdio: 'ignore' });
-    return true;
-  } catch (e) {
-    return false;
-  }
+	try {
+		execSync("hg --cwd . root", { stdio: "ignore" });
+		return true;
+	} catch (e) {
+		return false;
+	}
 }
 
 // Watch unless on CI or explicitly running all tests
 if (
-  !process.env.CI &&
-  argv.indexOf('--watchAll') === -1 &&
-  argv.indexOf('--watchAll=false') === -1
+	!process.env.CI &&
+	argv.indexOf("--watchAll") === -1 &&
+	argv.indexOf("--watchAll=false") === -1
 ) {
-  // https://github.com/facebook/create-react-app/issues/5210
-  const hasSourceControl = isInGitRepository() || isInMercurialRepository();
-  argv.push(hasSourceControl ? '--watch' : '--watchAll');
+	// https://github.com/facebook/create-react-app/issues/5210
+	const hasSourceControl = isInGitRepository() || isInMercurialRepository();
+	argv.push(hasSourceControl ? "--watch" : "--watchAll");
 }
-
 
 jest.run(argv);


### PR DESCRIPTION
## Description

Cleans up the Create-React-App ejected files to match our Prettier config.

* Moved the list of files to include from `package.json` to `.prettierignore` so it's in a single place and can include comments.
* Added CRA config files and build scripts to Prettier.
* Also added `/*.js` and `/*.mjs` to cover upcoming ESLint updates.
* Updated the `.editorconfig` for `*.mjs` files to match `*.js` files.

## Motivation and Context

Use consistent formatting between our source and config files.

## How Has This Been Tested?

Only affects formatting; tested via CI in this PR.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
