### PR TITLE
Clean up ImageBuilder comments and unused vars

### DIFF
--- a/backend/engine/tests/test_docker_builder.py
+++ b/backend/engine/tests/test_docker_builder.py
@@ -19,8 +19,6 @@ TEST_DATA = os.path.join(TEST_DIR, "data")
 
 TEST_DATA_IMAGE_RESULTS = os.path.join(TEST_DATA, "util", "image_results.json")
 
-TEST_DOCKERFILE_LIST = [os.path.join(TEST_DATA, "image", "test_file_for_docker")]
-
 TEST_DOCKERFILE_ERROR = os.path.join(TEST_DATA, "image", "Dockerfile.error")
 TEST_DOCKERFILE_SIMPLE = os.path.join(TEST_DATA, "image", "Dockerfile.simple")
 
@@ -39,7 +37,8 @@ def find_builder(name: str) -> bool:
     Raises an exception on failure.
     """
 
-    # Need to use the Docker CLI since Docker-Py does not yet support buildx.
+    # Need to use the Docker CLI since Docker-Py does not yet support BuildKit:
+    # https://github.com/docker/docker-py/issues/2230
     proc = subprocess.run(
         ["docker", "buildx", "ls", "--format=json"],
         capture_output=True,


### PR DESCRIPTION
## Description

Simple cleanups of the comments in ImageBuilder and the unit tests.

Replaced references "buildx" with "BuildKit" since that's a bit easier when searching, for folks interested in learning more ("docker buildx" is the command, BuildKit is the actual feature).

Also removed an unused variable.

## Motivation and Context

Documentation cleanups that didn't make it into https://github.com/WarnerMedia/artemis/pull/512 .

## How Has This Been Tested?

Ran unit tests (only place with code change -- rest is just comments and docstrings).

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
