### PR TITLE
Fix uses of deprecated Jest aliases

### DIFF
--- a/ui/src/api/__tests__/client.test.ts
+++ b/ui/src/api/__tests__/client.test.ts
@@ -33,7 +33,7 @@ describe("api client", () => {
 			exportsForTesting._formatError(error, "default");
 		};
 		expect(exception).toThrow(AuthError);
-		expect(exception).toThrowError(/session expired/i);
+		expect(exception).toThrow(/session expired/i);
 	});
 
 	test("formatError should throw failed.error if set in response", () => {
@@ -47,7 +47,7 @@ describe("api client", () => {
 		const exception = () => {
 			exportsForTesting._formatError(error, "default");
 		};
-		expect(exception).toThrowError("it failed");
+		expect(exception).toThrow("it failed");
 	});
 
 	test("formatError should throw statusText if set in response", () => {
@@ -59,7 +59,7 @@ describe("api client", () => {
 		const exception = () => {
 			exportsForTesting._formatError(error, "default");
 		};
-		expect(exception).toThrowError("it failed");
+		expect(exception).toThrow("it failed");
 	});
 
 	test("formatError should throw defaultError instead of error messsage", () => {
@@ -69,7 +69,7 @@ describe("api client", () => {
 		const exception = () => {
 			exportsForTesting._formatError(error, "default");
 		};
-		expect(exception).toThrowError("default");
+		expect(exception).toThrow("default");
 	});
 
 	test("formatError should throw defaulted error instead of error messsage", () => {
@@ -79,7 +79,7 @@ describe("api client", () => {
 		const exception = () => {
 			exportsForTesting._formatError(error);
 		};
-		expect(exception).toThrowError(/unknown error/i);
+		expect(exception).toThrow(/unknown error/i);
 	});
 
 	// test if a function calls a redux dispatch

--- a/ui/src/components/__tests__/ActivityTable.test.tsx
+++ b/ui/src/components/__tests__/ActivityTable.test.tsx
@@ -977,7 +977,7 @@ describe("ActivityTable component", () => {
 					toCsv={mockToCsv}
 				/>,
 			);
-			expect(mockOnDataLoad).toBeCalledWith({
+			expect(mockOnDataLoad).toHaveBeenCalledWith({
 				currentPage: 0,
 				filters: {},
 				itemsPerPage: defaultRowsPerPage,
@@ -1043,7 +1043,7 @@ describe("ActivityTable component", () => {
 					toCsv={mockToCsv}
 				/>,
 			);
-			expect(mockOnDataLoad).toBeCalledWith({
+			expect(mockOnDataLoad).toHaveBeenCalledWith({
 				currentPage: 0,
 				filters: {},
 				itemsPerPage: defaultRowsPerPage,
@@ -1095,7 +1095,7 @@ describe("ActivityTable component", () => {
 					toCsv={mockToCsv}
 				/>,
 			);
-			expect(mockOnDataLoad).toBeCalledWith({
+			expect(mockOnDataLoad).toHaveBeenCalledWith({
 				currentPage: 0,
 				filters: {},
 				itemsPerPage: defaultRowsPerPage,
@@ -1147,7 +1147,7 @@ describe("ActivityTable component", () => {
 					toCsv={mockToCsv}
 				/>,
 			);
-			expect(mockOnDataLoad).toBeCalledWith({
+			expect(mockOnDataLoad).toHaveBeenCalledWith({
 				currentPage: 0,
 				filters: {},
 				itemsPerPage: defaultRowsPerPage,
@@ -1213,7 +1213,7 @@ describe("ActivityTable component", () => {
 					toCsv={mockToCsv}
 				/>,
 			);
-			expect(mockOnDataLoad).toBeCalledWith({
+			expect(mockOnDataLoad).toHaveBeenCalledWith({
 				currentPage: 0,
 				filters: {},
 				itemsPerPage: defaultRowsPerPage,
@@ -1281,7 +1281,7 @@ describe("ActivityTable component", () => {
 					toCsv={mockToCsv}
 				/>,
 			);
-			expect(mockOnDataLoad).toBeCalledWith({
+			expect(mockOnDataLoad).toHaveBeenCalledWith({
 				currentPage: 0,
 				filters: {},
 				itemsPerPage: defaultRowsPerPage,

--- a/ui/src/pages/__tests__/BackButton.test.tsx
+++ b/ui/src/pages/__tests__/BackButton.test.tsx
@@ -39,7 +39,7 @@ describe("BackButton component", () => {
 		expect(button).toBeInTheDocument();
 
 		await user.click(button);
-		expect(mockNavigate).toBeCalledWith("/");
+		expect(mockNavigate).toHaveBeenCalledWith("/");
 	});
 
 	it("navigation to page goes back to prior page", async () => {
@@ -50,7 +50,7 @@ describe("BackButton component", () => {
 		expect(button).toBeInTheDocument();
 
 		await user.click(button);
-		expect(mockNavigate).toBeCalledWith(-1);
+		expect(mockNavigate).toHaveBeenCalledWith(-1);
 	});
 
 	it("redirection back to this page goes back 2 pages", async () => {
@@ -59,6 +59,6 @@ describe("BackButton component", () => {
 		expect(button).toBeInTheDocument();
 
 		await user.click(button);
-		expect(mockNavigate).toBeCalledWith(-2);
+		expect(mockNavigate).toHaveBeenCalledWith(-2);
 	});
 });

--- a/ui/src/pages/__tests__/UserSettings/BackButton.test.tsx
+++ b/ui/src/pages/__tests__/UserSettings/BackButton.test.tsx
@@ -97,7 +97,7 @@ describe("UserSettings component", () => {
 			expect(button).toBeInTheDocument();
 
 			await user.click(button);
-			expect(mockNavigate).toBeCalledWith("/");
+			expect(mockNavigate).toHaveBeenCalledWith("/");
 		});
 
 		it("back button should call fromRedirect if an auth code is passed in the page URL", async () => {


### PR DESCRIPTION
## Description

Replaced deprecated Jest aliases with their primary names.

These aliases are removed in Jest v30: https://jestjs.io/docs/upgrading-to-jest30#removal-of-alias-matcher-functions

## Motivation and Context

Prepare for future upgrade to Jest v30.

## How Has This Been Tested?

Unit tests run via CI.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
