### PR TITLE
Allow WAF Configurations to be customized externally

### DIFF
--- a/backend/terraform/modules/analyzer/api_main.tf
+++ b/backend/terraform/modules/analyzer/api_main.tf
@@ -408,8 +408,45 @@ resource "aws_wafv2_web_acl" "api" {
   description = "ACL for ${var.app} API"
   scope       = "REGIONAL"
 
-  default_action {
-    allow {}
+  # Sets the default action to allow or block based on the value of var.waf_default_action
+  # (This is logically an if/else statement, but there is no way to do that for blocks in Terraform)
+  dynamic "default_action" {
+    for_each = var.waf_default_action == "allow" ? [1] : []
+    content {
+      allow {}
+    }
+  }
+  dynamic "default_action" {
+    for_each = var.waf_default_action == "block" ? [1] : []
+    content {
+      block {}
+    }
+  }
+
+  # Dynamically load all rule groups provided as part of var.waf_rule_groups
+  dynamic "rule" {
+    for_each = var.waf_rule_groups
+
+    content {
+      name     = "${rule.value.name}-rule"
+      priority = index(var.waf_rule_groups, rule.value) + 1
+
+      override_action {
+        none {}
+      }
+
+      statement {
+        rule_group_reference_statement {
+          arn = rule.value.arn
+        }
+      }
+
+      visibility_config {
+        cloudwatch_metrics_enabled = false
+        metric_name                = "${rule.value.name}-rule-metric"
+        sampled_requests_enabled   = false
+      }
+    }
   }
 
   visibility_config {

--- a/backend/terraform/modules/analyzer/variables.tf
+++ b/backend/terraform/modules/analyzer/variables.tf
@@ -473,7 +473,10 @@ variable "waf_default_action" {
 }
 
 variable "waf_rule_groups" {
-  description = "ARNs of AWS WAF Rule Groups to apply to the WAF configuration"
+  description = "AWS WAF Rule Groups to apply to the WAF configuration"
   default     = []
-  type        = list(object)
+  type = list(object({
+    name = string
+    arn  = string
+  }))
 }

--- a/backend/terraform/modules/analyzer/variables.tf
+++ b/backend/terraform/modules/analyzer/variables.tf
@@ -456,3 +456,24 @@ variable "engine_scale_max_nat" {
 variable "nat_plugin_java_heap_size" {
   default = "2g"
 }
+
+################################################
+# AWS WAF Customization
+################################################
+
+variable "waf_default_action" {
+  description = "AWS WAF default action. Should be either 'allow' or 'block'"
+  default     = "allow"
+  type        = string
+
+  validation {
+    condition     = contains(["allow", "block"], var.waf_default_action)
+    error_message = "waf_default_action must be one of 'allow' or 'block'"
+  }
+}
+
+variable "waf_rule_groups" {
+  description = "ARNs of AWS WAF Rule Groups to apply to the WAF configuration"
+  default     = []
+  type        = list(object)
+}

--- a/orchestrator/terraform/modules/heimdall/variables.tf
+++ b/orchestrator/terraform/modules/heimdall/variables.tf
@@ -206,3 +206,27 @@ variable "datadog_environment_variables" {
     DD_SERVICE = "heimdall"
   }
 }
+
+################################################
+# AWS WAF Customization
+################################################
+
+variable "waf_default_action" {
+  description = "AWS WAF default action. Should be either 'allow' or 'block'"
+  default     = "allow"
+  type        = string
+
+  validation {
+    condition     = contains(["allow", "block"], var.waf_default_action)
+    error_message = "waf_default_action must be one of 'allow' or 'block'"
+  }
+}
+
+variable "waf_rule_groups" {
+  description = "AWS WAF Rule Groups to apply to the WAF configuration"
+  default     = []
+  type = list(object({
+    name = string
+    arn  = string
+  }))
+}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allows WAF configurations to be customized external to the module

## Description
<!--- Describe your changes in detail -->
- WAF configurations for Artemis API and Heimdall take two new variables:
  - `waf_default_action` - Either `"allow"` or `"block"` for the WAF `default_action`. Pretty self-explanatory 
  - `waf_rule_groups` - A list of rule groups that the WAF will implement.
- Defaults for `waf_default_action` and `waf_rule_groups` are consistent with the current behavior. Running `terraform plan` yielded no changes for both after this change (without setting values for `waf_default_action` or `waf_rule_groups`)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Gives more control over access to Artemis through AWS WAF

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Working in dev environment
- No changes detected from `terraform plan`

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
