### PR TITLE
Ignore utcnow DeprecationWarning from botocore

### DIFF
--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -28,3 +28,7 @@ pythonpath =
     libs/artemisapi
     libs/artemisdb
     libs/artemislib
+filterwarnings =
+    # Deprecation warning from using boto3, ignore until it's fixed in botocore:
+    # https://github.com/boto/boto3/issues/3889
+    ignore:datetime.datetime.utcnow\(\) is deprecated:DeprecationWarning:botocore.*


### PR DESCRIPTION
## Description

Explicitly ignores the `utcnow()` deprecation warning in botocore from unit tests.

We can't do anything about this warning until boto3/botocore finds a backwards-compatible solution: https://github.com/boto/boto3/issues/3889

## Motivation and Context

Clean up remaining unit test warnings.

## How Has This Been Tested?

Ran backend unit tests and confirmed no warnings.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
