### PR TITLE
Plugin Runner Toolbox: Fix format string injection and build with Go 1.24.6

### DIFF
--- a/backend/utilities/plugin_runner/toolbox/go.mod
+++ b/backend/utilities/plugin_runner/toolbox/go.mod
@@ -1,6 +1,6 @@
 module github.com/warnermedia/artemis/backend/utilities/plugin_runner/toolbox
 
-go 1.24.5
+go 1.24.6
 
 require (
 	github.com/fatih/color v1.18.0

--- a/backend/utilities/plugin_runner/toolbox/main.go
+++ b/backend/utilities/plugin_runner/toolbox/main.go
@@ -46,8 +46,7 @@ func NewPluginOutput(pluginType string, output []byte, exitCode int) *PluginOutp
 
 // usage prints the command-line help and exits.
 func usage() {
-	fmt.Fprintf(os.Stderr, "Usage: "+
-		os.Args[0]+" plugin plugin_type runner\n")
+	fmt.Fprintf(os.Stderr, "Usage: %s plugin plugin_type runner\n", os.Args[0])
 	os.Exit(1)
 }
 


### PR DESCRIPTION
## Description

Fixes a potential format string injection in the Plugin Runner Toolbox usage message.  This shouldn't be exploitable since we control the invocation via the entrypoint script generated by `plugin.sh`.

Also builds with [Go 1.24.6](https://go.dev/doc/devel/release#go1.24.6). This release includes a fix for `os/exec`.  We haven't run into any issues, but this is to be on the safe side.

## Motivation and Context

Clean up lint warning and preventative maintenance.

## How Has This Been Tested?

Tested running plugin runner locally.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation change

## Checklist

- [x] My code follows conforms to the coding standards.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
