### PR TITLE
Add project section to pyproject.toml

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,3 +1,8 @@
+[project]
+name = "artemis-backend"
+version = "2.7.0"
+requires-python = ">= 3.12"
+
 [tool.ruff]
 line-length = 120
 target-version = "py312"

--- a/orchestrator/pyproject.toml
+++ b/orchestrator/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">= 3.12"
 
 [tool.ruff]
 line-length = 120
-target-version = "py39"
+target-version = "py312"
 
 [tool.isort]
 profile = "black"

--- a/orchestrator/pyproject.toml
+++ b/orchestrator/pyproject.toml
@@ -1,3 +1,8 @@
+[project]
+name = "artemis-heimdall"
+version = "2.7.0"
+requires-python = ">= 3.12"
+
 [tool.ruff]
 line-length = 120
 target-version = "py39"


### PR DESCRIPTION
## Description

Adds a minimal `project` section to the backend and heimdall `pyproject.toml` files.

The version `2.7.0` is the somewhat-arbitrary version we've already been referencing in the UI, so this just makes it official.

Also fixes a missed update to Python 3.12 in the Heimdall `pyproject.toml`.

## Motivation and Context

When testing the migration from Pipenv to uv, the `project` metadata is needed to define the dependencies shared between projects.  If not defined, then the migration script will insert invalid values, so we need to manually set them ahead of time.

## How Has This Been Tested?

Validated using [validate-pyproject](https://pypi.org/project/validate-pyproject/).

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
